### PR TITLE
fix: clarify CI prompt to bypass interactive approval gate in learn-from-reviews workflow

### DIFF
--- a/.github/workflows/learn-from-reviews.yml
+++ b/.github/workflows/learn-from-reviews.yml
@@ -53,10 +53,13 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: >-
             Run the project skill at .claude/skills/learn-from-reviews/SKILL.md
-            using the feedback in /tmp/lfr.json. Classify, promote per the
-            ledger, and APPLY approved-kind entries to the .ai/ files and
-            ledger.json exactly as the skill specifies. Do NOT commit, push,
-            merge, or open a PR. Leave changes in the working tree only.
+            using the feedback in /tmp/lfr.json. You are running in CI
+            (non-interactive). Classify, promote per the ledger, then proceed
+            DIRECTLY to Step 5 (Apply) without waiting for human approval —
+            the Draft PR that follows IS the human review gate. Write all
+            approved-kind entries to the .ai/ files and update ledger.json.
+            Do NOT commit, push, merge, or open a PR. Leave changes in the
+            working tree only.
 
       - name: Open / update a DRAFT proposal PR (never auto-merged)
         if: steps.fetch.outputs.feedback_count != '0'


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- N/A

### 📌 ประเภทของ PR
- [ ] ✨ Feature ใหม่
- [ ] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [x] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
Workflow `learn-from-reviews` รันสำเร็จแต่ไม่เคยสร้าง `bot/learn-from-reviews` branch หรือ Draft PR เพราะ Claude ทำตาม SKILL.md Step 4 ที่บอกให้ "STOP" รอ human approve แทนที่จะ apply changes ลงไฟล์

### 🛠️ แก้ปัญหานั้นอย่างไร
อัปเดต prompt ใน `claude-code-action` step ให้:
- บอก Claude ว่าอยู่ใน CI (non-interactive) — ไม่มี human ตอบได้
- ชี้ตรงไปที่ Step 5 (Apply) และอธิบายว่า Draft PR คือ human review gate แทน
- ป้องกัน Claude ติด SKILL.md "STOP" instruction

### 🧪 วิธี Test
Trigger `workflow_dispatch` บน branch `develop` แล้วตรวจสอบว่า:
1. Step "Distill" รันสำเร็จ
2. มี branch `bot/learn-from-reviews` ถูกสร้าง
3. มี Draft PR ปรากฏขึ้น

### 🔑 Environment Variables ใหม่
- ไม่มี