### PR TITLE
🧠 learn-from-reviews: proposed knowledge updates

### DIFF
--- a/.ai/conventions.md
+++ b/.ai/conventions.md
@@ -15,3 +15,20 @@ if (!Number.isInteger(page) || page < 1) throw new BadRequestException('current_
 ```
 **Source:** PR#148 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/148
 **Added:** 2026-05-19  **Confidence:** medium (single occurrence)
+
+### C-002  Use a Guard or Decorator for role/permission checks; do not inline `if (role !== Admin)` inside controller action methods
+**Why:** PR#154 — a permission check was written inline inside a Happy Hour controller action. Inline checks scatter authorization logic across handlers and are easy to omit on new endpoints; Guards/Decorators centralise the policy and are composable.
+**Example:**
+```ts
+// ✗ inline in action
+if (req.user.role !== UserRole.Admin && !req.user.permission)
+  throw new ForbiddenException();
+
+// ✓ declare at the endpoint (or controller class)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.Admin)
+@Post('admin-action')
+adminAction() { ... }
+```
+**Source:** PR#154 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/154
+**Added:** 2026-06-01  **Confidence:** medium (single occurrence)

--- a/.ai/gotchas.md
+++ b/.ai/gotchas.md
@@ -10,3 +10,26 @@ Format per entry: `### G-NNN <statement>` then **Why:** / **Example:** / **Sourc
 **Why:** PR#143 P2 — getHotdealFromproCode (src/hotdeal/hotdeal.service.ts:660-667) converts the freebie's pro2_amount/pro2_unit using the MAIN product's unit ratio. If product2 (the freebie) uses different units, the freebie data returned by the API is wrong. Either don't convert here, or use product2's own unit ratio.
 **Source:** PR#143 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/143
 **Added:** 2026-05-19
+
+### G-002  Querying the DB once per entity inside a loop produces O(N) round-trips
+**Why:** PR#139 — `getAllHotdealsWithProductNames()`, `getHotdealByProCode()`, and `getHotdealInfo()` each called `transformProductWithUnits()` inside a `Promise.all(map(...))`, making two DB hits per hotdeal. 50 hotdeals = 100+ queries per request. The same PR already demonstrated the correct pattern in `getRewardsByTier`: batch-fetch with TypeORM's `In([...ids])` once, then group into a `Map` before iterating.
+**Example:**
+```ts
+// ✗ N+1 — two queries per hotdeal
+const items = await Promise.all(
+  hotdeals.map(async (hd) => {
+    const u1 = await this.productService.transformProductWithUnits(hd.product);
+    const u2 = await this.productService.transformProductWithUnits(hd.product2);
+    return { ...hd, u1, u2 };
+  }),
+);
+
+// ✓ batch once, look up in Map
+const proCodes = hotdeals.flatMap((hd) => [hd.pro_code1, hd.pro_code2]);
+const units = await this.productUnitRepo.find({ where: { pro_code: In(proCodes) } });
+const unitMap = new Map(units.map((u) => [u.pro_code, u]));
+const items = hotdeals.map((hd) => ({ ...hd, u1: unitMap.get(hd.pro_code1), u2: unitMap.get(hd.pro_code2) }));
+```
+**Location:** src/hotdeal/hotdeal.service.ts (getAllHotdealsWithProductNames, getHotdealByProCode, getHotdealInfo)
+**Source:** PR#139 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/139
+**Added:** 2026-06-01  **Confidence:** high

--- a/.ai/ledger.json
+++ b/.ai/ledger.json
@@ -1,6 +1,6 @@
 {
   "repo": "wangpharma-org/Backend-Ecommerce",
-  "last_run": "2026-05-19",
+  "last_run": "2026-06-01",
   "approvers": [
     "62theories"
   ],
@@ -12,17 +12,20 @@
       "status": "proposed",
       "source_prs": [
         121,
-        137
+        137,
+        157
       ],
       "reviewers": [
-        "MossOcelot"
+        "MossOcelot",
+        "62theories"
       ],
       "confidence": "high",
       "first_seen": "2026-05-19",
-      "last_seen": "2026-05-19",
+      "last_seen": "2026-06-01",
       "approved_by": null,
       "approved_at": null,
-      "promoted_from": "preference"
+      "promoted_from": "preference",
+      "note": "PR#157: CODEOWNER @62theories confirmed via CHANGES_REQUESTED: 'แก้จาก console.log เป็น lib ที่ไม่ block IO'"
     },
     {
       "id": "D-001",
@@ -89,6 +92,115 @@
       "confidence": "low",
       "first_seen": "2026-05-19",
       "last_seen": "2026-05-19",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "C-002",
+      "kind": "convention",
+      "file": ".ai/conventions.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        154
+      ],
+      "reviewers": [
+        "MossOcelot"
+      ],
+      "confidence": "medium",
+      "first_seen": "2026-06-01",
+      "last_seen": "2026-06-01",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "G-002",
+      "kind": "gotcha",
+      "file": ".ai/gotchas.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        139
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "high",
+      "first_seen": "2026-06-01",
+      "last_seen": "2026-06-01",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "Q-002",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "ai-review",
+      "source_prs": [
+        156
+      ],
+      "reviewers": [
+        "claude[bot]"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-06-01",
+      "last_seen": "2026-06-01",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "Q-003",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "ai-review",
+      "source_prs": [
+        156
+      ],
+      "reviewers": [
+        "claude[bot]"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-06-01",
+      "last_seen": "2026-06-01",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "Q-004",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "ai-review",
+      "source_prs": [
+        156,
+        139
+      ],
+      "reviewers": [
+        "claude[bot]"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-06-01",
+      "last_seen": "2026-06-01",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "Q-005",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "human",
+      "source_prs": [
+        139
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-06-01",
+      "last_seen": "2026-06-01",
       "approved_by": null,
       "approved_at": null
     }

--- a/.ai/quarantine.md
+++ b/.ai/quarantine.md
@@ -11,3 +11,56 @@ Format per entry: `### Q-NNN <statement>` then **Why:** / **Example:** / **Sourc
 **Promote to convention when:** seen again in ≥1 more PR by another reviewer.
 **Source:** PR#123 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/123
 **Added:** 2026-05-19  **Status:** quarantined (not team-agreed)
+
+### Q-002  TypeORM `softDelete()` does not cascade through relations
+**Why:** PR#156 — when the cron job called `promotionRepo.softDelete({ promo_id })`, the child `PromotionTierEntity` rows kept `deleted_at = null`, becoming orphaned active records. TypeORM `onDelete: 'CASCADE'` only fires for hard deletes at the SQL level; soft-deleted parents must explicitly soft-delete their children.
+**Example:**
+```ts
+// ✗ only parent gets deleted_at set
+await this.promotionRepo.softDelete({ promo_id: p.promo_id });
+
+// ✓ cascade manually
+await this.promotionTierRepo.softDelete({ promotion: { promo_id: p.promo_id } });
+await this.promotionRepo.softDelete({ promo_id: p.promo_id });
+```
+**Promote to gotcha when:** a human reviewer confirms this TypeORM behaviour in a PR.
+**Source:** PR#156 claude[bot] — github.com/wangpharma-org/Backend-Ecommerce/pull/156
+**Added:** 2026-06-01  **Status:** quarantined (ai-review only, no human corroboration yet)  **Origin:** ai-review
+
+### Q-003  Multi-entity write sequences must be wrapped in `dataSource.transaction()`
+**Why:** PR#156 — `duplicatePromotion()` saved Promotion → Tiers → Conditions → Rewards without a transaction. A failure mid-way left a partial promotion in the DB with missing tiers, requiring manual cleanup.
+**Example:**
+```ts
+return this.dataSource.transaction(async (manager) => {
+  const saved = await manager.save(manager.create(PromotionEntity, { ... }));
+  await Promise.all(tiers.map((t) => manager.save(manager.create(PromotionTierEntity, { ...t, promotion: saved }))));
+});
+```
+**Promote to convention when:** a human reviewer flags a missing transaction on a multi-entity write.
+**Source:** PR#156 claude[bot] — github.com/wangpharma-org/Backend-Ecommerce/pull/156
+**Added:** 2026-06-01  **Status:** quarantined (ai-review only)  **Origin:** ai-review
+
+### Q-004  `catch {}` or `catch(e) { throw new Error('...') }` silently discards the original stack trace
+**Why:** PR#156, PR#139 — bare catch blocks throw a new generic error without logging the original, making production debugging very difficult. Use `this.logger.error(message, err)` before rethrowing as an HTTP exception.
+**Example:**
+```ts
+// ✗ destroys stack trace
+} catch {
+  throw new Error('Failed to get promotions');
+}
+
+// ✓ preserve context
+} catch (err) {
+  this.logger.error('Failed to get promotions', err);
+  throw new InternalServerErrorException('Failed to get promotions');
+}
+```
+**Promote to convention when:** a human reviewer flags bare catch blocks.
+**Source:** PR#156 claude[bot]; PR#139 claude[bot] — github.com/wangpharma-org/Backend-Ecommerce/pull/156 , /pull/139
+**Added:** 2026-06-01  **Status:** quarantined (ai-review only, 2 PRs)  **Origin:** ai-review
+
+### Q-005  Shared utility functions should live in one service and be exported, not duplicated across services
+**Why:** PR#139 — `convertEnumToUnitName` and `getRatioFromUnits` were duplicated across 4 services (products, promotion, shopping-cart, shopping-order). Each copy drifted independently, causing different fallback behaviours (one returned `''`, others returned `String(unitEnum)`).
+**Promote to convention when:** seen in ≥1 more PR by another reviewer.
+**Source:** PR#139 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/139
+**Added:** 2026-06-01  **Status:** quarantined (single reviewer)  **Origin:** human

--- a/.ai/rules.md
+++ b/.ai/rules.md
@@ -16,5 +16,5 @@ console.log(result)
 private readonly logger = new Logger(ProductsService.name)
 this.logger.error('failed to fetch products', err)
 ```
-**Source:** PR#121 @MossOcelot, PR#137 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/121 , /pull/137
-**Added:** 2026-05-19  **Enforce:** lint (ESLint `no-console: error`)
+**Source:** PR#121 @MossOcelot, PR#137 @MossOcelot, PR#157 @62theories — github.com/wangpharma-org/Backend-Ecommerce/pull/121 , /pull/137 , /pull/157
+**Added:** 2026-05-19  **Last seen:** 2026-06-01  **Enforce:** lint (ESLint `no-console: error`)


### PR DESCRIPTION
## What is this PR?

This PR was **auto-distilled** from merged-PR review feedback by the `learn-from-reviews` scheduled bot (run: 2026-06-01). It is **propose-only** — no item takes effect until @62theories explicitly approves it.

All items have `status: "proposed"` (or `"quarantined"` for preferences/ai-review items) and `approved_by: null`. On merge, a human should flip approved items to `status: "agreed"` and set `approved_by` + `approved_at`.

---

## PRs scanned

26 merged PRs between `2026-05-19` and `2026-06-01`.

---

## Items proposed

| ID | Kind | Statement | Source | Origin | Confidence |
|----|------|-----------|--------|--------|------------|
| C-002 | convention | Use Guards/Decorators for role checks in controllers | PR#154 @MossOcelot | human | medium |
| G-002 | gotcha | Avoid N+1 DB queries in loops — batch with `In([...ids])` | PR#139 @Sasit-Nine | human | high |
| Q-002 | quarantine | TypeORM `softDelete()` does not cascade through relations | PR#156 claude[bot] | ai-review | low |
| Q-003 | quarantine | Multi-entity writes need `dataSource.transaction()` | PR#156 claude[bot] | ai-review | low |
| Q-004 | quarantine | Bare `catch{}` silently discards original stack trace | PR#156, PR#139 claude[bot] | ai-review | low |
| Q-005 | quarantine | Centralise shared utility helpers in one service | PR#139 @Sasit-Nine | human | low |

**Ledger update only (no new knowledge file entry):**
- **R-001** — added PR#157 @62theories (CODEOWNER) to `source_prs`. He left a CHANGES_REQUESTED specifically about `console.log` usage, which is direct CODEOWNER enforcement of this rule.

---

## Classification rationale

**C-002 (convention):** @MossOcelot left an inline comment on PR#154 saying "ย้ายไปเช็คเป็น Decorator/guard ถ้าจะมีการเช็คแบบนี้อีก" — move permission checks to a Guard/Decorator if this pattern recurs. Single occurrence; confidence medium. Not elevated to rule since no hard failure mode.

**G-002 (gotcha, high confidence):** @Sasit-Nine's CHANGES_REQUESTED review on PR#139 flagged N+1 queries in 3 separate methods (`getAllHotdealsWithProductNames`, `getHotdealByProCode`, `getHotdealInfo`) and pointed to `getRewardsByTier` as the existing correct pattern (batch with `In()` + Map). Three occurrences in one review, clear pattern, reviewer cited counter-example — high confidence.

**Q-002 / Q-003 / Q-004 (quarantined):** All from `claude[bot]` reviews on PR#156. AI-origin only — capped at quarantine per SKILL.md provenance rules. Promote when a human reviewer corroborates.

**Q-005 (quarantined):** Single human reviewer (@Sasit-Nine, PR#139) observed utility function duplication across 4 services. Single occurrence — classify as preference/quarantine per SKILL.md conservative rule.

**Discarded items (not recorded):**
- Specific one-off bugs (wrong `console` import from `node:inspector`, duplicate `.leftJoinAndSelect`, debug error messages with trailing numbers)
- Unit-conversion inconsistency tied entirely to the specific PR#139 refactor
- `isNaN(Number(pro_unit1))` guard — too context-specific

---

## How to review

1. Read each item in `.ai/conventions.md`, `.ai/gotchas.md`, `.ai/quarantine.md`.
2. For each item you agree with, note `approved_by: "62theories"` and `approved_at` in `.ai/ledger.json` — your approval IS the team agreement.
3. Delete or adjust any item that is wrong, too specific, or not worth keeping.
4. Merge when satisfied. You do not need a second reviewer (you are the sole CODEOWNER for `.ai/`).

> ⚠️ **The bot never approves its own output and will never merge this PR.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01H53zsDEsKnKMzkRCoFzgZ1)_