### PR TITLE
[WGDD-208] เพิ่ม pro_drugregister ใน product-detail API

### DIFF
--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -890,6 +890,7 @@ export class ProductsService {
           'product.pro_lowest_stock',
           'product.order_quantity',
           'product.sale_amount_day',
+          'product.pro_drugregister',
           'pharma.pro_code',
           'pharma.pp_properties',
           'pharma.pp_properties',


### PR DESCRIPTION
## WGDD-208 — เพิ่มเลขทะเบียนยาใน product-detail API

Subtask ของ WGDD-180 — https://nitipongjin-13063.atlassian.net/browse/WGDD-208

### สิ่งที่ทำ
เพิ่ม `product.pro_drugregister` เข้า `.select([...])` ของ method `getProductDetail` ใน `src/products/products.service.ts`

เดิม query ใช้ explicit select และไม่มี field นี้ ทำให้ไม่ถูกส่งออกใน API `/api/ecom/product-detail` (field มีอยู่ใน entity/DB แล้ว ไม่ต้องทำ migration)

### Test
- [x] field ออกมากับ response product-detail
- คู่กับ frontend PR (Ecommerce-Frontend feature/WGDD-208)

🤖 Generated with [Claude Code](https://claude.com/claude-code)