### PR TITLE
ECWC-215: Watermark anti-leak (backend) — audit token, lookup, feature flags

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -52,6 +52,7 @@ import { RatingModule } from './rating/rating.module';
 import { LineRegisterMeetingModule } from './line-register-meeting/line-register-meeting.module';
 import { ReviewRequestModule } from './review-request/review-request.module';
 import { ProductRequestModule } from './product-request/product-request.module';
+import { WatermarkAuditModule } from './watermark-audit/watermark-audit.module';
 
 @Module({
   imports: [
@@ -146,6 +147,7 @@ import { ProductRequestModule } from './product-request/product-request.module';
     LineRegisterMeetingModule,
     ReviewRequestModule,
     ProductRequestModule,
+    WatermarkAuditModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/migrations/1778990911655-CreateWatermarkAudit.ts
+++ b/src/migrations/1778990911655-CreateWatermarkAudit.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateWatermarkAudit1778990911655 implements MigrationInterface {
+    name = 'CreateWatermarkAudit1778990911655'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`watermark_audit\` (\`id\` int NOT NULL AUTO_INCREMENT, \`token\` varchar(32) NOT NULL, \`mem_code\` varchar(255) NOT NULL, \`page\` varchar(255) NOT NULL, \`ip\` varchar(64) NULL, \`user_agent\` varchar(512) NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), UNIQUE INDEX \`IDX_623fb3ab6de0c18a6607bffc90\` (\`token\`), INDEX \`IDX_eb46f33b18a535b402245b43b2\` (\`mem_code\`), INDEX \`IDX_7bc5e96d65d95b675a1fbe0723\` (\`created_at\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`watermark_audit_archive\` (\`id\` int NOT NULL AUTO_INCREMENT, \`token\` varchar(32) NOT NULL, \`mem_code\` varchar(255) NOT NULL, \`page\` varchar(255) NOT NULL, \`ip\` varchar(64) NULL, \`user_agent\` varchar(512) NULL, \`created_at\` datetime NOT NULL, \`archived_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), INDEX \`IDX_5aa1467c7df6ce82b32d86e3af\` (\`token\`), INDEX \`IDX_55987e5082dfea4f69f27c76d3\` (\`mem_code\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX \`IDX_55987e5082dfea4f69f27c76d3\` ON \`watermark_audit_archive\``);
+        await queryRunner.query(`DROP INDEX \`IDX_5aa1467c7df6ce82b32d86e3af\` ON \`watermark_audit_archive\``);
+        await queryRunner.query(`DROP TABLE \`watermark_audit_archive\``);
+        await queryRunner.query(`DROP INDEX \`IDX_7bc5e96d65d95b675a1fbe0723\` ON \`watermark_audit\``);
+        await queryRunner.query(`DROP INDEX \`IDX_eb46f33b18a535b402245b43b2\` ON \`watermark_audit\``);
+        await queryRunner.query(`DROP INDEX \`IDX_623fb3ab6de0c18a6607bffc90\` ON \`watermark_audit\``);
+        await queryRunner.query(`DROP TABLE \`watermark_audit\``);
+    }
+
+}

--- a/src/watermark-audit/watermark-audit-archive.entity.ts
+++ b/src/watermark-audit/watermark-audit-archive.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('watermark_audit_archive')
+export class WatermarkAuditArchiveEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index()
+  @Column({ length: 32 })
+  token: string;
+
+  @Index()
+  @Column()
+  mem_code: string;
+
+  @Column({ length: 255 })
+  page: string;
+
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  ip: string | null;
+
+  @Column({ type: 'varchar', length: 512, nullable: true })
+  user_agent: string | null;
+
+  @Column()
+  created_at: Date;
+
+  @CreateDateColumn()
+  archived_at: Date;
+}

--- a/src/watermark-audit/watermark-audit.controller.ts
+++ b/src/watermark-audit/watermark-audit.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  ForbiddenException,
   Get,
   Post,
   Query,
