### PR TITLE
ECWC-207 / Debug เส้น API Refresh Token เรื่องช้า

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import { UserEntity } from 'src/users/users.entity';
@@ -8,7 +8,6 @@ import { lastValueFrom } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
 import * as AWS from 'aws-sdk';
 import { RefreshTokenEntity } from './refresh-token.entity';
-import * as dayjs from 'dayjs';
 import * as bcrypt from 'bcrypt';
 import { SALT_ROUNDS } from '../constants/app.constants'; 
 import { EmployeesService } from 'src/employees/employees.service';
@@ -20,6 +19,7 @@ export interface SigninResponse {
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
   private s3: AWS.S3;
   constructor(
     private readonly userService: UsersService,
@@ -413,7 +413,7 @@ export class AuthService {
         where: { refresh_token: refresh_token },
       });
       if (!existingToken) {
-        console.log('No existing token found');
+        this.logger.warn('No existing token found');
         throw new UnauthorizedException('Invalid refresh token');
       }
 
@@ -424,14 +424,32 @@ export class AuthService {
         },
       );
 
-      await this.refreshTokenRepo.delete({ refresh_token: refresh_token });
-
-      const user = await this.userRepo.findOne({
-        where: { mem_code: payload.mem_code },
-      });
+      const [user] = await Promise.all([
+        this.userRepo.findOne({
+          where: { mem_code: payload.mem_code },
+          select: {
+            mem_username: true,
+            mem_nameSite: true,
+            mem_code: true,
+            mem_price: true,
+            mem_address: true,
+            mem_village: true,
+            mem_alley: true,
+            mem_tumbon: true,
+            mem_amphur: true,
+            mem_province: true,
+            mem_post: true,
+            mem_phone: true,
+            mem_route: true,
+            permision_admin: true,
+            role: true,
+          },
+        }),
+        this.refreshTokenRepo.delete({ refresh_token: refresh_token }),
+      ]);
 
       if (user) {
-        const payload = {
+        const tokenPayload = {
           username: user.mem_username,
           name: user.mem_nameSite ?? '',
           mem_code: user.mem_code ?? '',
@@ -454,27 +472,27 @@ export class AuthService {
           name: user.mem_nameSite ?? '',
           mem_code: user.mem_code ?? '',
         };
-        const access_token = await this.jwtService.signAsync(payload, {
-          expiresIn: '15m',
-        });
+
         const refreshTokenExpiresIn = source === 'mobile_app' ? '7d' : '18h';
-        const refresh_token = await this.jwtService.signAsync(payload_reflesh, {
-          secret: process.env.ACCESS_TOKEN_SECRET,
-          expiresIn: refreshTokenExpiresIn,
-        });
+        const [access_token, new_refresh_token] = await Promise.all([
+          this.jwtService.signAsync(tokenPayload, { expiresIn: '15m' }),
+          this.jwtService.signAsync(payload_reflesh, {
+            secret: process.env.ACCESS_TOKEN_SECRET,
+            expiresIn: refreshTokenExpiresIn,
+          }),
+        ]);
 
         await this.refreshTokenRepo.save({
           mem_code: user.mem_code,
-          refresh_token: refresh_token,
+          refresh_token: new_refresh_token,
         });
-        return { token: access_token, refresh_token: refresh_token };
+        return { token: access_token, refresh_token: new_refresh_token };
       } else {
         throw new UnauthorizedException('Invalid refresh token');
       }
-    } catch (error) {
-      console.log(error);
+    } catch (error: unknown) {
+      this.logger.error('refreshToken failed', error);
       throw new Error('Refresh token expired');
-      // throw new UnauthorizedException('Invalid refresh token');
     }
   }
 

--- a/src/auth/refresh-token.entity.ts
+++ b/src/auth/refresh-token.entity.ts
@@ -1,10 +1,11 @@
-import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, Index } from 'typeorm';
 
 @Entity({ name: 'reflesh-token' })
 export class RefreshTokenEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Index()
   @Column({ type: 'varchar', length: 512 })
   refresh_token: string;
 


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- https://nitipongjin-13063.atlassian.net/browse/ECWC-207

### 📌 ประเภทของ PR
- [ ] ✨ Feature ใหม่
- [x] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
เส้น `POST /ecom/refresh_token` ทำงานช้าเนื่องจาก:
1. ไม่มี index บน `refresh_token` column ทำให้ทุก request ต้อง full table scan บน `reflesh-token` table
2. DB queries และ JWT signing ที่ไม่ขึ้นต่อกันถูก execute แบบ sequential
3. `userRepo.findOne` ดึง user ทั้ง 53 columns ทั้งที่ใช้แค่ 14 fields

### 🛠️ แก้ปัญหานั้นอย่างไร
- **`refresh-token.entity.ts`** — เพิ่ม `@Index()` บน `refresh_token` column
- **`auth.service.ts`** — parallelize ด้วย `Promise.all`:
  - `userRepo.findOne` + `refreshTokenRepo.delete` ทำพร้อมกัน
  - `jwtService.signAsync` x2 ทำพร้อมกัน
- **`auth.service.ts`** — เพิ่ม `select` เฉพาะ 14 fields ที่ใช้จริงใน `userRepo.findOne`
- แทน `console.log` ด้วย NestJS Logger ตาม R-001

> ⚠️ ต้องสร้าง migration เพิ่ม index บน DB:
> ```sql
> CREATE INDEX `IDX_reflesh_token_refresh_token` ON `reflesh-token` (`refresh_token`(255))
> ```

### 🧪 วิธี Test
1. Login เพื่อรับ refresh token
2. รอให้ access token ใกล้หมดอายุ (หรือแก้ exp ชั่วคราว) แล้ว call `POST /ecom/refresh_token`
3. ตรวจสอบว่าได้ `token` และ `refresh_token` ใหม่กลับมาถูกต้อง
4. ตรวจ response time เปรียบเทียบก่อน/หลัง

### 🔑 Environment Variables ใหม่
- ไม่มี