### PR TITLE
🧠 learn-from-reviews: proposed knowledge updates

### DIFF
--- a/.ai/gotchas.md
+++ b/.ai/gotchas.md
@@ -10,3 +10,18 @@ Format per entry: `### G-NNN <statement>` then **Why:** / **Example:** / **Sourc
 **Why:** PR#143 P2 — getHotdealFromproCode (src/hotdeal/hotdeal.service.ts:660-667) converts the freebie's pro2_amount/pro2_unit using the MAIN product's unit ratio. If product2 (the freebie) uses different units, the freebie data returned by the API is wrong. Either don't convert here, or use product2's own unit ratio.
 **Source:** PR#143 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/143
 **Added:** 2026-05-19
+
+### G-002  Fixing an N+1 query in one method does not fix sibling methods that load the same relationship
+**Why:** PR#176 (Sasit-Nine, Medium): `enrichSlotWithProducts()` had its N+1 fixed with a batch IN query, but `simulate()` in the same service still used the per-item `findOne()` loop. The PR claimed N+1 was resolved but the fix was incomplete — only the most visible code path was updated.
+**Example:**
+```ts
+// ✗ simulate() still N+1 even after enrichSlotWithProducts() was fixed
+const products = await Promise.all(
+  rewards.map(r => this.productRepo.findOne({ where: { pro_code: r.pro_code } }))
+)
+// ✓ extract a shared batch helper and apply it everywhere
+const products = await this.batchFetchProductsByCodes(rewards.map(r => r.pro_code))
+```
+**Location:** src/happy-hour/happy-hour.service.ts — simulate() vs enrichSlotWithProducts()
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-06-08