@@ -44,7 +45,13 @@ export class WatermarkAuditController {
   // Admin: resolve a leaked watermark token -> who/when/which page.
   @UseGuards(JwtAuthGuard)
   @Get('watermark/lookup')
-  lookup(@Query('token') token: string) {
+  lookup(
+    @Req() req: Request & { user: JwtPayload },
+    @Query('token') token: string,
+  ) {
+    if (req.user.permission !== true) {
+      throw new ForbiddenException('Insufficient permissions');
+    }
     if (!token) {
       throw new BadRequestException('token จำเป็นต้องระบุ');
     }

--- a/src/watermark-audit/watermark-audit.controller.ts
+++ b/src/watermark-audit/watermark-audit.controller.ts
@@ -1,0 +1,41 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { JwtPayload } from '../app.controller';
+import { WatermarkAuditService } from './watermark-audit.service';
+
+@Controller('ecom')
+export class WatermarkAuditController {
+  constructor(private readonly service: WatermarkAuditService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post('watermark/token')
+  issueToken(
+    @Req() req: Request & { user: JwtPayload },
+    @Body('page') page: string,
+  ) {
+    if (!page) {
+      throw new BadRequestException('page จำเป็นต้องระบุ');
+    }
+    const xff = req.headers['x-forwarded-for'];
+    const ip =
+      (Array.isArray(xff) ? xff[0] : xff?.split(',')[0]?.trim()) ??
+      req.ip ??
+      null;
+    const userAgent = req.headers['user-agent'] ?? null;
+
+    return this.service.issueToken({
+      mem_code: req.user.mem_code,
+      page,
+      ip,
+      user_agent: userAgent,
+    });
+  }
+}

--- a/src/watermark-audit/watermark-audit.controller.ts
+++ b/src/watermark-audit/watermark-audit.controller.ts
@@ -2,7 +2,9 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Get,
   Post,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -37,5 +39,15 @@ export class WatermarkAuditController {
       ip,
       user_agent: userAgent,
     });
+  }
+
+  // Admin: resolve a leaked watermark token -> who/when/which page.
+  @UseGuards(JwtAuthGuard)
+  @Get('watermark/lookup')
+  lookup(@Query('token') token: string) {
+    if (!token) {
+      throw new BadRequestException('token จำเป็นต้องระบุ');
+    }
+    return this.service.lookup(token.trim());
   }
 }

--- a/src/watermark-audit/watermark-audit.entity.ts
+++ b/src/watermark-audit/watermark-audit.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('watermark_audit')
+export class WatermarkAuditEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index({ unique: true })
+  @Column({ length: 32 })
+  token: string;
+
+  @Index()
+  @Column()
+  mem_code: string;
+
+  @Column({ length: 255 })
+  page: string;
+
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  ip: string | null;
+
+  @Column({ type: 'varchar', length: 512, nullable: true })
+  user_agent: string | null;
+
+  @Index()
+  @CreateDateColumn()
+  created_at: Date;
+}

--- a/src/watermark-audit/watermark-audit.module.ts
+++ b/src/watermark-audit/watermark-audit.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WatermarkAuditEntity } from './watermark-audit.entity';
+import { WatermarkAuditArchiveEntity } from './watermark-audit-archive.entity';
+import { WatermarkAuditService } from './watermark-audit.service';
+import { WatermarkAuditController } from './watermark-audit.controller';
+import { FeatureFlagsModule } from '../feature-flags/feature-flags.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      WatermarkAuditEntity,
+      WatermarkAuditArchiveEntity,
+    ]),
+    FeatureFlagsModule,
+  ],
+  providers: [WatermarkAuditService],
+  controllers: [WatermarkAuditController],
+  exports: [WatermarkAuditService],
+})
+export class WatermarkAuditModule {}

--- a/src/watermark-audit/watermark-audit.service.ts
+++ b/src/watermark-audit/watermark-audit.service.ts
@@ -12,11 +12,15 @@ import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 // watermark is turned off, so trace data is not lost during an investigation.
 export const WATERMARK_DISPLAY_FLAG = 'watermark_display';
 export const WATERMARK_AUDIT_FLAG = 'watermark_audit';
+// QR can be toggled independently of the faint text watermark: turn QR off
+// while keeping the text token (still traceable) when QR is too noisy.
+export const WATERMARK_QR_FLAG = 'watermark_qr';
 const RETENTION_DAYS = 90;
 const ARCHIVE_BATCH_SIZE = 5000;
 
 export interface IssuedToken {
   enabled: boolean;
+  qr: boolean;
   token: string | null;
 }
 
