### PR TITLE
fix(ci): point Claude workflows at CLAUDE_CODE_OAUTH_TOKEN secret

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Always respond in Thai language (ภาษาไทย). ตอบเป็นภาษาไทยเสมอ
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,7 +23,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             You are a senior staff engineer performing a thorough code review.
             Always respond in Thai language (ภาษาไทย).

--- a/.github/workflows/learn-from-reviews.yml
+++ b/.github/workflows/learn-from-reviews.yml
@@ -50,7 +50,7 @@ jobs:
         if: steps.fetch.outputs.feedback_count != '0'
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: >-
             Run the project skill at .claude/skills/learn-from-reviews/SKILL.md
             using the feedback in /tmp/lfr.json. You are running in CI


### PR DESCRIPTION
## Problem
Three Claude workflows referenced `secrets.ANTHROPIC_API_KEY`, which was never created as a usable secret in this repo. The action received an empty/invalid key and failed with **"Invalid API key"**:

- **learn-from-reviews** — the `distill` step failed on every run, so the review-feedback loop never produced its draft proposal PR.
- **claude-review** — failed on every PR.
- **claude-code-review** — failed silently (`continue-on-error: true`), so the AI review never actually ran.

Meanwhile `claude.yml` already used `claude_code_oauth_token` / `CLAUDE_CODE_OAUTH_TOKEN` correctly — these three were just inconsistent.

## Fix
Point all three workflows at `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` — the OAuth-token input documented for Claude Max/Pro subscriptions (`claude setup-token`), matching `claude.yml`.

`CLAUDE_CODE_OAUTH_TOKEN` has been refreshed at **org level** (visible to all repos) with a current `sk-ant-oat` token; the stale repo-level copy was removed so it no longer overrides org.

## Note on this PR's own checks
claude-code-action enforces that the workflow file must be **identical to the version on the default branch**. Because this PR *changes* those workflow files, the review workflows running on this PR will fail that validation:
> "Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch."

This is **expected** — the action's own error message says to ignore it for first-time workflow changes. The fix only takes effect once merged into `develop`; the next `learn-from-reviews` / review run on `develop` will be the first real test of the token.

## Files changed
- `.github/workflows/learn-from-reviews.yml`
- `.github/workflows/claude-review.yml`
- `.github/workflows/claude-code-review.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)