### PR TITLE
ECWC-174 / api ดึงข้อมูล list การยืนยันตัวตน / ยังไม่ยืนยันตัวตน + มี ui

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -43,6 +43,7 @@ import { ProductReturnModule } from './product-return/product-return.module';
 import { BehaviorTrackingModule } from './behavior-tracking/behavior-tracking.module';
 import { NotifyRtModule } from './notifyapp/notifyapp.module';
 import { CompanyDayAnalyticModule } from './company-day-analytic/company-day-analytic.module';
+import { LineOaMonitorModule } from './line-oa-monitor/line-oa-monitor.module';
 import { envValidationSchema } from './env.validation';
 import { ElasticsearchModule } from './elasticsearch/elasticsearch.module';
 
@@ -111,6 +112,7 @@ import { RatingModule } from './rating/rating.module';
     BehaviorTrackingModule,
     NotifyRtModule,
     CompanyDayAnalyticModule,
+    LineOaMonitorModule,
     ElasticsearchModule,
     MailerModule.forRootAsync({
       imports: [ConfigModule],

--- a/src/line-oa-monitor/line-oa-monitor.controller.ts
+++ b/src/line-oa-monitor/line-oa-monitor.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { LineOaMonitorService, LineOaMonitorResponse } from './line-oa-monitor.service';
+
+@Controller('ecom')
+export class LineOaMonitorController {
+  constructor(private readonly lineOaMonitorService: LineOaMonitorService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Get('admin/line-oa-monitor')
+  async getMonitorData(): Promise<LineOaMonitorResponse> {
+    return this.lineOaMonitorService.getMonitorData();
+  }
+}

--- a/src/line-oa-monitor/line-oa-monitor.module.ts
+++ b/src/line-oa-monitor/line-oa-monitor.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserEntity } from '../users/users.entity';
+import { FeatureFlagsModule } from '../feature-flags/feature-flags.module';
+import { LineOaMonitorService } from './line-oa-monitor.service';
+import { LineOaMonitorController } from './line-oa-monitor.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserEntity]), FeatureFlagsModule],
+  controllers: [LineOaMonitorController],
+  providers: [LineOaMonitorService],
+})
+export class LineOaMonitorModule {}

--- a/src/line-oa-monitor/line-oa-monitor.service.ts
+++ b/src/line-oa-monitor/line-oa-monitor.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import axios from 'axios';
+import { UserEntity } from '../users/users.entity';
+
+export interface LineOaMemberDto {
+  mem_code: string;
+  mem_nameSite: string | null;
+  emp_id_ref: string | null;
+  isRegistered: boolean;
+}
+
+export interface LineOaMonitorResponse {
+  total: number;
+  registered: number;
+  unregistered: number;
+  members: LineOaMemberDto[];
+}
+
+@Injectable()
+export class LineOaMonitorService {
+  private readonly notificationServiceUrl =
+    process.env.NOTIFICATION_SERVICE_URL || 'http://localhost:3005';
+
+  constructor(
+    @InjectRepository(UserEntity)
+    private readonly userRepo: Repository<UserEntity>,
+  ) {}
+
+  async getMonitorData(): Promise<LineOaMonitorResponse> {
+    const [registeredResult, users] = await Promise.all([
+      axios.get<{ memCodes: string[] }>(
+        `${this.notificationServiceUrl}/api/notifications/admin/users/line-registered`,
+      ),
+      this.userRepo.find({
+        select: {
+          mem_code: true,
+          mem_nameSite: true,
+          emp_id_ref: true,
+        },
+      }),
+    ]);
+
+    const registeredSet = new Set(registeredResult.data.memCodes);
+
+    const members: LineOaMemberDto[] = users.map((u) => ({
+      mem_code: u.mem_code,
+      mem_nameSite: u.mem_nameSite,
+      emp_id_ref: u.emp_id_ref,
+      isRegistered: registeredSet.has(u.mem_code),
+    }));
+
+    return {
+      total: members.length,
+      registered: members.filter((m) => m.isRegistered).length,
+      unregistered: members.filter((m) => !m.isRegistered).length,
+      members,
+    };
+  }
+}


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- https://nitipongjin-13063.atlassian.net/browse/ECWC-174

### 📌 ประเภทของ PR
- [x] ✨ Feature ใหม่
- [ ] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
เพิ่ม `line-oa-monitor` module ที่รวบรวมข้อมูลจาก notification-service และ users table ของ Ecommerce เพื่อแสดงสถานะการลงทะเบียน Line OA ของลูกค้าแต่ละราย

### 🛠️ แก้ปัญหานั้นอย่างไร
- สร้าง `LineOaMonitorService` — เรียก notification-service API พร้อมกับ query `users` table แล้ว merge ผลลัพธ์
- สร้าง `LineOaMonitorController` — `GET /api/ecom/admin/line-oa-monitor` (ต้องมี JWT)
- คืนข้อมูล: total, registered, unregistered, และ list ลูกค้าพร้อมสถานะ `isRegistered`, ชื่อร้าน, รหัสฝ่ายขาย

### 🧪 วิธี Test
1. เปิด notification-service (port 3005) และ Backend-Ecommerce (port 3021)
2. เรียก `GET http://localhost:3021/api/ecom/admin/line-oa-monitor` พร้อม Bearer token
3. ต้องได้ `{ total, registered, unregistered, members: [...] }`

### 🔑 Environment Variables ใหม่
- `NOTIFICATION_SERVICE_URL=http://localhost:3005` — URL ของ notification-service