@@ -38,13 +42,14 @@ export class WatermarkAuditService {
     ip: string | null;
     user_agent: string | null;
   }): Promise<IssuedToken> {
-    const [displayEnabled, auditEnabled] = await Promise.all([
+    const [displayEnabled, auditEnabled, qrEnabled] = await Promise.all([
       this.featureFlagsService.getFlag(WATERMARK_DISPLAY_FLAG),
       this.featureFlagsService.getFlag(WATERMARK_AUDIT_FLAG),
+      this.featureFlagsService.getFlag(WATERMARK_QR_FLAG),
     ]);
 
     if (!displayEnabled && !auditEnabled) {
-      return { enabled: false, token: null };
+      return { enabled: false, qr: false, token: null };
     }
 
     const token = randomBytes(12).toString('base64url');
@@ -64,6 +69,7 @@ export class WatermarkAuditService {
     // independent: it may have persisted above even when display is off.
     return {
       enabled: displayEnabled,
+      qr: displayEnabled && qrEnabled,
       token: displayEnabled ? token : null,
     };
   }

--- a/src/watermark-audit/watermark-audit.service.ts
+++ b/src/watermark-audit/watermark-audit.service.ts
@@ -10,12 +10,14 @@ import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 // Decoupled flags: display (visible watermark) and audit (forensic logging)
 // can be toggled independently — logging keeps running even if the visible
 // watermark is turned off, so trace data is not lost during an investigation.
-// watermark_display = master switch for ALL visible watermark (text + QR).
-// watermark_text and watermark_qr are independent sub-toggles under it, so
-// text and QR can each be turned off while the other (and audit) stays on.
+// watermark_display = master switch for ALL visible watermark (text + QR +
+// sticky identity header). watermark_text, watermark_qr and watermark_header
+// are independent sub-toggles under it, so each can be turned off while the
+// others (and audit) stay on.
 export const WATERMARK_DISPLAY_FLAG = 'watermark_display';
 export const WATERMARK_TEXT_FLAG = 'watermark_text';
 export const WATERMARK_QR_FLAG = 'watermark_qr';
+export const WATERMARK_HEADER_FLAG = 'watermark_header';
 export const WATERMARK_AUDIT_FLAG = 'watermark_audit';
 const RETENTION_DAYS = 90;
 const ARCHIVE_BATCH_SIZE = 5000;
@@ -24,6 +26,7 @@ export interface IssuedToken {
   enabled: boolean;
   text: boolean;
   qr: boolean;
+  header: boolean;
   token: string | null;
 }
 
@@ -45,19 +48,32 @@ export class WatermarkAuditService {
     ip: string | null;
     user_agent: string | null;
   }): Promise<IssuedToken> {
-    const [displayEnabled, textEnabled, qrEnabled, auditEnabled] =
-      await Promise.all([
-        this.featureFlagsService.getFlag(WATERMARK_DISPLAY_FLAG),
-        this.featureFlagsService.getFlag(WATERMARK_TEXT_FLAG),
-        this.featureFlagsService.getFlag(WATERMARK_QR_FLAG),
-        this.featureFlagsService.getFlag(WATERMARK_AUDIT_FLAG),
-      ]);
+    const [
+      displayEnabled,
+      textEnabled,
+      qrEnabled,
+      headerEnabled,
+      auditEnabled,
+    ] = await Promise.all([
+      this.featureFlagsService.getFlag(WATERMARK_DISPLAY_FLAG),
+      this.featureFlagsService.getFlag(WATERMARK_TEXT_FLAG),
+      this.featureFlagsService.getFlag(WATERMARK_QR_FLAG),
+      this.featureFlagsService.getFlag(WATERMARK_HEADER_FLAG),
+      this.featureFlagsService.getFlag(WATERMARK_AUDIT_FLAG),
+    ]);
 
     const textOn = displayEnabled && textEnabled;
     const qrOn = displayEnabled && qrEnabled;
+    const headerOn = displayEnabled && headerEnabled;
 
     if (!displayEnabled && !auditEnabled) {
-      return { enabled: false, text: false, qr: false, token: null };
+      return {
+        enabled: false,
+        text: false,
+        qr: false,
+        header: false,
+        token: null,
+      };
     }
 
     const token = randomBytes(12).toString('base64url');
@@ -81,6 +97,7 @@ export class WatermarkAuditService {
       enabled: displayEnabled,
       text: textOn,
       qr: qrOn,
+      header: headerOn,
       token: showAny ? token : null,
     };
   }

--- a/src/watermark-audit/watermark-audit.service.ts
+++ b/src/watermark-audit/watermark-audit.service.ts
@@ -195,8 +195,11 @@ export class WatermarkAuditService {
             created_at: row.created_at,
           }),
         );
