### PR TITLE
fix: add id-token permission to learn-from-reviews workflow

### DIFF
--- a/.github/workflows/learn-from-reviews.yml
+++ b/.github/workflows/learn-from-reviews.yml
@@ -10,6 +10,7 @@ on:
   # so the two mechanisms don't open duplicate PRs.
 
 permissions:
+  id-token: write
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- N/A

### 📌 ประเภทของ PR
- [ ] ✨ Feature ใหม่
- [ ] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [x] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
เพิ่ม `id-token: write` permission ใน workflow `learn-from-reviews` เพื่อให้ job สามารถใช้ OIDC token ได้

### 🛠️ แก้ปัญหานั้นอย่างไร
เพิ่ม permission `id-token: write` ใน `.github/workflows/learn-from-reviews.yml`

### 🧪 วิธี Test
รัน workflow `learn-from-reviews` แล้วตรวจสอบว่า job ผ่านโดยไม่มี permission error

### 🔑 Environment Variables ใหม่
- ไม่มี