### PR TITLE
fix(ECWC-296): fix company day date range query

### DIFF
--- a/src/migrations/1780084387026-prod.ts
+++ b/src/migrations/1780084387026-prod.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Prod1780084387026 implements MigrationInterface {
+    name = 'Prod1780084387026'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`happy_hour_slot_min_products\` (\`id\` int NOT NULL AUTO_INCREMENT, \`pro_code\` varchar(20) NOT NULL, \`pro_name\` varchar(255) NULL, \`slot_id\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot_reward\` ADD \`amount\` int NOT NULL DEFAULT '1'`);
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot\` ADD \`reward_type\` enum ('card', 'bill_discount') NOT NULL DEFAULT 'card'`);
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot\` ADD \`reward_value\` decimal(10,2) NOT NULL DEFAULT '0.00'`);
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot\` ADD \`min_order_scope\` enum ('all', 'specific', 'vendor') NOT NULL DEFAULT 'all'`);
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot\` ADD \`min_order_vendor_code\` varchar(50) NULL`);
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot_min_products\` ADD CONSTRAINT \`FK_02d5f72ee52ce2c2c9aadb7626d\` FOREIGN KEY (\`slot_id\`) REFERENCES \`happy_hour_slot\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot_min_products\` DROP FOREIGN KEY \`FK_02d5f72ee52ce2c2c9aadb7626d\``);
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot\` DROP COLUMN \`min_order_vendor_code\``);
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot\` DROP COLUMN \`min_order_scope\``);
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot\` DROP COLUMN \`reward_value\``);
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot\` DROP COLUMN \`reward_type\``);
+        await queryRunner.query(`ALTER TABLE \`happy_hour_slot_reward\` DROP COLUMN \`amount\``);
+        await queryRunner.query(`DROP TABLE \`happy_hour_slot_min_products\``);
+    }
+
+}

--- a/src/promotion/promotion.service.ts
+++ b/src/promotion/promotion.service.ts
@@ -418,17 +418,15 @@ export class PromotionService {
     mem_route?: string,
   ): Promise<GetAllTiersResult> {
     try {
-      const Today = new Date();
-      const startOfDay = new Date(Today.setHours(0, 0, 0, 0));
-      const endOfDay = new Date(Today.setHours(23, 59, 59, 999));
+      const { startOfDay, endOfDay } = getTodayRange();
       const isL16 = await this.isL16Member(mem_code, mem_route);
 
       const poster = await this.promotionTierRepo.find({
         where: {
           promotion: {
             status: true,
-            start_date: LessThanOrEqual(startOfDay),
-            end_date: MoreThanOrEqual(endOfDay),
+            start_date: LessThanOrEqual(endOfDay),
+            end_date: MoreThanOrEqual(startOfDay),
           },
         },
         relations: {
@@ -1174,9 +1172,7 @@ export class PromotionService {
     mem_code: string,
   ): Promise<TierConditionWithTransformedTier[]> {
     try {
-      const Today = new Date();
-      const startOfDay = new Date(Today.setHours(0, 0, 0, 0));
-      const endOfDay = new Date(Today.setHours(23, 59, 59, 999));
+      const { startOfDay, endOfDay } = getTodayRange();
       const tierCondition = await this.promotionConditionRepo
         .createQueryBuilder('condition')
         .leftJoinAndSelect('condition.product', 'product')
@@ -1316,16 +1312,14 @@ export class PromotionService {
 
   async getTierAllProduct() {
     try {
-      const Today = new Date();
-      const startOfDay = new Date(Today.setHours(0, 0, 0, 0));
-      const endOfDay = new Date(Today.setHours(23, 59, 59, 999));
+      const { startOfDay, endOfDay } = getTodayRange();
       return await this.promotionTierRepo.find({
         where: {
           all_products: true,
           promotion: {
             status: true,
-            start_date: LessThanOrEqual(startOfDay),
-            end_date: MoreThanOrEqual(endOfDay),
+            start_date: LessThanOrEqual(endOfDay),
+            end_date: MoreThanOrEqual(startOfDay),
           },
         },
         relations: {

--- a/src/promotion/promotion.service.ts
+++ b/src/promotion/promotion.service.ts
@@ -21,6 +21,7 @@ import { PromotionTierEntity } from './promotion-tier.entity';
 import { PromotionConditionEntity } from './promotion-condition.entity';
 import { PromotionRewardEntity } from './promotion-reward.entity';
 import * as AWS from 'aws-sdk';
+import { getTodayRange } from 'src/utils/date.util';
 import { Cron } from '@nestjs/schedule';
 import { ShoppingCartEntity } from 'src/shopping-cart/shopping-cart.entity';
 import { CodePromotionEntity } from './code-promotion.entity';
@@ -454,7 +455,7 @@ export class PromotionService {
       });
 
       if (!poster.length) {
-        this.logger.log("No active promotions found");
+        this.logger.log('No active promotions found');
         return { poster: [], reward: [] };
       }
 
@@ -462,7 +463,7 @@ export class PromotionService {
         .map((p) => p.tier_id)
         .filter((id): id is number => id !== undefined && id !== null);
       if (!tierIds.length) {
-        this.logger.log("No tier IDs found for active promotions");
+        this.logger.log('No tier IDs found for active promotions');
         return { poster, reward: [] };
       }
 
@@ -541,22 +542,20 @@ export class PromotionService {
 
       return { poster, reward: limitedReward };
     } catch (error) {
-      this.logger.error("Error in getAllTiers:", error);
+      this.logger.error('Error in getAllTiers:', error);
       throw new Error(`Failed to get tiers: ${error}`);
     }
   }
 
   async getAllTiersProduct(): Promise<string[]> {
     try {
-      const Today = new Date();
-      const startOfDay = new Date(Today.setHours(0, 0, 0, 0));
-      const endOfDay = new Date(Today.setHours(23, 59, 59, 999));
+      const { startOfDay, endOfDay } = getTodayRange();
       const tiers = await this.promotionTierRepo.find({
         where: {
           promotion: {
             status: true,
-            start_date: LessThanOrEqual(startOfDay),
-            end_date: MoreThanOrEqual(endOfDay),
+            start_date: LessThanOrEqual(endOfDay),
+            end_date: MoreThanOrEqual(startOfDay),
           },
         },
         relations: {
@@ -708,7 +707,6 @@ export class PromotionService {
     file: Express.Multer.File;
     is_unit_based?: boolean;
   }) {
-    
     try {
       const promotion = await this.promotionRepo.findOne({
         where: { promo_id: data.promo_id },
@@ -1050,7 +1048,7 @@ export class PromotionService {
     promotions: PromotionEntityWithTransformedData[];
   }> {
     try {
-      this.logger.log("Fetching active promotions with all relations");
+      this.logger.log('Fetching active promotions with all relations');
 
       // ดึงข้อมูลพร้อม relations ทั้งหมดในครั้งเดียว
       const promotions = await this.promotionRepo.find({
@@ -1125,11 +1123,11 @@ export class PromotionService {
               ...reward,
               giftProduct: this.transformProductData(reward.giftProduct),
             })) as PromotionRewardWithTransformedProduct[] | undefined,
-          })) as PromotionTierWithTransformedData[] | undefined,
-        })) as PromotionEntityWithTransformedData[],
+          })),
+        })),
       };
     } catch (error) {
-      this.logger.error("Error fetching promotions:", error);
+      this.logger.error('Error fetching promotions:', error);
       throw new Error('Failed to get active promotions');
     }
   }
@@ -1289,7 +1287,7 @@ export class PromotionService {
             units: condition.product
               ? unitsMap[condition.product.pro_code]
               : [],
-          })) as PromotionConditionWithTransformedProduct[] | undefined,
+          })),
           rewards: tc.tier.rewards?.map((reward) => {
             const rewardUnits = reward.giftProduct
               ? unitsMap[reward.giftProduct.pro_code] || []
@@ -1311,7 +1309,7 @@ export class PromotionService {
         },
       })) as TierConditionWithTransformedTier[];
     } catch (error) {
-      this.logger.error("Error in getTierWithProCode:", error);
+      this.logger.error('Error in getTierWithProCode:', error);
       throw new Error('Failed to get tier with product code');
     }
   }