-        await this.archiveRepo.save(archived);
-        await this.auditRepo.delete(batch.map((row) => row.id));
+        const batchIds = batch.map((row) => row.id);
+        await this.auditRepo.manager.transaction(async (tx) => {
+          await tx.save(WatermarkAuditArchiveEntity, archived);
+          await tx.delete(WatermarkAuditEntity, batchIds);
+        });
 
         totalArchived += batch.length;
         if (batch.length < ARCHIVE_BATCH_SIZE) {

--- a/src/watermark-audit/watermark-audit.service.ts
+++ b/src/watermark-audit/watermark-audit.service.ts
@@ -10,16 +10,19 @@ import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 // Decoupled flags: display (visible watermark) and audit (forensic logging)
 // can be toggled independently — logging keeps running even if the visible
 // watermark is turned off, so trace data is not lost during an investigation.
+// watermark_display = master switch for ALL visible watermark (text + QR).
+// watermark_text and watermark_qr are independent sub-toggles under it, so
+// text and QR can each be turned off while the other (and audit) stays on.
 export const WATERMARK_DISPLAY_FLAG = 'watermark_display';
-export const WATERMARK_AUDIT_FLAG = 'watermark_audit';
-// QR can be toggled independently of the faint text watermark: turn QR off
-// while keeping the text token (still traceable) when QR is too noisy.
+export const WATERMARK_TEXT_FLAG = 'watermark_text';
 export const WATERMARK_QR_FLAG = 'watermark_qr';
+export const WATERMARK_AUDIT_FLAG = 'watermark_audit';
 const RETENTION_DAYS = 90;
 const ARCHIVE_BATCH_SIZE = 5000;
 
 export interface IssuedToken {
   enabled: boolean;
+  text: boolean;
   qr: boolean;
   token: string | null;
 }
@@ -42,14 +45,19 @@ export class WatermarkAuditService {
     ip: string | null;
     user_agent: string | null;
   }): Promise<IssuedToken> {
-    const [displayEnabled, auditEnabled, qrEnabled] = await Promise.all([
-      this.featureFlagsService.getFlag(WATERMARK_DISPLAY_FLAG),
-      this.featureFlagsService.getFlag(WATERMARK_AUDIT_FLAG),
-      this.featureFlagsService.getFlag(WATERMARK_QR_FLAG),
-    ]);
+    const [displayEnabled, textEnabled, qrEnabled, auditEnabled] =
+      await Promise.all([
+        this.featureFlagsService.getFlag(WATERMARK_DISPLAY_FLAG),
+        this.featureFlagsService.getFlag(WATERMARK_TEXT_FLAG),
+        this.featureFlagsService.getFlag(WATERMARK_QR_FLAG),
+        this.featureFlagsService.getFlag(WATERMARK_AUDIT_FLAG),
+      ]);
+
+    const textOn = displayEnabled && textEnabled;
+    const qrOn = displayEnabled && qrEnabled;
 
     if (!displayEnabled && !auditEnabled) {
-      return { enabled: false, qr: false, token: null };
+      return { enabled: false, text: false, qr: false, token: null };
     }
 
     const token = randomBytes(12).toString('base64url');
@@ -65,12 +73,15 @@ export class WatermarkAuditService {
       });
     }
 
-    // `enabled` drives the visible watermark on the client. Logging is
-    // independent: it may have persisted above even when display is off.
+    // `enabled` = master switch. text/qr are independent sub-toggles under
+    // it. Logging is independent and may have persisted above even when the
+    // visible watermark is off. Token is sent only if something is shown.
+    const showAny = textOn || qrOn;
     return {
       enabled: displayEnabled,
-      qr: displayEnabled && qrEnabled,
-      token: displayEnabled ? token : null,
+      text: textOn,
+      qr: qrOn,
+      token: showAny ? token : null,
     };
   }
 

