### PR TITLE
chore(claude): enable org vtsls LSP via wangpharma marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,12 @@
 {
+  "extraKnownMarketplaces": {
+    "wangpharma": {
+      "source": { "source": "github", "repo": "wangpharma-org/claude-plugins" }
+    }
+  },
+  "enabledPlugins": {
+    "vtsls-lsp@wangpharma": true
+  },
   "hooks": {
     "Stop": [
       {


### PR DESCRIPTION
Wires Backend-Ecommerce to the org marketplace **`wangpharma-org/claude-plugins`** so the team gets vtsls TypeScript code intelligence (go-to-definition, find references, hover, diagnostics) in Claude Code.

## What
`.claude/settings.json` gains:
- `extraKnownMarketplaces.wangpharma` → GitHub source `wangpharma-org/claude-plugins`
- `enabledPlugins["vtsls-lsp@wangpharma"] = true`

## Per-dev prerequisite
The plugin only configures *how* to connect — it does **not** ship the binary. Each dev installs it once:
```bash
npm i -g @vtsls/language-server
```
After pulling, open `/hooks` once (or restart Claude Code) so the settings watcher picks it up. If `Executable not found in $PATH`, launch Claude Code from a terminal or symlink `vtsls`.

## Stacked on #172
Base is `chore/claude-stop-hook` so this diff shows **only** the LSP change. GitHub will retarget the base to `develop` automatically once #172 merges.

Refs NNRB-1167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)