@@ -1490,7 +1488,7 @@ export class PromotionService {
         url: imgData.Location,
       };
     } catch (error) {
-      this.logger.error("Error updating tier poster:", error);
+      this.logger.error('Error updating tier poster:', error);
       throw new Error(`Failed to update tier poster`);
     }
   }
@@ -1520,7 +1518,7 @@ export class PromotionService {
         (t) => t.tier_id === tier_id,
       )?.min_amount;
 
-      this.logger.debug("editReward data:", data);
+      this.logger.debug('editReward data:', data);
 
       this.logger.debug(
         `Min amount for promotion ${promotion_id} and tier ${tier_id}: ${minAmount}`,

--- a/src/utils/date.util.ts
+++ b/src/utils/date.util.ts
@@ -1,0 +1,15 @@
+import * as dayjs from 'dayjs';
+import * as utc from 'dayjs/plugin/utc';
+import * as timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const TZ = 'Asia/Bangkok';
+
+export function getTodayRange(): { startOfDay: Date; endOfDay: Date } {
+  return {
+    startOfDay: dayjs().tz(TZ).startOf('day').toDate(),
+    endOfDay: dayjs().tz(TZ).endOf('day').toDate(),
+  };
+}


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- [ECWC-296 — recheck company day bug](https://nitipongjin-13063.atlassian.net/jira/software/projects/ECWC/boards/500?selectedIssue=ECWC-296)

### 📌 ประเภทของ PR
- [x] 🐛 แก้ Bug

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
Bug: ตั้ง company day วันที่ 1-1 ไม่ได้ ต้องตั้ง 1-2 เพื่อให้มีโปรในวันที่ 1

สาเหตุ: query ใน `getAllTiersProduct()` เช็ค `end_date >= endOfDay (23:59:59.999)` แต่ถ้า `end_date` ที่เก็บใน DB เป็น `00:00:00` ของวันนั้น จะไม่ผ่านเงื่อนไข ทำให้ promotion หายไปทั้งวัน

### 🛠️ แก้ปัญหานั้นอย่างไร
1. **แก้ query logic** ใน `getAllTiersProduct()`:
   - เดิม: `start_date <= startOfDay` AND `end_date >= endOfDay`
   - ใหม่: `start_date <= endOfDay` AND `end_date >= startOfDay`
   
   ทำให้จับ promotion ที่ active อยู่ในวันนี้ได้ครบ ไม่ว่า end_date จะเก็บเป็นเวลาไหนของวัน

2. **สร้าง `src/utils/date.util.ts`** — utility `getTodayRange()` ที่ใช้ dayjs + timezone `Asia/Bangkok` แทน native `Date.setHours()` ที่ mutate object ต้นทาง

### 🧪 วิธี Test
1. สร้าง promotion ที่มี `start_date = วันนี้ 00:00` และ `end_date = วันนี้ 00:00`
2. เรียก API ที่ใช้ `getAllTiersProduct()` — ควรเห็น promotion นั้นใน response
3. ตรวจสอบว่า promotion ที่เริ่มกลางวัน (เช่น 08:00) หรือจบกลางวัน (เช่น 18:00) ยังถูก return

### 🔑 Environment Variables ใหม่
- ไม่มี