--- a/.ai/ledger.json
+++ b/.ai/ledger.json
@@ -1,6 +1,6 @@
 {
   "repo": "wangpharma-org/Backend-Ecommerce",
-  "last_run": "2026-05-19",
+  "last_run": "2026-06-08",
   "approvers": [
     "62theories"
   ],
@@ -10,25 +10,82 @@
       "kind": "rule",
       "file": ".ai/rules.md",
       "status": "proposed",
+      "origin": "human",
       "source_prs": [
         121,
-        137
+        137,
+        178
       ],
       "reviewers": [
-        "MossOcelot"
+        "MossOcelot",
+        "Sasit-Nine"
       ],
       "confidence": "high",
       "first_seen": "2026-05-19",
-      "last_seen": "2026-05-19",
+      "last_seen": "2026-06-08",
       "approved_by": null,
       "approved_at": null,
       "promoted_from": "preference"
+    },
+    {
+      "id": "R-002",
+      "kind": "rule",
+      "file": ".ai/rules.md",
+      "status": "proposed",
+      "origin": "internal",
+      "source_prs": [],
+      "reviewers": [],
+      "confidence": "high",
+      "first_seen": "2026-05-30",
+      "last_seen": "2026-05-30",
+      "approved_by": null,
+      "approved_at": null,
+      "note": "Added from ECWC-282 session (Jira ADF format issue), not from PR review"
+    },
+    {
+      "id": "R-003",
+      "kind": "rule",
+      "file": ".ai/rules.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        176,
+        154
+      ],
+      "reviewers": [
+        "Sasit-Nine",
+        "MossOcelot"
+      ],
+      "confidence": "high",
+      "first_seen": "2026-06-08",
+      "last_seen": "2026-06-08",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "R-004",
+      "kind": "rule",
+      "file": ".ai/rules.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "medium",
+      "first_seen": "2026-06-08",
+      "last_seen": "2026-06-08",
+      "approved_by": null,
+      "approved_at": null
     },
     {
       "id": "D-001",
       "kind": "domain",
       "file": ".ai/domain.md",
       "status": "proposed",
+      "origin": "human",
       "source_prs": [
         143
       ],
@@ -46,6 +103,7 @@
       "kind": "convention",
       "file": ".ai/conventions.md",
       "status": "proposed",
+      "origin": "human",
       "source_prs": [
         148
       ],
@@ -63,6 +121,7 @@
       "kind": "gotcha",
       "file": ".ai/gotchas.md",
       "status": "proposed",
+      "origin": "human",
       "source_prs": [
         143
       ],
@@ -76,10 +135,29 @@
       "approved_at": null
     },
     {
+      "id": "G-002",
+      "kind": "gotcha",
+      "file": ".ai/gotchas.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "medium",
+      "first_seen": "2026-06-08",
+      "last_seen": "2026-06-08",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
       "id": "Q-001",
       "kind": "preference",
       "file": ".ai/quarantine.md",
       "status": "quarantined",
+      "origin": "human",
       "source_prs": [
         123
       ],
@@ -89,6 +167,60 @@
       "confidence": "low",
       "first_seen": "2026-05-19",
       "last_seen": "2026-05-19",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "Q-002",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-06-08",
+      "last_seen": "2026-06-08",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "Q-003",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-06-08",
+      "last_seen": "2026-06-08",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "Q-004",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "ai-review",
+      "source_prs": [
+        154
+      ],
+      "reviewers": [
+        "claude[bot]"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-06-08",
+      "last_seen": "2026-06-08",
       "approved_by": null,
       "approved_at": null
     }

--- a/.ai/quarantine.md
+++ b/.ai/quarantine.md
@@ -11,3 +11,21 @@ Format per entry: `### Q-NNN <statement>` then **Why:** / **Example:** / **Sourc
 **Promote to convention when:** seen again in ≥1 more PR by another reviewer.
 **Source:** PR#123 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/123
 **Added:** 2026-05-19  **Status:** quarantined (not team-agreed)
+
+### Q-002  Use TypeORM object-style `select` — `{ field: true }` — not array style `['field']`
+**Why:** PR#176 (Sasit-Nine, minor): `select: ['pro_unit1', 'pro_unit2', ...]` in `findSmallestUnit`. Object style is the v0.3+ TypeORM API and produces better type inference.
+**Promote to convention when:** seen in ≥1 more PR by another reviewer.
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-06-08  **Status:** quarantined (single occurrence)
+
+### Q-003  Domain-specific endpoints belong in their own controller, not AppController
+**Why:** PR#176 (Sasit-Nine, medium): `/ecom/check-happy-hour-reward` was added to `AppController`, pulling in a domain service dependency and blurring responsibility. Suggested home: `HappyHourController` or `ShoppingOrderController`.
+**Promote to convention when:** seen in ≥1 more PR by another reviewer.
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-06-08  **Status:** quarantined (single occurrence)
+
+### Q-004  PR description must include a Jira task link
+**Why:** AI review (claude[bot]) on PR#154 repeatedly flagged the empty Jira link field in the PR template. Traceability between tickets and code helps review and future debugging.
+**Promote to convention when:** a human reviewer flags the same point in ≥1 PR.
+**Source:** PR#154 claude[bot] — github.com/wangpharma-org/Backend-Ecommerce/pull/154
+**Added:** 2026-06-08  **Status:** quarantined (ai-review only — no human corroboration yet)

--- a/.ai/rules.md
+++ b/.ai/rules.md
@@ -37,3 +37,30 @@ this.logger.error('failed to fetch products', err)
 ```
 **Source:** ECWC-282 session 2026-05-30
 **Added:** 2026-05-30
+
+### R-003  Every controller endpoint that is not explicitly public must be protected with `@UseGuards(JwtAuthGuard)`
+**Why:** PR#176 (Sasit-Nine, Critical): `/ecom/check-happy-hour-reward` had no auth guard — any unauthenticated caller could POST an order ID and manipulate reward counts. PR#154 (MossOcelot): inline role checks inside controller actions should move to guards/decorators so the control point is consistent and visible.
+**Example:**
+```ts
+// ✗ no — endpoint is accessible without authentication
+@Post('/ecom/check-happy-hour-reward')
+async checkHappyHourReward(@Body() body: { sh_running: string }) { ... }
+
+// ✓ protect every non-public endpoint
+@UseGuards(JwtAuthGuard)
+@Post('/ecom/check-happy-hour-reward')
+async checkHappyHourReward(@Body() body: { sh_running: string }) { ... }
+```
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176 ; PR#154 @MossOcelot — /pull/154
+**Added:** 2026-06-08  **Enforce:** PR review checklist; consider custom guard-presence lint rule
+
+### R-004  Every PR that adds or changes database tables/columns must include a TypeORM migration file in the same diff
+**Why:** PR#176 (Sasit-Nine, Medium/blocker): `happy_hour_slot_reward` table and `start_date`/`end_date` columns were added but no migration was included. With `synchronize: false` in production this silently breaks the deploy.
+**Example:**
+```ts
+// ✗ no — entity updated, migration absent from PR
+// ✓ always generate and commit before opening the PR:
+// npm run migration:generate -- src/migrations/AddHappyHourSlotReward
+```
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-06-08  **Enforce:** PR review checklist (reviewer verifies migration is in diff)


### PR DESCRIPTION
## Auto-distilled from merged-PR review feedback

This PR was generated automatically by the `learn-from-reviews` scheduled agent on **2026-06-08**. It distilled human (and a small number of AI-bot) review comments from merged PRs since the previous run (`last_run: 2026-05-19`) into proposed knowledge entries.

**This is a PROPOSE-ONLY PR.** All items carry `status: "proposed"` with `approved_by: null`. No item is authoritative until this PR is reviewed and approved.

---

## What changed

### `.ai/rules.md` — 2 new rules proposed

| ID | Statement | Source | Origin | Confidence |
|----|-----------|--------|--------|------------|
| R-003 | Every non-public endpoint must have `@UseGuards(JwtAuthGuard)` | PR#176 @Sasit-Nine (Critical), PR#154 @MossOcelot | human | high |
| R-004 | Every PR that changes DB schema must include a TypeORM migration file | PR#176 @Sasit-Nine (Medium/blocker) | human | medium |

### `.ai/gotchas.md` — 1 new gotcha proposed

| ID | Statement | Source | Origin | Confidence |
|----|-----------|--------|--------|------------|
| G-002 | Fixing N+1 in one method doesn't fix sibling methods loading the same relation | PR#176 @Sasit-Nine | human | medium |

### `.ai/quarantine.md` — 3 new preferences quarantined

| ID | Statement | Source | Origin | Note |
|----|-----------|--------|--------|------|
| Q-002 | Use TypeORM object-style `select: { field: true }`, not array style | PR#176 @Sasit-Nine | human | Promote when seen in ≥1 more PR |
| Q-003 | Domain endpoints belong in their own controller, not AppController | PR#176 @Sasit-Nine | human | Promote when seen in ≥1 more PR |
| Q-004 | PR description must include a Jira task link | PR#154 claude[bot] | ai-review | Promote only after human corroboration |

### `.ai/ledger.json` — housekeeping updates

- **R-001** `last_seen` updated; PR#178 + reviewer Sasit-Nine added to evidence (3× "เอา console.log ออก" in PR#178 corroborates existing rule)
- **R-002** ledger entry added (rule existed in `rules.md` since 2026-05-30 but was missing from ledger)
- `origin` field backfilled on all existing ledger items
- `last_run` updated to `2026-06-08`

---

## PRs covered in this run

| PR | Title | Key feedback source |
|----|-------|-------------------|
| #176 | Happy Hour V2 | Sasit-Nine (human review — Critical/Medium/Minor items) |
| #178 | Enhance logging in ShoppingCartService | Sasit-Nine (3× inline "remove console.log") |
| #154 | Add Happy Hour module | MossOcelot (human inline — use Guards); claude[bot] (ai-review — auth + Jira link) |

PRs with only approval reviews and no substantive feedback (no new knowledge): #182, #186, #185, #180, #168, #163, #166, #165, #164, #160, #161, #157, #187, #188, #183, #189, #172 — all checked.

---

## How to approve

**CODEOWNER @62theories** — your review is the team agreement. For each item you approve:
1. Approve this PR on GitHub
2. After merge, flip the item's `status` from `"proposed"` → `"agreed"` and set `approved_by: "62theories"` + `approved_at: <date>` in `ledger.json`

For preferences in quarantine (Q-001 through Q-004): hold until they recur in ≥1 more PR by another reviewer before promoting to a convention.

The bot never merges, never approves its own output, and never writes to `develop` directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHrff6kY5yvgeueoPuMsbk)_