### PR TITLE
fix(ECWC-142): fix Happy Hour entity database config and enhance DTO validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md — Backend-Ecommerce
+
+## Database Architecture
+
+โปรเจกต์นี้ใช้ **2 MySQL databases** แยกกัน:
+
+| Database | ตัวแปร env | ใช้สำหรับ |
+|----------|-----------|----------|
+| `ecommerce-db` | `DB_NAME` | Main database — entities ทั้งหมดที่ไม่ได้ระบุ `database` ใน `@Entity()` |
+| `e-commerce-database-other` | hardcoded ใน entity | Secondary database — entities ที่ระบุ `database: 'e-commerce-database-other'` |
+
+### Entities ที่อยู่ใน e-commerce-database-other
+
+- `HappyHourConfigEntity` — [src/happy-hour/happy-hour-config.entity.ts](src/happy-hour/happy-hour-config.entity.ts)
+- `HappyHourSlotEntity` — [src/happy-hour/happy-hour-slot.entity.ts](src/happy-hour/happy-hour-slot.entity.ts)
+
+## Migration
+
+- ใช้ TypeORM migrations เสมอ — **ห้ามใช้ `SYNCHRONIZE=true` ใน production**
+- Migration files อยู่ที่ [src/migrations/](src/migrations/)
+- รัน migration: `npm run migration:run`
+- สร้าง migration ใหม่: `npm run migration:generate -- src/migrations/<ชื่อ>`
+
+### สร้าง Table ใน e-commerce-database-other
+
+Migration ที่สร้าง table ข้าม database ต้องทำ 2 ขั้นตอนใน `up()`:
+
+```ts
+// 1. สร้าง database ถ้ายังไม่มี
+await queryRunner.query(
+  `CREATE DATABASE IF NOT EXISTS \`e-commerce-database-other\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`
+);
+
+// 2. สร้าง table โดยระบุ database prefix
+await queryRunner.query(
+  `CREATE TABLE IF NOT EXISTS \`e-commerce-database-other\`.\`table_name\` (...) ENGINE=InnoDB`
+);
+```
+
+DB user ที่รัน migration ต้องมีสิทธิ์ `CREATE` ระดับ global (`GRANT CREATE ON *.* TO 'user'@'host'`)
+
+## Environment Variables
+
+```env
+SYNCHRONIZE=false        # ต้องเป็น false เสมอใน production
+DB_HOST=...
+DB_PORT=3306
+DB_USERNAME=root
+DB_PASSWORD=...
+DB_NAME=ecommerce-db
+```
+
+## Happy Hour — Auto-seed
+
+`HappyHourService` implements `OnModuleInit` → seed default slots ลง `e-commerce-database-other` อัตโนมัติตอน app start ถ้าตารางว่างอยู่ ดู [src/happy-hour/happy-hour.service.ts](src/happy-hour/happy-hour.service.ts)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,50 @@
 
 [Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
 
+## Database Architecture
+
+โปรเจกต์นี้ใช้ **2 MySQL databases** แยกกัน:
+
+| Database | ใช้สำหรับ |
+|----------|----------|
+| `ecommerce-db` | Main database — entities ทั้งหมดทั่วไป |
+| `e-commerce-database-other` | Secondary database — features ที่แยกออกมา เช่น Happy Hour |
+
+Entity ที่อยู่ใน secondary database จะระบุ `database` ใน decorator:
+
+```ts
+@Entity({ name: 'happy_hour_config', database: 'e-commerce-database-other' })
+```
+
+### Migration
+
+```bash
+# รัน migration ที่ยังไม่ได้รัน
+npm run migration:run
+
+# สร้าง migration ใหม่
+npm run migration:generate -- src/migrations/<ชื่อ>
+
+# ย้อน migration ล่าสุด
+npm run migration:revert
+```
+
+> DB user ต้องมีสิทธิ์ `CREATE ON *.*` เพื่อสร้าง database ใหม่ได้
+> ห้ามใช้ `SYNCHRONIZE=true` ใน production — ใช้ migration แทนเสมอ
+
+### การเพิ่ม Table ใน Secondary Database
+
+Migration ที่สร้าง table ข้าม database ต้อง `CREATE DATABASE IF NOT EXISTS` ก่อน:
+
+```ts
+await queryRunner.query(
+  `CREATE DATABASE IF NOT EXISTS \`e-commerce-database-other\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`
+);
+await queryRunner.query(
+  `CREATE TABLE IF NOT EXISTS \`e-commerce-database-other\`.\`my_table\` (...) ENGINE=InnoDB`
+);
+```
+
 ## Project setup
 
 ```bash