--- a/src/watermark-audit/watermark-audit.service.ts
+++ b/src/watermark-audit/watermark-audit.service.ts
@@ -1,0 +1,125 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Cron } from '@nestjs/schedule';
+import { LessThan, Repository } from 'typeorm';
+import { randomBytes } from 'crypto';
+import { WatermarkAuditEntity } from './watermark-audit.entity';
+import { WatermarkAuditArchiveEntity } from './watermark-audit-archive.entity';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+
+export const WATERMARK_AUDIT_FLAG = 'watermark_audit';
+const RETENTION_DAYS = 90;
+const ARCHIVE_BATCH_SIZE = 5000;
+
+export interface IssuedToken {
+  enabled: boolean;
+  token: string | null;
+}
+
+@Injectable()
+export class WatermarkAuditService {
+  private readonly logger = new Logger(WatermarkAuditService.name);
+
+  constructor(
+    @InjectRepository(WatermarkAuditEntity)
+    private readonly auditRepo: Repository<WatermarkAuditEntity>,
+    @InjectRepository(WatermarkAuditArchiveEntity)
+    private readonly archiveRepo: Repository<WatermarkAuditArchiveEntity>,
+    private readonly featureFlagsService: FeatureFlagsService,
+  ) {}
+
+  async issueToken(input: {
+    mem_code: string;
+    page: string;
+    ip: string | null;
+    user_agent: string | null;
+  }): Promise<IssuedToken> {
+    const enabled =
+      await this.featureFlagsService.getFlag(WATERMARK_AUDIT_FLAG);
+    if (!enabled) {
+      return { enabled: false, token: null };
+    }
+
+    const token = randomBytes(12).toString('base64url');
+
+    // Fire-and-forget: do not block the response on the audit write.
+    this.persist({
+      token,
+      mem_code: input.mem_code,
+      page: input.page,
+      ip: input.ip,
+      user_agent: input.user_agent,
+    });
+
+    return { enabled: true, token };
+  }
+
+  private persist(row: {
+    token: string;
+    mem_code: string;
+    page: string;
+    ip: string | null;
+    user_agent: string | null;
+  }): void {
+    const entity = this.auditRepo.create(row);
+    this.auditRepo.save(entity).catch((err) => {
+      this.logger.error(
+        `Failed to persist watermark audit: token=${row.token} mem_code=${row.mem_code} ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    });
+  }
+
+  // Retention: rows older than 90 days are moved to the archive table
+  // (PDPA — archive, not delete) so the hot table stays lean.
+  @Cron('0 3 * * *', { timeZone: 'Asia/Bangkok' })
+  async archiveExpired(): Promise<void> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - RETENTION_DAYS);
+
+    let totalArchived = 0;
+    try {
+      for (;;) {
+        const batch = await this.auditRepo.find({
+          where: { created_at: LessThan(cutoff) },
+          order: { id: 'ASC' },
+          take: ARCHIVE_BATCH_SIZE,
+        });
+        if (batch.length === 0) {
+          break;
+        }
+
+        const archived = batch.map((row) =>
+          this.archiveRepo.create({
+            token: row.token,
+            mem_code: row.mem_code,
+            page: row.page,
+            ip: row.ip,
+            user_agent: row.user_agent,
+            created_at: row.created_at,
+          }),
+        );
+        await this.archiveRepo.save(archived);
+        await this.auditRepo.delete(batch.map((row) => row.id));
+
+        totalArchived += batch.length;
+        if (batch.length < ARCHIVE_BATCH_SIZE) {
+          break;
+        }
+      }
+
+      if (totalArchived > 0) {
+        this.logger.log(
+          `Archived ${totalArchived} watermark audit rows older than ${RETENTION_DAYS} days`,
+        );
+      }
+    } catch (err) {
+      this.logger.error(
+        `Failed to archive watermark audit rows: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+}

--- a/src/watermark-audit/watermark-audit.service.ts
+++ b/src/watermark-audit/watermark-audit.service.ts
@@ -7,6 +7,10 @@ import { WatermarkAuditEntity } from './watermark-audit.entity';
 import { WatermarkAuditArchiveEntity } from './watermark-audit-archive.entity';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 
+// Decoupled flags: display (visible watermark) and audit (forensic logging)
+// can be toggled independently — logging keeps running even if the visible
+// watermark is turned off, so trace data is not lost during an investigation.
+export const WATERMARK_DISPLAY_FLAG = 'watermark_display';
 export const WATERMARK_AUDIT_FLAG = 'watermark_audit';
 const RETENTION_DAYS = 90;
 const ARCHIVE_BATCH_SIZE = 5000;
@@ -34,24 +38,34 @@ export class WatermarkAuditService {
     ip: string | null;
     user_agent: string | null;
   }): Promise<IssuedToken> {
-    const enabled =
-      await this.featureFlagsService.getFlag(WATERMARK_AUDIT_FLAG);
-    if (!enabled) {
+    const [displayEnabled, auditEnabled] = await Promise.all([
+      this.featureFlagsService.getFlag(WATERMARK_DISPLAY_FLAG),
+      this.featureFlagsService.getFlag(WATERMARK_AUDIT_FLAG),
+    ]);
+
+    if (!displayEnabled && !auditEnabled) {
       return { enabled: false, token: null };
     }
 
     const token = randomBytes(12).toString('base64url');
 
-    // Fire-and-forget: do not block the response on the audit write.
-    this.persist({
-      token,
-      mem_code: input.mem_code,
-      page: input.page,
-      ip: input.ip,
-      user_agent: input.user_agent,
-    });
+    if (auditEnabled) {
+      // Fire-and-forget: do not block the response on the audit write.
+      this.persist({
+        token,
+        mem_code: input.mem_code,
+        page: input.page,
+        ip: input.ip,
+        user_agent: input.user_agent,
+      });
+    }
 
-    return { enabled: true, token };
+    // `enabled` drives the visible watermark on the client. Logging is
+    // independent: it may have persisted above even when display is off.
+    return {
+      enabled: displayEnabled,
+      token: displayEnabled ? token : null,
+    };
   }
 
   private persist(row: {

--- a/src/watermark-audit/watermark-audit.service.ts
+++ b/src/watermark-audit/watermark-audit.service.ts
@@ -11,13 +11,15 @@ import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 // can be toggled independently — logging keeps running even if the visible
 // watermark is turned off, so trace data is not lost during an investigation.
 // watermark_display = master switch for ALL visible watermark (text + QR +
-// sticky identity header). watermark_text, watermark_qr and watermark_header
-// are independent sub-toggles under it, so each can be turned off while the
-// others (and audit) stay on.
+// sticky identity header + per-card token line). watermark_text,
+// watermark_qr, watermark_header and watermark_card_token are independent
+// sub-toggles under it, so each can be turned off while the others (and
+// audit) stay on.
 export const WATERMARK_DISPLAY_FLAG = 'watermark_display';
 export const WATERMARK_TEXT_FLAG = 'watermark_text';
 export const WATERMARK_QR_FLAG = 'watermark_qr';
 export const WATERMARK_HEADER_FLAG = 'watermark_header';
+export const WATERMARK_CARD_TOKEN_FLAG = 'watermark_card_token';
 export const WATERMARK_AUDIT_FLAG = 'watermark_audit';
 const RETENTION_DAYS = 90;
 const ARCHIVE_BATCH_SIZE = 5000;
@@ -27,6 +29,7 @@ export interface IssuedToken {
   text: boolean;
   qr: boolean;
   header: boolean;
+  cardToken: boolean;
   token: string | null;
 }
 
@@ -53,18 +56,21 @@ export class WatermarkAuditService {
       textEnabled,
       qrEnabled,
       headerEnabled,
+      cardTokenEnabled,
       auditEnabled,
     ] = await Promise.all([
       this.featureFlagsService.getFlag(WATERMARK_DISPLAY_FLAG),
       this.featureFlagsService.getFlag(WATERMARK_TEXT_FLAG),
       this.featureFlagsService.getFlag(WATERMARK_QR_FLAG),
       this.featureFlagsService.getFlag(WATERMARK_HEADER_FLAG),
+      this.featureFlagsService.getFlag(WATERMARK_CARD_TOKEN_FLAG),
       this.featureFlagsService.getFlag(WATERMARK_AUDIT_FLAG),
     ]);
 
     const textOn = displayEnabled && textEnabled;
     const qrOn = displayEnabled && qrEnabled;
     const headerOn = displayEnabled && headerEnabled;
+    const cardTokenOn = displayEnabled && cardTokenEnabled;
 
     if (!displayEnabled && !auditEnabled) {
       return {
@@ -72,6 +78,7 @@ export class WatermarkAuditService {
         text: false,
         qr: false,
         header: false,
+        cardToken: false,
         token: null,
       };
     }
@@ -92,12 +99,13 @@ export class WatermarkAuditService {
     // `enabled` = master switch. text/qr are independent sub-toggles under
     // it. Logging is independent and may have persisted above even when the
     // visible watermark is off. Token is sent only if something is shown.
-    const showAny = textOn || qrOn;
+    const showAny = textOn || qrOn || cardTokenOn;
     return {
       enabled: displayEnabled,
       text: textOn,
       qr: qrOn,
       header: headerOn,
+      cardToken: cardTokenOn,
       token: showAny ? token : null,
     };
   }

--- a/src/watermark-audit/watermark-audit.service.ts
+++ b/src/watermark-audit/watermark-audit.service.ts
@@ -68,6 +68,45 @@ export class WatermarkAuditService {
     };
   }
 
+  // Admin lookup: resolve a leaked watermark token back to who saw it,
+  // when, and on which page. Checks the hot table first, then the archive
+  // (rows older than the retention window).
+  async lookup(token: string): Promise<{
+    found: boolean;
+    source?: 'live' | 'archive';
+    mem_code?: string;
+    page?: string;
+    ip?: string | null;
+    user_agent?: string | null;
+    created_at?: Date;
+  }> {
+    const live = await this.auditRepo.findOne({ where: { token } });
+    if (live) {
+      return {
+        found: true,
+        source: 'live',
+        mem_code: live.mem_code,
+        page: live.page,
+        ip: live.ip,
+        user_agent: live.user_agent,
+        created_at: live.created_at,
+      };
+    }
+    const archived = await this.archiveRepo.findOne({ where: { token } });
+    if (archived) {
+      return {
+        found: true,
+        source: 'archive',
+        mem_code: archived.mem_code,
+        page: archived.page,
+        ip: archived.ip,
+        user_agent: archived.user_agent,
+        created_at: archived.created_at,
+      };
+    }
+    return { found: false };
+  }
+
   private persist(row: {
     token: string;
     mem_code: string;


### PR DESCRIPTION
Story **ECWC-215** — มาตรการกัน/สาวการแคปข้อมูล catalog/ราคา (ฝั่ง backend)

## รวมในนี้
- **ECWC-220** audit token + `watermark_audit` / `watermark_audit_archive` (async write, retention 90 วัน + archive)
- **ECWC-221** admin lookup endpoint `GET /api/ecom/watermark/lookup` (live + archive)
- **ECWC-219 / ECWC-231** flags: `watermark_display` (master) · `watermark_text` · `watermark_qr` · `watermark_audit` (อิสระ)
- **ECWC-223** เพิ่ม flag `watermark_header` (sub-toggle ใต้ `watermark_display` เหมือน text/qr), `/watermark/token` คืน `header:boolean`
- **ECWC-237** เพิ่ม flag `watermark_card_token` (sub-toggle ใต้ watermark_display) → `/watermark/token` คืน `cardToken:boolean` (smoke ผ่าน)
- migration `CreateWatermarkAudit`

## Verify
- build / lint ผ่าน · smoke test: issue→lookup, ทุก flag combo (display×text×qr×header), retention/archive

## หมายเหตุ / นอก scope
- **ยังเหลือ ECWC-222** (detection risk-score + Slack) ใน story — ยังไม่อยู่ใน PR นี้ (กำลังทำต่อ)
- bug แยกที่เปิดไว้: **ECWC-224** JWT verify ด้วย 'fallback-secret' (security, ควรแก้ก่อน prod) · **ECWC-225** feature_flag ไม่มี unique index · **ECWC-227** doc flag `all`
- `docker-compose.yaml` / `.env` (port 3312, SYNCHRONIZE=false) เป็น local dev — ไม่รวมใน PR นี้โดยตั้งใจ

🤖 Generated with [Claude Code](https://claude.com/claude-code)