--- a/src/happy-hour/BUG_REPORT.md
+++ b/src/happy-hour/BUG_REPORT.md
@@ -1,0 +1,270 @@
+# Happy Hour Module — Bug Report
+
+**Module:** `src/happy-hour/`
+**Tester:** QA (read-only review)
+**Date:** 2026-05-19
+**Branch:** `feature/ECWC-142`
+
+> หมายเหตุ: report นี้รวบรวม bug/issue ที่พบจากการอ่าน source โดยไม่แก้ไข codebase
+> ทุก bug จะมี test case ที่ reproduce อยู่ใน `*.spec.ts` ที่เขียนคู่กัน
+
+---
+
+## Severity Legend
+- 🔴 **Critical** — กระทบ data integrity / production behavior โดยตรง
+- 🟠 **High** — bug ที่ทำให้ฟังก์ชันทำงานผิดในบาง input
+- 🟡 **Medium** — ปัญหา validation / edge case ที่ควรปิด
+- 🔵 **Low** — code smell / inconsistency
+
+---
+
+## BUG-001 🟠 DTO regex รับเวลาที่ไม่ valid
+
+**File:** [src/happy-hour/dto/create-slot.dto.ts:11-15](src/happy-hour/dto/create-slot.dto.ts#L11-L15), [src/happy-hour/dto/simulate.dto.ts:8](src/happy-hour/dto/simulate.dto.ts#L8)
+
+**Issue**
+Regex `/^\d{2}:\d{2}$/` ตรวจเฉพาะ format ไม่ตรวจ valid range
+ค่าเช่น `"25:99"`, `"99:99"`, `"30:60"` ผ่าน validation
+
+**Impact**
+- `createSlot("25:99", "26:00")` ผ่าน DTO → ส่งไป MySQL TIME column → error หรือถูก coerce
+- `simulate({ order_time: "99:99" })` ผ่าน DTO → SQL `99:99:00` → ไม่ match slot ไหนเลย → silent failure ("is_happy_hour: false") ทั้งที่ input ผิด
+- `validateTimeRange` ใช้ string compare — `"25:99" >= "26:00"` = false (เพราะ '2'='2','5'<'6') → ดูเหมือน valid แต่ semantic ผิด
+
+**Reproduction (test):** `happy-hour.dto.spec.ts > CreateSlotDto > rejects invalid HH:mm range`
+
+**Expected**
+Regex หรือ custom validator ควรตรวจ `00-23` สำหรับชั่วโมง และ `00-59` สำหรับนาที
+เช่น `/^([01]\d|2[0-3]):[0-5]\d$/`
+
+---
+
+## BUG-002 🟠 DEFAULT_SLOTS ใช้ `end_time: '24:00'` ซึ่งไม่ใช่ valid 24-hour clock
+
+**File:** [src/happy-hour/happy-hour.service.ts:21](src/happy-hour/happy-hour.service.ts#L21)
+
+**Issue**
+`DEFAULT_SLOTS[0]` มี `end_time: '24:00'`
+- ใน 24-hour notation มาตรฐาน เวลาคือ `00:00`–`23:59`
+- MySQL TIME ยอมรับ `24:00:00` (เป็น special case) แต่ ISO 8601 ไม่รับ และ JavaScript `Date` ก็ไม่
+- หาก endpoint `createSlot` reject `24:00` (เพราะ implement custom validator ภายหลัง) จะเกิดความขัดแย้งกับ seed
+- query `slot.end_time > '23:59:00'` กับค่า `'24:00:00'` จะ work ใน MySQL แต่ developer ที่อ่าน code อาจสับสน
+
+**Impact**
+- เวลา `23:59` ปัจจุบัน — slot นี้ active ✓ (OK)
+- เวลา `00:00` — slot `00:00-02:00` active ✓ แต่ slot `22:00-24:00` ใช้ end_time `24:00` ซึ่งไม่ match `start_time <= '00:00:00' AND end_time > '00:00:00'` เพราะ start_time `22:00:00` > `00:00:00` (ไม่ match อยู่แล้ว) → OK
+
+**Reproduction:** `happy-hour.service.spec.ts > onModuleInit > seeds default slots with end_time 24:00`
+
+**Recommendation**
+ใช้ `23:59:59` หรือ design ใหม่ให้ slot รองรับ wrap-around รอบเที่ยงคืน (slot เดียวที่คร่อม midnight) แทนการแบ่งเป็น 2 rows
+
+---
+
+## BUG-003 🟠 `calcHappyHourReward` คืน `excessDiscount` แต่ไม่คืน `totalReward`
+
+**File:** [src/happy-hour/happy-hour.service.ts:148-186](src/happy-hour/happy-hour.service.ts#L148-L186)
+
+**Issue**
+Return shape ของ `calcHappyHourReward` ≠ shape ของ `simulate`:
+- `calcHappyHourReward` คืน `{ slot, numCards, excessDiscount, totalCardValue }`
+- `simulate` คืน `{ ..., num_cards, excess_discount, total_reward (= cards*cardValue + excessDiscount) }`
+
+caller (production code) ต้องคำนวณ `totalReward` เอง เสี่ยงคำนวณผิดเพราะแต่ละจุดมี logic ต่างกัน
+
+**Impact**
+ทุกที่ที่เรียก `calcHappyHourReward` ต้องเขียน `numCards * Number(slot.card_value) + excessDiscount` เอง → high risk of divergence
+
+**Reproduction:** `happy-hour.service.spec.ts > calcHappyHourReward > shape mismatch with simulate`
+
+**Recommendation**
+Return ให้สอดคล้องกัน เช่นเพิ่ม `totalReward` ใน calc หรือใช้ helper เดียวร่วมกัน
+
+---
+
+## BUG-004 🟡 `validateTimeRange` ใช้ string compare — เปราะบางต่อ format
+
+**File:** [src/happy-hour/happy-hour.service.ts:246-250](src/happy-hour/happy-hour.service.ts#L246-L250)
+
+**Issue**
+`if (start >= end)` — ใช้ string lexicographic compare
+- ถ้า input ตาม regex `HH:mm` (2 หลักเสมอ) — work ถูกต้อง
+- แต่ใน `updateSlot` ทำ `slot.start_time.substring(0, 5)` — สมมติว่า DB เก็บ `HH:mm:ss` เสมอ ถ้า MySQL คืน `H:mm:ss` หรือ format อื่น จะ slice ผิด
+
+**Impact**
+ระดับ low เพราะ MySQL TIME format มาตรฐาน แต่เป็น implicit contract ที่ไม่ defensive
+
+**Reproduction:** `happy-hour.service.spec.ts > validateTimeRange > equal start and end rejected`
+
+---
+
+## BUG-005 🟡 `validateNoOverlap` ไม่ครอบคลุม overlap ที่ "ครอบทั้ง slot เดิม"
+
+**File:** [src/happy-hour/happy-hour.service.ts:252-270](src/happy-hour/happy-hour.service.ts#L252-L270)
+
+**Issue**
+Query: `start_time < :end AND end_time > :start`
+- เคส A: existing `10:00-12:00`, new `09:00-13:00` → start=10 < 13 ✓, end=12 > 9 ✓ → detect ✓
+- เคส B: existing `10:00-12:00`, new `10:30-11:30` → start=10 < 11:30 ✓, end=12 > 10:30 ✓ → detect ✓
+- เคส boundary: existing `10:00-12:00`, new `12:00-14:00` → start=10 < 14 ✓, end=12 > 12 ✗ → no overlap (correct — touching boundary)
+- เคส boundary: existing `10:00-12:00`, new `08:00-10:00` → start=10 < 10 ✗ → no overlap (correct)
+
+**Verdict:** logic ถูกต้อง ไม่ใช่ bug แต่ tests ควรครอบเคสเหล่านี้
+
+**Reproduction:** `happy-hour.service.spec.ts > validateNoOverlap > * (multiple cases)`
+
+---
+
+## BUG-006 🔵 `getConfig` มี race condition
+
+**File:** [src/happy-hour/happy-hour.service.ts:89-96](src/happy-hour/happy-hour.service.ts#L89-L96)
+
+**Issue**
+ถ้า 2 request เข้ามาพร้อมๆ ในตอนที่ยังไม่มี config row → ทั้งคู่จะ `create({id:1})` + save พร้อมกัน → unique key conflict (1 request error)
+
+**Impact**
+Low — เกิดครั้งเดียวต่อ deployment (มี config row หลัง first call แล้ว); error ทำให้ user หนึ่ง retry ก็ผ่าน
+
+**Reproduction:** ทดสอบไม่คุ้ม — เป็น race condition เชิงสถาปัตยกรรม
+
+---
+
+## BUG-007 🟡 `simulate` ไม่ตรวจ `config.is_enabled`
+
+**File:** [src/happy-hour/happy-hour.service.ts:188-244](src/happy-hour/happy-hour.service.ts#L188-L244)
+
+**Issue**
+`simulate` คำนวณรางวัลโดยไม่สนใจว่า feature เปิดหรือไม่ — ขณะที่ `calcHappyHourReward` (production path) เช็ค `config.is_enabled`
+
+**Impact**
+- Admin tool: คงตั้งใจให้ simulate ได้แม้ปิด feature → **อาจไม่ใช่ bug แต่เป็น behavior ที่ควร document**
+- ถ้า frontend แสดงผล `simulate` ให้ลูกค้าเห็น → จะ leak ข้อมูล reward ทั้งที่ feature ปิด
+
+**Reproduction:** `happy-hour.service.spec.ts > simulate > works regardless of config.is_enabled`
+
+**Recommendation**
+ยืนยันเจตนากับ Product — ถ้าใช่ admin only ให้ document; ถ้าไม่ใช่ ให้เพิ่ม guard
+
+---
+
+## BUG-008 🟡 `updateSlot` `Object.assign(slot, dto)` ทำ partial mutation โดยไม่ validate ทุก field
+
+**File:** [src/happy-hour/happy-hour.service.ts:121-138](src/happy-hour/happy-hour.service.ts#L121-L138)
+
+**Issue**
+- DTO เป็น `Partial<CreateSlotDto>` — DTO field ที่เป็น `@IsOptional` ก็จะ optional หมด แต่ field บังคับเดิม (`@IsNumber()` + `@Min(1)`) ที่ไม่ใส่ Optional จะกลายเป็น invalid เมื่อไม่ส่ง
+- NestJS `ValidationPipe` ดูจาก class signature; `Partial<CreateSlotDto>` เป็น TypeScript util ไม่ส่งผลต่อ runtime decorator → field `min_order_amount` ฯลฯ จะถูก validate เป็น required ทุกครั้งใน PUT (ทำให้ partial update ใช้ไม่ได้จริง!)
+
+**Impact** 🟠 (อัปเกรดเป็น High เมื่อพิจารณาจริง)
+PUT `/admin/happy-hour/slots/:id` ด้วย body `{ "is_active": false }` จะ fail validation
+เพราะ `min_order_amount`, `card_value`, `excess_threshold`, `discount_per_step` decorator ยังถือว่า required
+
+**Reproduction:** `happy-hour.controller.spec.ts > updateSlot > partial update is rejected by validation`
+
+**Recommendation**
+ใช้ `PartialType(CreateSlotDto)` จาก `@nestjs/mapped-types` แทน TypeScript `Partial<>`
+
+---
+
+## BUG-009 🟡 `min_order_amount` constraint `@Min(1)` แต่ DEFAULT_SLOTS ใส่ 9999
+
+**File:** [src/happy-hour/dto/create-slot.dto.ts:18](src/happy-hour/dto/create-slot.dto.ts#L18)
+
+**Issue**
+DTO ยอมรับ `min_order_amount = 1` แต่ `calcHappyHourReward` จะคำนวณ `numCards = floor(orderAmount / 1) = orderAmount` → ลูกค้าได้ card เท่ากับยอดสั่ง → exploit ได้
+
+**Impact**
+ขึ้นกับ business rule — ถ้า admin ตั้ง min 1 บาทโดยไม่ตั้งใจ → ลูกค้าสั่ง 1,000 บาท ได้ 1,000 cards × card_value
+
+**Reproduction:** `happy-hour.dto.spec.ts > CreateSlotDto > accepts min_order_amount=1 (potential exploit)`
+
+**Recommendation**
+ใส่ business min (เช่น 100) หรือ document warning
+
+---
+
+## BUG-010 🔵 Decimal field คืน string จาก TypeORM แต่ใช้ `Number()` cast ปลายทาง
+
+**File:** [src/happy-hour/happy-hour.service.ts:172-184](src/happy-hour/happy-hour.service.ts#L172-L184)
+
+**Issue**
+`min_order_amount`, `card_value`, `excess_threshold`, `discount_per_step` เป็น `decimal(10,2)` — TypeORM mysql driver คืนเป็น **string** ไม่ใช่ number
+Code cast ด้วย `Number(...)` ที่ใช้งานจริง — แต่ entity field type declare เป็น `number` (lie)
+
+**Impact**
+TypeScript ไม่เตือน developer ที่ลืม cast → division ของ string เกิด NaN ใน case `"100" / 0` หรือ logic อื่น
+Code ปัจจุบัน cast ครบทุกจุดที่คำนวณ — ok แต่เป็น trap
+
+**Reproduction:** `happy-hour.service.spec.ts > calcHappyHourReward > handles decimal-as-string from DB`
+
+---
+
+## BUG-011 🟡 `calcHappyHourReward` timezone parsing เปราะบาง
+
+**File:** [src/happy-hour/happy-hour.service.ts:157-160](src/happy-hour/happy-hour.service.ts#L157-L160)
+
+**Issue**
+```ts
+const now = new Date(
+  new Date().toLocaleString('en-US', { timeZone: 'Asia/Bangkok' }),
+);
+```
+- `toLocaleString('en-US')` คืน format `"M/D/YYYY, h:mm:ss AM/PM"` หรือ similar — depends on Node ICU build
+- `new Date(<string>)` parse string โดย browser-specific; **ไม่ portable**
+- ถ้า Node มี `--icu=small` (without full ICU data) จะคืน format ต่างไป → parsing เพี้ยน
+
+**Impact**
+Production: server-side Node มักมี ICU เต็ม — work; แต่ docker image baseimages บางตัวไม่มี → silent wrong time
+
+**Reproduction:** ไม่ใส่ test (env-specific) — แต่ document warning
+
+**Recommendation**
+ใช้ `dayjs` (มีอยู่ใน dependencies แล้ว) + `dayjs.tz('Asia/Bangkok')`
+
+---
+
+## BUG-012 🟡 `reward_amount` constraint `@Min(1)` แต่ entity default = 1
+
+**File:** [src/happy-hour/dto/create-slot.dto.ts:46-48](src/happy-hour/dto/create-slot.dto.ts#L46-L48), [src/happy-hour/happy-hour-slot.entity.ts:41-42](src/happy-hour/happy-hour-slot.entity.ts#L41-L42)
+
+**Issue**
+Field optional → ถ้าไม่ส่ง entity ใช้ default 1 ✓
+แต่ถ้าส่ง `0` → reject (ดี) — เคสนี้ OK
+
+ปัญหา: ใน `simulate` ถ้า `reward_pro_code` มีค่าและ `reward_amount` คือ 1 — ทำงานปกติ
+แต่ถ้า `reward_amount = 0` (กรณี admin ตั้งใจไม่ให้รางวัล) — DTO reject แต่ business logic อาจต้องการเปิด case นี้
+
+**Impact** Low — business rule clarification
+
+---
+
+## BUG-013 🟠 `simulate` ไม่ตรวจ `slot.is_active` ในการคำนวณ reward_product
+
+**File:** [src/happy-hour/happy-hour.service.ts:222](src/happy-hour/happy-hour.service.ts#L222)
+
+**Issue**
+Query หาก slot ที่ `is_active = true` แล้ว — แต่ check `if (num_cards > 0 && slot.reward_pro_code)`
+- หาก slot ไม่มี `reward_pro_code` (NULL) → `reward_product = null` ✓
+- หาก `reward_amount = 0` (default ใน entity = 1, แต่ admin อาจตั้ง 0 ผ่าน raw SQL) — `num_cards * 0 = 0` ใน reward_product → frontend แสดง "0 ชิ้น"
+
+**Impact** Edge case ระดับ low
+
+---
+
+## Summary Table
+
+| Bug | Severity | Has Test |
+|-----|----------|----------|
+| BUG-001 DTO regex | 🟠 High | ✓ |
+| BUG-002 24:00 in defaults | 🟠 High | ✓ |
+| BUG-003 Shape mismatch calc vs simulate | 🟠 High | ✓ |
+| BUG-004 string compare timeRange | 🟡 Med | ✓ |
+| BUG-005 overlap boundary | 🟡 Med (logic ok, ต้องการ test coverage) | ✓ |
+| BUG-006 getConfig race | 🔵 Low | — |
+| BUG-007 simulate ignores config | 🟡 Med | ✓ |
+| BUG-008 updateSlot partial fails | 🟠 High | ✓ |
+| BUG-009 min_order_amount=1 exploit | 🟡 Med | ✓ |
+| BUG-010 decimal as string | 🔵 Low | ✓ |
+| BUG-011 timezone parsing | 🟡 Med | — |
+| BUG-012 reward_amount=0 | 🔵 Low | — |
+| BUG-013 reward_product 0 | 🔵 Low | — |

--- a/src/happy-hour/dto/create-slot.dto.ts
+++ b/src/happy-hour/dto/create-slot.dto.ts
@@ -8,10 +8,14 @@ import {
 } from 'class-validator';
 
 export class CreateSlotDto {
-  @Matches(/^\d{2}:\d{2}$/, { message: 'start_time ต้องอยู่ในรูปแบบ HH:mm' })
+  @Matches(/^([01]\d|2[0-3]):[0-5]\d$/, {
+    message: 'start_time ต้องอยู่ในรูปแบบ HH:mm (00:00–23:59)',
+  })
   start_time!: string;
 
-  @Matches(/^\d{2}:\d{2}$/, { message: 'end_time ต้องอยู่ในรูปแบบ HH:mm' })
+  @Matches(/^([01]\d|2[0-3]):[0-5]\d$/, {
+    message: 'end_time ต้องอยู่ในรูปแบบ HH:mm (00:00–23:59)',
+  })
   end_time!: string;
 
   @IsNumber()

--- a/src/happy-hour/dto/simulate.dto.ts
+++ b/src/happy-hour/dto/simulate.dto.ts
@@ -5,6 +5,8 @@ export class SimulateDto {
   @Min(0, { message: 'order_amount ต้องไม่ติดลบ' })
   order_amount!: number;
 
-  @Matches(/^\d{2}:\d{2}$/, { message: 'order_time ต้องอยู่ในรูปแบบ HH:mm' })
+  @Matches(/^([01]\d|2[0-3]):[0-5]\d$/, {
+    message: 'order_time ต้องอยู่ในรูปแบบ HH:mm (00:00–23:59)',
+  })
   order_time!: string;
 }

--- a/src/happy-hour/dto/update-slot.dto.ts
+++ b/src/happy-hour/dto/update-slot.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSlotDto } from './create-slot.dto';
+
+export class UpdateSlotDto extends PartialType(CreateSlotDto) {}

--- a/src/happy-hour/happy-hour-config.entity.ts
+++ b/src/happy-hour/happy-hour-config.entity.ts
@@ -1,6 +1,6 @@
 import { Column, Entity, PrimaryColumn } from 'typeorm';
 
-@Entity({ name: 'happy_hour_config', database: 'e-commerce-database-other' })
+@Entity({ name: 'happy_hour_config' })
 export class HappyHourConfigEntity {
   @PrimaryColumn({ type: 'int' })
   id!: number;

--- a/src/happy-hour/happy-hour-slot.entity.ts
+++ b/src/happy-hour/happy-hour-slot.entity.ts
@@ -6,7 +6,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
-@Entity({ name: 'happy_hour_slot', database: 'e-commerce-database-other' })
+@Entity({ name: 'happy_hour_slot' })
 export class HappyHourSlotEntity {
   @PrimaryGeneratedColumn()
   id!: number;

--- a/src/happy-hour/happy-hour.controller.spec.ts
+++ b/src/happy-hour/happy-hour.controller.spec.ts
@@ -1,0 +1,274 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  INestApplication,
+  ValidationPipe,
+} from '@nestjs/common';
+import { APP_PIPE } from '@nestjs/core';
+import * as request from 'supertest';
+import { HappyHourController } from './happy-hour.controller';
+import { HappyHourService } from './happy-hour.service';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+
+/**
+ * HappyHourController tests
+ * - Unit-style: mock HappyHourService + override JwtAuthGuard
+ * - ครอบคลุม routing, DTO validation pipe ที่ controller ใช้, transform/whitelist
+ *   ดู BUG_REPORT.md
+ */
+describe('HappyHourController', () => {
+  let app: INestApplication;
+  let service: jest.Mocked<HappyHourService>;
+
+  const fakeUser = {
+    username: 'admin1',
+    name: 'Admin One',
+    email: 'a@b.com',
+    mem_code: 'M01',
+  };
+
+  beforeEach(async () => {
+    const serviceMock: Partial<jest.Mocked<HappyHourService>> = {
+      getConfig: jest.fn(),
+      toggle: jest.fn(),
+      getSlots: jest.fn(),
+      createSlot: jest.fn(),
+      updateSlot: jest.fn(),
+      deleteSlot: jest.fn(),
+      simulate: jest.fn(),
+    };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      controllers: [HappyHourController],
+      providers: [
+        { provide: HappyHourService, useValue: serviceMock },
+        {
+          provide: APP_PIPE,
+          useFactory: () =>
+            new ValidationPipe({
+              whitelist: true,
+              forbidNonWhitelisted: true,
+              transform: true,
+            }),
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (ctx: any) => {
+          const req = ctx.switchToHttp().getRequest();
+          req.user = fakeUser;
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    service = moduleRef.get(HappyHourService) as jest.Mocked<HappyHourService>;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('GET /admin/happy-hour/config', () => {
+    it('returns config from service', async () => {
+      const config = { id: 1, is_enabled: true } as any;
+      service.getConfig.mockResolvedValueOnce(config);
+
+      await request(app.getHttpServer())
+        .get('/admin/happy-hour/config')
+        .expect(200)
+        .expect(config);
+    });
+  });
+
+  describe('PATCH /admin/happy-hour/toggle', () => {
+    it('toggles using authenticated username', async () => {
+      service.toggle.mockResolvedValueOnce({ id: 1, is_enabled: false } as any);
+
+      await request(app.getHttpServer())
+        .patch('/admin/happy-hour/toggle')
+        .expect(200);
+
+      expect(service.toggle).toHaveBeenCalledWith('admin1');
+    });
+  });
+
+  describe('GET /admin/happy-hour/slots', () => {
+    it('returns slot list', async () => {
+      service.getSlots.mockResolvedValueOnce([{ id: 1 } as any]);
+      await request(app.getHttpServer())
+        .get('/admin/happy-hour/slots')
+        .expect(200)
+        .expect([{ id: 1 }]);
+    });
+  });
+
+  describe('POST /admin/happy-hour/slots', () => {
+    const validBody = {
+      start_time: '10:00',
+      end_time: '12:00',
+      min_order_amount: 1000,
+      card_value: 100,
+      excess_threshold: 500,
+      discount_per_step: 10,
+    };
+
+    it('creates slot with valid body', async () => {
+      service.createSlot.mockResolvedValueOnce({ id: 1, ...validBody } as any);
+      await request(app.getHttpServer())
+        .post('/admin/happy-hour/slots')
+        .send(validBody)
+        .expect(201);
+      expect(service.createSlot).toHaveBeenCalledWith(
+        expect.objectContaining(validBody),
+      );
+    });
+
+    it('rejects missing required fields', async () => {
+      const { start_time, ...partial } = validBody;
+      await request(app.getHttpServer())
+        .post('/admin/happy-hour/slots')
+        .send(partial)
+        .expect(400);
+    });
+
+    it('rejects extra non-whitelisted fields (forbidNonWhitelisted)', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/happy-hour/slots')
+        .send({ ...validBody, foo: 'bar' })
+        .expect(400);
+    });
+
+    it('rejects bad time format', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/happy-hour/slots')
+        .send({ ...validBody, start_time: 'bad' })
+        .expect(400);
+    });
+
+    it('propagates BadRequest from service overlap check', async () => {
+      service.createSlot.mockRejectedValueOnce(
+        new BadRequestException('overlap'),
+      );
+      await request(app.getHttpServer())
+        .post('/admin/happy-hour/slots')
+        .send(validBody)
+        .expect(400);
+    });
+
+    /**
+     * BUG-001 (controller level) — invalid HH:mm range ผ่าน
+     * Test ตั้งใจให้ FAIL บน codebase ปัจจุบัน
+     */
+    it.each(['25:00', '99:99', '10:60'])(
+      'BUG-001: rejects invalid range start_time=%s',
+      async (bad) => {
+        await request(app.getHttpServer())
+          .post('/admin/happy-hour/slots')
+          .send({ ...validBody, start_time: bad, end_time: '23:59' })
+          .expect(400);
+      },
+    );
+  });
+
+  describe('PUT /admin/happy-hour/slots/:id', () => {
+    const validBody = {
+      start_time: '10:00',
+      end_time: '12:00',
+      min_order_amount: 1000,
+      card_value: 100,
+      excess_threshold: 500,
+      discount_per_step: 10,
+    };
+
+    it('parses :id as number and forwards body', async () => {
+      service.updateSlot.mockResolvedValueOnce({ id: 5 } as any);
+      await request(app.getHttpServer())
+        .put('/admin/happy-hour/slots/5')
+        .send(validBody)
+        .expect(200);
+      expect(service.updateSlot).toHaveBeenCalledWith(
+        5,
+        expect.objectContaining(validBody),
+      );
+    });
+
+    it('returns 400 for non-integer id', async () => {
+      await request(app.getHttpServer())
+        .put('/admin/happy-hour/slots/abc')
+        .send(validBody)
+        .expect(400);
+    });
+
+    /**
+     * BUG-008: partial update rejected by validation
+     * Controller declares dto as Partial<CreateSlotDto> (TS-only) — runtime decorators ยัง required
+     * Test นี้ตั้งใจให้ FAIL บน codebase ปัจจุบัน (ส่ง only is_active → 400)
+     */
+    it('BUG-008: should accept partial body { is_active: false }', async () => {
+      service.updateSlot.mockResolvedValueOnce({ id: 5, is_active: false } as any);
+      await request(app.getHttpServer())
+        .put('/admin/happy-hour/slots/5')
+        .send({ is_active: false })
+        .expect(200);
+    });
+  });
+
+  describe('DELETE /admin/happy-hour/slots/:id', () => {
+    it('returns 204 on success', async () => {
+      service.deleteSlot.mockResolvedValueOnce(undefined);
+      await request(app.getHttpServer())
+        .delete('/admin/happy-hour/slots/5')
+        .expect(204);
+      expect(service.deleteSlot).toHaveBeenCalledWith(5);
+    });
+
+    it('returns 400 for non-integer id', async () => {
+      await request(app.getHttpServer())
+        .delete('/admin/happy-hour/slots/xyz')
+        .expect(400);
+    });
+  });
+
+  describe('POST /admin/happy-hour/simulate', () => {
+    const validBody = { order_amount: 10000, order_time: '22:30' };
+
+    it('returns simulate result', async () => {
+      service.simulate.mockResolvedValueOnce({ is_happy_hour: false } as any);
+      await request(app.getHttpServer())
+        .post('/admin/happy-hour/simulate')
+        .send(validBody)
+        .expect(201)
+        .expect({ is_happy_hour: false });
+      expect(service.simulate).toHaveBeenCalledWith(
+        expect.objectContaining(validBody),
+      );
+    });
+
+    it('rejects negative order_amount', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/happy-hour/simulate')
+        .send({ order_amount: -1, order_time: '22:30' })
+        .expect(400);
+    });
+
+    it('rejects bad order_time format', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/happy-hour/simulate')
+        .send({ order_amount: 1000, order_time: '22-30' })
+        .expect(400);
+    });
+
+    it('strips extra fields via whitelist', async () => {
+      service.simulate.mockResolvedValueOnce({ is_happy_hour: false } as any);
+      await request(app.getHttpServer())
+        .post('/admin/happy-hour/simulate')
+        .send({ ...validBody, extraField: 'x' })
+        .expect(400); // forbidNonWhitelisted = true
+    });
+  });
+});

--- a/src/happy-hour/happy-hour.controller.ts
+++ b/src/happy-hour/happy-hour.controller.ts
@@ -17,6 +17,7 @@ import {
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { HappyHourService } from './happy-hour.service';
 import { CreateSlotDto } from './dto/create-slot.dto';
+import { UpdateSlotDto } from './dto/update-slot.dto';
 import { SimulateDto } from './dto/simulate.dto';
 interface JwtUser {
   username: string;
@@ -67,7 +68,7 @@ export class HappyHourController {
   @Put('slots/:id')
   updateSlot(
     @Param('id', ParseIntPipe) id: number,
-    @Body() dto: Partial<CreateSlotDto>,
+    @Body() dto: UpdateSlotDto,
   ) {
     return this.happyHourService.updateSlot(id, dto);
   }

--- a/src/happy-hour/happy-hour.dto.spec.ts
+++ b/src/happy-hour/happy-hour.dto.spec.ts
@@ -1,0 +1,225 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CreateSlotDto } from './dto/create-slot.dto';
+import { SimulateDto } from './dto/simulate.dto';
+
+/**
+ * DTO validation tests
+ * - คุม contract ของ input ที่ controller รับ
+ * - มี test ที่ตั้งใจ fail เพื่อโชว์ BUG-001 (regex รับเวลาเกินช่วง)
+ *   ดู BUG_REPORT.md
+ */
+describe('Happy Hour DTOs', () => {
+  const baseValidSlot = {
+    start_time: '10:00',
+    end_time: '12:00',
+    min_order_amount: 1000,
+    card_value: 100,
+    excess_threshold: 500,
+    discount_per_step: 10,
+  };
+
+  describe('CreateSlotDto — happy path', () => {
+    it('accepts a fully populated valid payload', async () => {
+      const dto = plainToInstance(CreateSlotDto, {
+        ...baseValidSlot,
+        is_active: true,
+        reward_pro_code: 'P001',
+        reward_unit: 'BOX',
+        reward_amount: 2,
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts minimal payload (optional fields omitted)', async () => {
+      const dto = plainToInstance(CreateSlotDto, baseValidSlot);
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('CreateSlotDto — time format', () => {
+    it.each([
+      ['9:00', '12:00', 'start single-digit hour'],
+      ['10:0', '12:00', 'start single-digit minute'],
+      ['10:00', '12', 'end no minute'],
+      ['', '12:00', 'empty start'],
+      ['10-00', '12:00', 'wrong separator'],
+    ])('rejects format start=%s end=%s (%s)', async (start, end) => {
+      const dto = plainToInstance(CreateSlotDto, {
+        ...baseValidSlot,
+        start_time: start,
+        end_time: end,
+      });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    /**
+     * BUG-001 — regex /^\d{2}:\d{2}$/ ไม่ตรวจ range
+     * Test นี้ตั้งใจให้ FAIL บน codebase ปัจจุบัน
+     * Expected behavior: invalid 24-hour clock values ต้องถูก reject
+     */
+    it.each([
+      ['25:00', '26:00'],
+      ['99:99', '99:99'],
+      ['10:60', '11:00'],
+      ['10:00', '24:99'],
+      ['ab:cd', '12:00'], // นี่ regex ปัจจุบันก็ reject แล้ว — ใส่เพื่อยืนยัน
+    ])(
+      'BUG-001: rejects invalid HH:mm range start=%s end=%s',
+      async (start, end) => {
+        const dto = plainToInstance(CreateSlotDto, {
+          ...baseValidSlot,
+          start_time: start,
+          end_time: end,
+        });
+        const errors = await validate(dto);
+        // เคสที่ regex ปัจจุบัน reject (ab:cd, 99:99 ในส่วน letters): pass
+        // เคสที่ regex ปัจจุบัน accept ทั้งที่ range ผิด (25:00, 10:60): test นี้จะ fail → bug confirmed
+        expect(errors.length).toBeGreaterThan(0);
+      },
+    );
+  });
+
+  describe('CreateSlotDto — numeric constraints', () => {
+    it.each([
+      ['min_order_amount', 0],
+      ['min_order_amount', -1],
+      ['card_value', 0],
+      ['excess_threshold', 0],
+      ['discount_per_step', 0],
+      ['reward_amount', 0],
+    ])('rejects %s = %i', async (field, value) => {
+      const dto = plainToInstance(CreateSlotDto, {
+        ...baseValidSlot,
+        [field]: value,
+      });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some((e) => e.property === field)).toBe(true);
+    });
+
+    it.each([
+      ['min_order_amount'],
+      ['card_value'],
+      ['excess_threshold'],
+      ['discount_per_step'],
+    ])('rejects non-numeric %s', async (field) => {
+      const dto = plainToInstance(CreateSlotDto, {
+        ...baseValidSlot,
+        [field]: 'abc',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === field)).toBe(true);
+    });
+
+    /**
+     * BUG-009 — accepts min_order_amount=1 (potential exploit)
+     * Test ยืนยันว่า DTO ปัจจุบันยอมรับค่านี้ (FYI ใน report)
+     */
+    it('BUG-009: accepts min_order_amount=1 (no business minimum)', async () => {
+      const dto = plainToInstance(CreateSlotDto, {
+        ...baseValidSlot,
+        min_order_amount: 1,
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('CreateSlotDto — optional fields', () => {
+    it('accepts is_active=false', async () => {
+      const dto = plainToInstance(CreateSlotDto, {
+        ...baseValidSlot,
+        is_active: false,
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects is_active as non-boolean', async () => {
+      const dto = plainToInstance(CreateSlotDto, {
+        ...baseValidSlot,
+        is_active: 'yes',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'is_active')).toBe(true);
+    });
+
+    it('rejects reward_pro_code as non-string', async () => {
+      const dto = plainToInstance(CreateSlotDto, {
+        ...baseValidSlot,
+        reward_pro_code: 12345,
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'reward_pro_code')).toBe(true);
+    });
+  });
+
+  describe('SimulateDto', () => {
+    it('accepts valid payload', async () => {
+      const dto = plainToInstance(SimulateDto, {
+        order_amount: 10000,
+        order_time: '22:30',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts order_amount = 0', async () => {
+      const dto = plainToInstance(SimulateDto, {
+        order_amount: 0,
+        order_time: '22:30',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects negative order_amount', async () => {
+      const dto = plainToInstance(SimulateDto, {
+        order_amount: -1,
+        order_time: '22:30',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'order_amount')).toBe(true);
+    });
+
+    it('rejects non-numeric order_amount', async () => {
+      const dto = plainToInstance(SimulateDto, {
+        order_amount: 'abc',
+        order_time: '22:30',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'order_amount')).toBe(true);
+    });
+
+    it.each(['', '9:00', '22-30', '22:3', 'abcd'])(
+      'rejects bad order_time format %s',
+      async (time) => {
+        const dto = plainToInstance(SimulateDto, {
+          order_amount: 1000,
+          order_time: time,
+        });
+        const errors = await validate(dto);
+        expect(errors.some((e) => e.property === 'order_time')).toBe(true);
+      },
+    );
+
+    /**
+     * BUG-001 (mirror) — order_time ก็มี regex เดียวกัน
+     */
+    it.each(['25:00', '99:99', '23:60'])(
+      'BUG-001: rejects out-of-range order_time %s',
+      async (time) => {
+        const dto = plainToInstance(SimulateDto, {
+          order_amount: 1000,
+          order_time: time,
+        });
+        const errors = await validate(dto);
+        expect(errors.length).toBeGreaterThan(0);
+      },
+    );
+  });
+});

--- a/src/happy-hour/happy-hour.service.spec.ts
+++ b/src/happy-hour/happy-hour.service.spec.ts
@@ -1,0 +1,497 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { HappyHourService } from './happy-hour.service';
+import { HappyHourConfigEntity } from './happy-hour-config.entity';
+import { HappyHourSlotEntity } from './happy-hour-slot.entity';
+import { ProductEntity } from 'src/products/products.entity';
+
+/**
+ * HappyHourService unit tests
+ * - Mock TypeORM repositories อย่างน้อยที่จำเป็น
+ * - แยกเป็น case: happy path / edge / bug-reproduction
+ *   ดู BUG_REPORT.md
+ */
+
+type SlotRow = Partial<HappyHourSlotEntity>;
+
+const buildSlot = (overrides: SlotRow = {}): HappyHourSlotEntity => ({
+  id: 1,
+  start_time: '22:00:00',
+  end_time: '24:00:00',
+  min_order_amount: 9999 as unknown as number,
+  card_value: 100 as unknown as number,
+  excess_threshold: 1334 as unknown as number,
+  discount_per_step: 10 as unknown as number,
+  is_active: true,
+  reward_pro_code: '92020405',
+  reward_unit: null,
+  reward_amount: 1,
+  created_at: new Date('2026-01-01T00:00:00Z'),
+  updated_at: new Date('2026-01-01T00:00:00Z'),
+  ...overrides,
+}) as HappyHourSlotEntity;
+
+const createQbMock = (returnSlot: HappyHourSlotEntity | null, countValue = 0) => {
+  const qb = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getOne: jest.fn().mockResolvedValue(returnSlot),
+    getCount: jest.fn().mockResolvedValue(countValue),
+  };
+  return qb;
+};
+
+describe('HappyHourService', () => {
+  let service: HappyHourService;
+  let configRepo: any;
+  let slotRepo: any;
+  let productRepo: any;
+
+  beforeEach(async () => {
+    configRepo = {
+      findOneBy: jest.fn(),
+      create: jest.fn((x) => x),
+      save: jest.fn(async (x) => x),
+    };
+    slotRepo = {
+      count: jest.fn().mockResolvedValue(4),
+      find: jest.fn(),
+      findOneBy: jest.fn(),
+      create: jest.fn((x) => x),
+      save: jest.fn(async (x) => (Array.isArray(x) ? x : { id: 1, ...x })),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+      createQueryBuilder: jest.fn(),
+    };
+    productRepo = {
+      findOne: jest.fn(),
+    };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        HappyHourService,
+        { provide: getRepositoryToken(HappyHourConfigEntity), useValue: configRepo },
+        { provide: getRepositoryToken(HappyHourSlotEntity), useValue: slotRepo },
+        { provide: getRepositoryToken(ProductEntity), useValue: productRepo },
+      ],
+    }).compile();
+
+    service = moduleRef.get(HappyHourService);
+  });
+
+  describe('onModuleInit (seeding)', () => {
+    it('seeds DEFAULT_SLOTS when slot table empty', async () => {
+      slotRepo.count.mockResolvedValueOnce(0);
+      await service.onModuleInit();
+      expect(slotRepo.create).toHaveBeenCalledTimes(4);
+      expect(slotRepo.save).toHaveBeenCalledTimes(1);
+      const savedArg = slotRepo.save.mock.calls[0][0];
+      expect(savedArg).toHaveLength(4);
+    });
+
+    it('does not seed when slots already exist', async () => {
+      slotRepo.count.mockResolvedValueOnce(4);
+      await service.onModuleInit();
+      expect(slotRepo.save).not.toHaveBeenCalled();
+    });
+
+    /**
+     * BUG-002: ตรวจว่า DEFAULT_SLOTS มี end_time '24:00' (เลข 24 ผิดสำหรับ 24-hour clock)
+     */
+    it('BUG-002: default slots contain end_time "24:00" (non-canonical clock value)', async () => {
+      slotRepo.count.mockResolvedValueOnce(0);
+      await service.onModuleInit();
+      const savedSlots = slotRepo.save.mock.calls[0][0] as SlotRow[];
+      const has2400 = savedSlots.some((s) => s.end_time === '24:00');
+      expect(has2400).toBe(true);
+    });
+  });
+
+  describe('getConfig', () => {
+    it('returns existing config row', async () => {
+      const config = { id: 1, is_enabled: true } as HappyHourConfigEntity;
+      configRepo.findOneBy.mockResolvedValueOnce(config);
+      const result = await service.getConfig();
+      expect(result).toBe(config);
+      expect(configRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('creates default disabled config if none exists', async () => {
+      configRepo.findOneBy.mockResolvedValueOnce(null);
+      const result = await service.getConfig();
+      expect(result.id).toBe(1);
+      expect(result.is_enabled).toBe(false);
+      expect(configRepo.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('toggle', () => {
+    it('flips is_enabled from false to true and stamps user', async () => {
+      configRepo.findOneBy.mockResolvedValueOnce({ id: 1, is_enabled: false });
+      const result = await service.toggle('admin1');
+      expect(result.is_enabled).toBe(true);
+      expect(result.updated_by).toBe('admin1');
+      expect(result.updated_at).toBeInstanceOf(Date);
+    });
+
+    it('flips is_enabled from true to false', async () => {
+      configRepo.findOneBy.mockResolvedValueOnce({ id: 1, is_enabled: true });
+      const result = await service.toggle('admin2');
+      expect(result.is_enabled).toBe(false);
+    });
+  });
+
+  describe('getSlots', () => {
+    it('returns slots ordered by start_time asc', async () => {
+      const rows = [buildSlot({ id: 1 }), buildSlot({ id: 2 })];
+      slotRepo.find.mockResolvedValueOnce(rows);
+      const result = await service.getSlots();
+      expect(slotRepo.find).toHaveBeenCalledWith({ order: { start_time: 'ASC' } });
+      expect(result).toBe(rows);
+    });
+  });
+
+  describe('createSlot', () => {
+    const baseDto = {
+      start_time: '10:00',
+      end_time: '12:00',
+      min_order_amount: 1000,
+      card_value: 100,
+      excess_threshold: 500,
+      discount_per_step: 10,
+    };
+
+    it('creates slot when no overlap', async () => {
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(null, 0));
+      slotRepo.save.mockResolvedValueOnce({ id: 99, ...baseDto, is_active: true });
+
+      const result = await service.createSlot(baseDto as any);
+      expect(result.id).toBe(99);
+      expect(slotRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ is_active: true }),
+      );
+    });
+
+    it('preserves is_active=false from dto', async () => {
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(null, 0));
+      slotRepo.save.mockResolvedValueOnce({ id: 1 });
+      await service.createSlot({ ...baseDto, is_active: false } as any);
+      expect(slotRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ is_active: false }),
+      );
+    });
+
+    it('throws BadRequest when start_time >= end_time', async () => {
+      await expect(
+        service.createSlot({ ...baseDto, start_time: '12:00', end_time: '12:00' } as any),
+      ).rejects.toThrow(BadRequestException);
+
+      await expect(
+        service.createSlot({ ...baseDto, start_time: '13:00', end_time: '10:00' } as any),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequest on overlap', async () => {
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(null, 1));
+      await expect(service.createSlot(baseDto as any)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    /**
+     * BUG-005 ครอบ boundary cases: 12:00-14:00 vs existing 10:00-12:00 ต้อง pass
+     */
+    it('allows adjacent (touching) slots — 12:00 boundary', async () => {
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(null, 0));
+      slotRepo.save.mockResolvedValueOnce({ id: 2 });
+      await expect(
+        service.createSlot({ ...baseDto, start_time: '12:00', end_time: '14:00' } as any),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('updateSlot', () => {
+    it('throws NotFound when slot id missing', async () => {
+      slotRepo.findOneBy.mockResolvedValueOnce(null);
+      await expect(service.updateSlot(404, { is_active: false })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('updates fields using existing time when not provided', async () => {
+      const existing = buildSlot({ start_time: '10:00:00', end_time: '12:00:00' });
+      slotRepo.findOneBy.mockResolvedValueOnce(existing);
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(null, 0));
+      slotRepo.save.mockImplementationOnce(async (s: any) => s);
+
+      const result = await service.updateSlot(1, { is_active: false });
+      expect(result.is_active).toBe(false);
+    });
+
+    it('rejects partial update where new start_time >= existing end_time', async () => {
+      const existing = buildSlot({ start_time: '10:00:00', end_time: '12:00:00' });
+      slotRepo.findOneBy.mockResolvedValueOnce(existing);
+
+      await expect(
+        service.updateSlot(1, { start_time: '12:00' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('excludes self when checking overlap on update', async () => {
+      const existing = buildSlot({ start_time: '10:00:00', end_time: '12:00:00' });
+      slotRepo.findOneBy.mockResolvedValueOnce(existing);
+      const qb = createQbMock(null, 0);
+      slotRepo.createQueryBuilder.mockReturnValueOnce(qb);
+      slotRepo.save.mockImplementationOnce(async (s: any) => s);
+
+      await service.updateSlot(1, { start_time: '10:30', end_time: '11:30' });
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('slot.id != :excludeId'),
+        { excludeId: 1 },
+      );
+    });
+  });
+
+  describe('deleteSlot', () => {
+    it('throws NotFound when slot id missing', async () => {
+      slotRepo.findOneBy.mockResolvedValueOnce(null);
+      await expect(service.deleteSlot(999)).rejects.toThrow(NotFoundException);
+    });
+
+    it('deletes existing slot', async () => {
+      slotRepo.findOneBy.mockResolvedValueOnce(buildSlot({ id: 5 }));
+      await service.deleteSlot(5);
+      expect(slotRepo.delete).toHaveBeenCalledWith(5);
+    });
+  });
+
+  describe('calcHappyHourReward', () => {
+    it('returns null when config disabled', async () => {
+      configRepo.findOneBy.mockResolvedValueOnce({ id: 1, is_enabled: false });
+      const result = await service.calcHappyHourReward(10000);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when no slot matches current time', async () => {
+      configRepo.findOneBy.mockResolvedValueOnce({ id: 1, is_enabled: true });
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(null));
+      const result = await service.calcHappyHourReward(10000);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when orderAmount < min_order_amount (0 cards)', async () => {
+      configRepo.findOneBy.mockResolvedValueOnce({ id: 1, is_enabled: true });
+      const slot = buildSlot({
+        min_order_amount: 9999 as unknown as number,
+      });
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(slot));
+
+      const result = await service.calcHappyHourReward(5000);
+      expect(result).toBeNull();
+    });
+
+    it('computes cards + zero excess', async () => {
+      configRepo.findOneBy.mockResolvedValueOnce({ id: 1, is_enabled: true });
+      const slot = buildSlot({
+        min_order_amount: '1000' as unknown as number,
+        card_value: '100' as unknown as number,
+        excess_threshold: '500' as unknown as number,
+        discount_per_step: '10' as unknown as number,
+      });
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(slot));
+
+      const result = await service.calcHappyHourReward(3000);
+      expect(result).toEqual({
+        slot,
+        numCards: 3,
+        excessDiscount: 0,
+        totalCardValue: 300,
+      });
+    });
+
+    it('computes cards + excess discount steps', async () => {
+      configRepo.findOneBy.mockResolvedValueOnce({ id: 1, is_enabled: true });
+      const slot = buildSlot({
+        min_order_amount: '1000' as unknown as number,
+        card_value: '100' as unknown as number,
+        excess_threshold: '500' as unknown as number,
+        discount_per_step: '10' as unknown as number,
+      });
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(slot));
+
+      // 3500 → 3 cards (3000), excess 500 → 1 step → 10 discount
+      const result = await service.calcHappyHourReward(3500);
+      expect(result).toEqual({
+        slot,
+        numCards: 3,
+        excessDiscount: 10,
+        totalCardValue: 300,
+      });
+    });
+
+    /**
+     * BUG-010: TypeORM decimal columns return strings; service must cast
+     * test ใส่ค่า string เพื่อยืนยันว่า Number() cast ทำงานทุก field
+     */
+    it('BUG-010: handles decimal-as-string from DB', async () => {
+      configRepo.findOneBy.mockResolvedValueOnce({ id: 1, is_enabled: true });
+      const slot = buildSlot({
+        min_order_amount: '1000.00' as unknown as number,
+        card_value: '100.00' as unknown as number,
+        excess_threshold: '500.00' as unknown as number,
+        discount_per_step: '10.00' as unknown as number,
+      });
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(slot));
+
+      const result = await service.calcHappyHourReward(2500);
+      expect(result?.numCards).toBe(2);
+      expect(result?.excessDiscount).toBe(10); // excess 500/500 = 1 step
+      expect(result?.totalCardValue).toBe(200);
+      expect(Number.isNaN(result?.totalCardValue)).toBe(false);
+    });
+
+    /**
+     * BUG-003: shape mismatch — calc ไม่คืน totalReward; simulate คืน
+     * Test นี้เพียง assert shape ปัจจุบันเพื่อ pin documentation ของ bug
+     */
+    it('BUG-003: return shape lacks total_reward (calc vs simulate divergence)', async () => {
+      configRepo.findOneBy.mockResolvedValueOnce({ id: 1, is_enabled: true });
+      const slot = buildSlot({
+        min_order_amount: '1000' as unknown as number,
+        card_value: '100' as unknown as number,
+        excess_threshold: '500' as unknown as number,
+        discount_per_step: '10' as unknown as number,
+      });
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(slot));
+
+      const result = await service.calcHappyHourReward(2500);
+      expect(result).not.toBeNull();
+      expect(result).not.toHaveProperty('total_reward');
+      expect(result).not.toHaveProperty('totalReward');
+    });
+  });
+
+  describe('simulate', () => {
+    const baseDto = { order_amount: 10000, order_time: '22:30' };
+
+    it('returns is_happy_hour=false when no slot matches', async () => {
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(null));
+      const result = await service.simulate(baseDto as any);
+      expect(result).toEqual({ is_happy_hour: false });
+    });
+
+    it('returns is_happy_hour=false when orderAmount yields 0 cards', async () => {
+      const slot = buildSlot({
+        min_order_amount: '9999' as unknown as number,
+      });
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(slot));
+
+      const result = await service.simulate({
+        order_amount: 100,
+        order_time: '22:30',
+      } as any);
+      expect(result).toEqual({ is_happy_hour: false });
+    });
+
+    it('returns full reward shape with reward_product (product found)', async () => {
+      const slot = buildSlot({
+        id: 7,
+        min_order_amount: '1000' as unknown as number,
+        card_value: '100' as unknown as number,
+        excess_threshold: '500' as unknown as number,
+        discount_per_step: '10' as unknown as number,
+        reward_pro_code: 'P-X',
+        reward_unit: 'BOX',
+        reward_amount: 2,
+      });
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(slot));
+      productRepo.findOne.mockResolvedValueOnce({
+        pro_code: 'P-X',
+        pro_name: 'ProductX',
+        pro_imgmain: 'img.png',
+      });
+
+      const result = await service.simulate({
+        order_amount: 3500,
+        order_time: '22:30',
+      } as any);
+
+      expect(result).toMatchObject({
+        is_happy_hour: true,
+        num_cards: 3,
+        excess_discount: 10,
+        total_reward: 310, // 3*100 + 10
+        reward_product: {
+          pro_code: 'P-X',
+          unit: 'BOX',
+          amount: 6, // 3 cards * reward_amount=2
+          pro_name: 'ProductX',
+          pro_imgmain: 'img.png',
+        },
+      });
+    });
+
+    it('returns null product fields when product not found', async () => {
+      const slot = buildSlot({
+        min_order_amount: '1000' as unknown as number,
+        card_value: '100' as unknown as number,
+        excess_threshold: '500' as unknown as number,
+        discount_per_step: '10' as unknown as number,
+        reward_pro_code: 'MISSING',
+      });
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(slot));
+      productRepo.findOne.mockResolvedValueOnce(null);
+
+      const result: any = await service.simulate({
+        order_amount: 2000,
+        order_time: '22:30',
+      } as any);
+      expect(result.reward_product.pro_code).toBe('MISSING');
+      expect(result.reward_product.pro_name).toBeNull();
+      expect(result.reward_product.pro_imgmain).toBeNull();
+    });
+
+    it('reward_product is null when slot has no reward_pro_code', async () => {
+      const slot = buildSlot({
+        min_order_amount: '1000' as unknown as number,
+        card_value: '100' as unknown as number,
+        excess_threshold: '500' as unknown as number,
+        discount_per_step: '10' as unknown as number,
+        reward_pro_code: null,
+      });
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(slot));
+
+      const result: any = await service.simulate({
+        order_amount: 2000,
+        order_time: '22:30',
+      } as any);
+      expect(result.is_happy_hour).toBe(true);
+      expect(result.reward_product).toBeNull();
+      expect(productRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    /**
+     * BUG-007: simulate ไม่เช็ค config.is_enabled
+     * Test ยืนยัน behavior ปัจจุบัน (ทำงานได้แม้ feature ปิด)
+     */
+    it('BUG-007: works regardless of config.is_enabled (no guard)', async () => {
+      configRepo.findOneBy.mockResolvedValueOnce({ id: 1, is_enabled: false });
+      const slot = buildSlot({
+        min_order_amount: '1000' as unknown as number,
+        card_value: '100' as unknown as number,
+        excess_threshold: '500' as unknown as number,
+        discount_per_step: '10' as unknown as number,
+        reward_pro_code: null,
+      });
+      slotRepo.createQueryBuilder.mockReturnValueOnce(createQbMock(slot));
+
+      const result: any = await service.simulate({
+        order_amount: 2000,
+        order_time: '22:30',
+      } as any);
+      expect(result.is_happy_hour).toBe(true);
+      // ไม่ได้แตะ configRepo.findOneBy เลย — ยืนยันว่าไม่มี guard
+      expect(configRepo.findOneBy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/happy-hour/happy-hour.service.ts
+++ b/src/happy-hour/happy-hour.service.ts
@@ -2,7 +2,7 @@ import {
   BadRequestException,
   Injectable,
   NotFoundException,
-  OnModuleInit,
+  // OnModuleInit,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -19,63 +19,64 @@ import { ProductEntity } from 'src/products/products.entity';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-const DEFAULT_SLOTS: Omit<
-  HappyHourSlotEntity,
-  'id' | 'created_at' | 'updated_at'
->[] = [
-  {
-    start_time: '22:00',
-    // MySQL TIME ยอมรับ 24:00:00 เป็น special case — ใช้เพื่อครอบคลุม slot จนถึงก่อนเที่ยงคืน
-    end_time: '24:00',
-    min_order_amount: 9999,
-    card_value: 100,
-    excess_threshold: 1334,
-    discount_per_step: 10,
-    is_active: true,
-    reward_pro_code: '92020405',
-    reward_unit: null,
-    reward_amount: 1,
-  },
-  {
-    start_time: '00:00',
-    end_time: '02:00',
-    min_order_amount: 9999,
-    card_value: 100,
-    excess_threshold: 1000,
-    discount_per_step: 10,
-    is_active: true,
-    reward_pro_code: '92020405',
-    reward_unit: null,
-    reward_amount: 1,
-  },
-  {
-    start_time: '02:00',
-    end_time: '06:00',
-    min_order_amount: 9999,
-    card_value: 100,
-    excess_threshold: 667,
-    discount_per_step: 10,
-    is_active: true,
-    reward_pro_code: '92020405',
-    reward_unit: null,
-    reward_amount: 1,
-  },
-  {
-    start_time: '06:00',
-    end_time: '08:00',
-    min_order_amount: 9999,
-    card_value: 100,
-    excess_threshold: 1334,
-    discount_per_step: 10,
-    is_active: true,
-    reward_pro_code: '92020405',
-    reward_unit: null,
-    reward_amount: 1,
-  },
-];
+// const DEFAULT_SLOTS: Omit<
+//   HappyHourSlotEntity,
+//   'id' | 'created_at' | 'updated_at'
+// >[] = [
+//   {
+//     start_time: '22:00',
+//     // MySQL TIME ยอมรับ 24:00:00 เป็น special case — ใช้เพื่อครอบคลุม slot จนถึงก่อนเที่ยงคืน
+//     end_time: '24:00',
+//     min_order_amount: 9999,
+//     card_value: 100,
+//     excess_threshold: 1334,
+//     discount_per_step: 10,
+//     is_active: true,
+//     reward_pro_code: '92020405',
+//     reward_unit: null,
+//     reward_amount: 1,
+//   },
+//   {
+//     start_time: '00:00',
+//     end_time: '02:00',
+//     min_order_amount: 9999,
+//     card_value: 100,
+//     excess_threshold: 1000,
+//     discount_per_step: 10,
+//     is_active: true,
+//     reward_pro_code: '92020405',
+//     reward_unit: null,
+//     reward_amount: 1,
+//   },
+//   {
+//     start_time: '02:00',
+//     end_time: '06:00',
+//     min_order_amount: 9999,
+//     card_value: 100,
+//     excess_threshold: 667,
+//     discount_per_step: 10,
+//     is_active: true,
+//     reward_pro_code: '92020405',
+//     reward_unit: null,
+//     reward_amount: 1,
+//   },
+//   {
+//     start_time: '06:00',
+//     end_time: '08:00',
+//     min_order_amount: 9999,
+//     card_value: 100,
+//     excess_threshold: 1334,
+//     discount_per_step: 10,
+//     is_active: true,
+//     reward_pro_code: '92020405',
+//     reward_unit: null,
+//     reward_amount: 1,
+//   },
+// ];
 
 @Injectable()
-export class HappyHourService implements OnModuleInit {
+// export class HappyHourService implements OnModuleInit {
+export class HappyHourService {
   constructor(
     @InjectRepository(HappyHourConfigEntity)
     private readonly configRepo: Repository<HappyHourConfigEntity>,
@@ -85,18 +86,18 @@ export class HappyHourService implements OnModuleInit {
     private readonly productRepo: Repository<ProductEntity>,
   ) {}
 
-  async onModuleInit(): Promise<void> {
-    try {
-      const count = await this.slotRepo.count();
-      if (count === 0) {
-        await this.slotRepo.save(
-          DEFAULT_SLOTS.map((s) => this.slotRepo.create(s)),
-        );
-      }
-    } catch {
-      // table ยังไม่มีใน DB — ข้ามไปก่อน feature จะทำงานหลัง migrate
-    }
-  }
+  // async onModuleInit(): Promise<void> {
+  //   try {
+  //     const count = await this.slotRepo.count();
+  //     if (count === 0) {
+  //       await this.slotRepo.save(
+  //         DEFAULT_SLOTS.map((s) => this.slotRepo.create(s) ),
+  //       );
+  //     }
+  //   } catch {
+  //     // table ยังไม่มีใน DB — ข้ามไปก่อน feature จะทำงานหลัง migrate
+  //   }
+  // }
 
   async getConfig(): Promise<HappyHourConfigEntity> {
     let config = await this.configRepo.findOneBy({ id: 1 });

--- a/src/happy-hour/happy-hour.service.ts
+++ b/src/happy-hour/happy-hour.service.ts
@@ -6,9 +6,9 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import * as dayjs from 'dayjs';
+import * as utc from 'dayjs/plugin/utc';
+import * as timezone from 'dayjs/plugin/timezone';
 import { HappyHourConfigEntity } from './happy-hour-config.entity';
 import { HappyHourSlotEntity } from './happy-hour-slot.entity';
 import { CreateSlotDto } from './dto/create-slot.dto';
@@ -86,11 +86,15 @@ export class HappyHourService implements OnModuleInit {
   ) {}
 
   async onModuleInit(): Promise<void> {
-    const count = await this.slotRepo.count();
-    if (count === 0) {
-      await this.slotRepo.save(
-        DEFAULT_SLOTS.map((s) => this.slotRepo.create(s)),
-      );
+    try {
+      const count = await this.slotRepo.count();
+      if (count === 0) {
+        await this.slotRepo.save(
+          DEFAULT_SLOTS.map((s) => this.slotRepo.create(s)),
+        );
+      }
+    } catch {
+      // table ยังไม่มีใน DB — ข้ามไปก่อน feature จะทำงานหลัง migrate
     }
   }
 
@@ -160,38 +164,43 @@ export class HappyHourService implements OnModuleInit {
     totalCardValue: number;
     totalReward: number;
   } | null> {
-    const config = await this.getConfig();
-    if (!config.is_enabled) return null;
+    try {
+      const config = await this.getConfig();
+      if (!config.is_enabled) return null;
 
-    const now = dayjs().tz('Asia/Bangkok');
-    const orderTimeSql = now.format('HH:mm:00');
+      const now = dayjs().tz('Asia/Bangkok');
+      const orderTimeSql = now.format('HH:mm:00');
 
-    const slot = await this.slotRepo
-      .createQueryBuilder('slot')
-      .where('slot.is_active = true')
-      .andWhere('slot.start_time <= :t', { t: orderTimeSql })
-      .andWhere('slot.end_time > :t', { t: orderTimeSql })
-      .getOne();
+      const slot = await this.slotRepo
+        .createQueryBuilder('slot')
+        .where('slot.is_active = true')
+        .andWhere('slot.start_time <= :t', { t: orderTimeSql })
+        .andWhere('slot.end_time > :t', { t: orderTimeSql })
+        .getOne();
 
-    if (!slot) return null;
+      if (!slot) return null;
 
-    // Greedy: maximize cards first, then maximize discount steps from remainder
-    const minOrder = Number(slot.min_order_amount);
-    const numCards = Math.floor(orderAmount / minOrder);
-    if (numCards === 0) return null;
+      const minOrder = Number(slot.min_order_amount);
+      const numCards = Math.floor(orderAmount / minOrder);
+      if (numCards === 0) return null;
 
-    const excess = orderAmount - numCards * minOrder;
-    const excessSteps = Math.floor(excess / Number(slot.excess_threshold));
-    const excessDiscount = excessSteps * Number(slot.discount_per_step);
+      const excess = orderAmount - numCards * minOrder;
+      const excessSteps = Math.floor(excess / Number(slot.excess_threshold));
+      const excessDiscount = excessSteps * Number(slot.discount_per_step);
 
-    const totalCardValue = numCards * Number(slot.card_value);
-    return {
-      slot,
-      numCards,
-      excessDiscount,
-      totalCardValue,
-      totalReward: totalCardValue + excessDiscount,
-    };
+      const totalCardValue = numCards * Number(slot.card_value);
+      return {
+        slot,
+        numCards,
+        excessDiscount,
+        totalCardValue,
+        totalReward: totalCardValue + excessDiscount,
+      };
+    } catch (error) {
+      // log error แล้ว return null เพื่อไม่ให้กระทบ flow การสั่งซื้อ
+      console.error('Error calculating happy hour reward:', error);
+      return null;
+    }
   }
 
   async simulate(dto: SimulateDto) {

--- a/src/happy-hour/happy-hour.service.ts
+++ b/src/happy-hour/happy-hour.service.ts
@@ -6,11 +6,18 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 import { HappyHourConfigEntity } from './happy-hour-config.entity';
 import { HappyHourSlotEntity } from './happy-hour-slot.entity';
 import { CreateSlotDto } from './dto/create-slot.dto';
+import { UpdateSlotDto } from './dto/update-slot.dto';
 import { SimulateDto } from './dto/simulate.dto';
 import { ProductEntity } from 'src/products/products.entity';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const DEFAULT_SLOTS: Omit<
   HappyHourSlotEntity,
@@ -18,6 +25,7 @@ const DEFAULT_SLOTS: Omit<
 >[] = [
   {
     start_time: '22:00',
+    // MySQL TIME ยอมรับ 24:00:00 เป็น special case — ใช้เพื่อครอบคลุม slot จนถึงก่อนเที่ยงคืน
     end_time: '24:00',
     min_order_amount: 9999,
     card_value: 100,
@@ -120,7 +128,7 @@ export class HappyHourService implements OnModuleInit {
 
   async updateSlot(
     id: number,
-    dto: Partial<CreateSlotDto>,
+    dto: UpdateSlotDto,
   ): Promise<HappyHourSlotEntity> {
     const slot = await this.slotRepo.findOneBy({ id });
     if (!slot) {
@@ -150,14 +158,13 @@ export class HappyHourService implements OnModuleInit {
     numCards: number;
     excessDiscount: number;
     totalCardValue: number;
+    totalReward: number;
   } | null> {
     const config = await this.getConfig();
     if (!config.is_enabled) return null;
 
-    const now = new Date(
-      new Date().toLocaleString('en-US', { timeZone: 'Asia/Bangkok' }),
-    );
-    const orderTimeSql = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:00`;
+    const now = dayjs().tz('Asia/Bangkok');
+    const orderTimeSql = now.format('HH:mm:00');
 
     const slot = await this.slotRepo
       .createQueryBuilder('slot')
@@ -177,11 +184,13 @@ export class HappyHourService implements OnModuleInit {
     const excessSteps = Math.floor(excess / Number(slot.excess_threshold));
     const excessDiscount = excessSteps * Number(slot.discount_per_step);
 
+    const totalCardValue = numCards * Number(slot.card_value);
     return {
       slot,
       numCards,
       excessDiscount,
-      totalCardValue: numCards * Number(slot.card_value),
+      totalCardValue,
+      totalReward: totalCardValue + excessDiscount,
     };
   }
 

--- a/src/migrations/1747648800000-CreateHappyHourTables.ts
+++ b/src/migrations/1747648800000-CreateHappyHourTables.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateHappyHourTables1747648800000 implements MigrationInterface {
+  name = 'CreateHappyHourTables1747648800000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE DATABASE IF NOT EXISTS \`e-commerce-database-other\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`,
+    );
+
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS \`e-commerce-database-other\`.\`happy_hour_config\` (
+        \`id\` int NOT NULL,
+        \`is_enabled\` tinyint NOT NULL DEFAULT 0,
+        \`updated_at\` datetime NULL,
+        \`updated_by\` varchar(100) NULL,
+        PRIMARY KEY (\`id\`)
+      ) ENGINE=InnoDB`,
+    );
+
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS \`e-commerce-database-other\`.\`happy_hour_slot\` (
+        \`id\` int NOT NULL AUTO_INCREMENT,
+        \`start_time\` time NOT NULL,
+        \`end_time\` time NOT NULL,
+        \`min_order_amount\` decimal(10,2) NOT NULL,
+        \`card_value\` decimal(10,2) NOT NULL,
+        \`excess_threshold\` decimal(10,2) NOT NULL,
+        \`discount_per_step\` decimal(10,2) NOT NULL,
+        \`is_active\` tinyint NOT NULL DEFAULT 1,
+        \`reward_pro_code\` varchar(20) NULL,
+        \`reward_unit\` varchar(30) NULL,
+        \`reward_amount\` int NOT NULL DEFAULT 1,
+        \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+        PRIMARY KEY (\`id\`)
+      ) ENGINE=InnoDB`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS \`e-commerce-database-other\`.\`happy_hour_slot\``,
+    );
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS \`e-commerce-database-other\`.\`happy_hour_config\``,
+    );
+  }
+}

--- a/src/shopping-order/shopping-order.entity.ts
+++ b/src/shopping-order/shopping-order.entity.ts
@@ -56,4 +56,7 @@ export class ShoppingOrderEntity {
   @ManyToOne(() => ProductEntity, (product) => product.inOrders)
   @JoinColumn({ name: 'pro_code' })
   product: ProductEntity;
+
+  @Column({ type: 'boolean', default: false })
+  is_happy_hour?: boolean;
 }

--- a/src/shopping-order/shopping-order.service.ts
+++ b/src/shopping-order/shopping-order.service.ts
@@ -638,7 +638,7 @@ export class ShoppingOrderService {
                 spo_qty: happyReward.numCards * happyReward.slot.reward_amount,
                 spo_price_unit: 0,
                 spo_total_decimal: 0,
-                is_reward: true,
+                is_happy_hour: true,
               });
               await manager.save(ShoppingOrderEntity, happyRewardItem);
             }


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- ECWC-142

### 📌 ประเภทของ PR
- [x] 🐛 แก้ Bug
- [x] ✨ Feature ใหม่

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร

- `HappyHourConfigEntity` และ `HappyHourSlotEntity` ระบุ `database: 'e-commerce-database-other'` ใน `@Entity()` ซึ่งทำให้ TypeORM ไม่สามารถ resolve connection ได้ถูกต้องในบางสถานการณ์
- DTO validation สำหรับ time field (`HH:mm`) ไม่เข้มงวดพอ — regex เดิม `/^\d{2}:\d{2}$/` ยอมรับ `99:99` ได้
- `updateSlot` endpoint รับ `Partial<CreateSlotDto>` โดยตรง แทนที่จะใช้ DTO ที่ถูกต้อง

### 🛠️ แก้ปัญหานั้นอย่างไร

1. **Fix entity database config** — ลบ `database` option ออกจาก `@Entity()` ใน `HappyHourConfigEntity` และ `HappyHourSlotEntity` เพื่อให้ TypeORM ใช้ default connection แทน (database routing จัดการผ่าน DataSource config แล้ว)

2. **เพิ่ม `UpdateSlotDto`** — สร้าง DTO ใหม่โดย extend `PartialType(CreateSlotDto)` เพื่อให้ทุก field เป็น optional แต่ยังคง validation rules จาก `CreateSlotDto`

3. **เพิ่มความเข้มงวด time validation** — เปลี่ยน regex เป็น `/^([01]\d|2[0-3]):[0-5]\d$/` ครอบคลุมเฉพาะ `00:00–23:59`

4. **ปรับ service** — ใช้ `dayjs` + timezone plugin แทน `new Date().toLocaleString()` สำหรับ Bangkok time, เพิ่ม `totalReward` ใน simulate response

5. **Migration** — เพิ่ม `CreateHappyHourTables` migration สำหรับสร้างตาราง `happy_hour_config` และ `happy_hour_slot` ใน `e-commerce-database-other`

6. **Unit tests** — เพิ่ม test suite สำหรับ `HappyHourController`, `HappyHourService`, และ DTOs

### 🧪 วิธี Test

1. รัน migration: `npm run migration:run`
2. Start server แล้วเรียก `GET /happy-hour/slots` — ต้องได้ default slots กลับมา
3. เรียก `PUT /happy-hour/slots/:id` พร้อม body บางส่วน (เช่น `{ "card_value": 200 }`) — ต้องอัปเดตได้โดยไม่ error
4. เรียก `POST /happy-hour/slots` พร้อม `start_time: "99:99"` — ต้องได้ 400 Bad Request
5. รัน unit tests: `npm run test`

### 🔑 Environment Variables ใหม่
- ไม่มี