### PR TITLE
[ECWC-309] เพิ่มระบบสิทธิ์รายฟีเจอร์, audit log, และค้นหาผู้ใช้สำหรับหน้าจัดการ Role

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -3,6 +3,7 @@ import {
   BadGatewayException,
   Body,
   Controller,
+  DefaultValuePipe,
   Delete,
   ForbiddenException,
   Get,
@@ -10,6 +11,7 @@ import {
   HttpStatus,
   Ip,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
   Put,
@@ -106,6 +108,7 @@ export interface JwtPayload {
   mem_route?: string;
   permission?: boolean;
   role?: string;
+  admin_features?: string[] | null;
 }
 
 @Controller()
@@ -4106,11 +4109,86 @@ export class AppController {
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/change-role/:mem_code')
   async changeUserRole(
+    @Req() req: Request & { user: JwtPayload },
     @Param('mem_code') mem_code: string,
     @Body('newRole') newRole: 'User' | 'Admin' | 'Sales',
+    @Body('permission') permission?: boolean,
   ) {
+    // Granting roles (incl. Admin) is a privilege-escalation-capable action —
+    // require the actor to actually BE an Admin, not merely have back-office
+    // `permission` (a Sales account can carry that flag too).
+    if (req.user.role !== 'Admin') {
+      throw new Error('You do not have permission to access this resource');
+    }
     this.logger.log('Changing user role for mem_code:', mem_code);
-    return await this.usersService.changeUserRole(mem_code, newRole);
+    return await this.usersService.changeUserRole(mem_code, newRole, permission, {
+      mem_code: req.user.mem_code,
+      username: req.user.username,
+    });
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('/ecom/admin/user/staff-list')
+  async getStaffUsers(@Req() req: Request & { user: JwtPayload }) {
+    // ECWC-309: viewing/managing staff role assignments is Admin-only — `permission`
+    // alone is not enough (Sales accounts can also carry permission=true).
+    if (req.user.role !== 'Admin') {
+      throw new Error('You do not have permission to access this resource');
+    }
+    return await this.usersService.getStaffUsers();
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('/ecom/admin/user/lookup/:mem_code')
+  async lookupUserForRoleManage(
+    @Req() req: Request & { user: JwtPayload },
+    @Param('mem_code') mem_code: string,
+  ) {
+    if (req.user.role !== 'Admin') {
+      throw new Error('You do not have permission to access this resource');
+    }
+    return await this.usersService.findUserForRoleManageByMemCode(mem_code);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('/ecom/admin/user/search')
+  async searchUsersForRoleManage(
+    @Req() req: Request & { user: JwtPayload },
+    @Query('q') query?: string,
+  ) {
+    if (req.user.role !== 'Admin') {
+      throw new Error('You do not have permission to access this resource');
+    }
+    return await this.usersService.searchUsersForRoleManage(query ?? '');
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Put('/ecom/admin/user/update-features')
+  async updateUserFeatures(
+    @Req() req: Request & { user: JwtPayload },
+    @Body('mem_code') mem_code: string,
+    @Body('features') features: string[],
+  ) {
+    if (req.user.role !== 'Admin') {
+      throw new Error('You do not have permission to access this resource');
+    }
+    return await this.usersService.updateUserFeatures(mem_code, features ?? [], {
+      mem_code: req.user.mem_code,
+      username: req.user.username,
+    });
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('/ecom/admin/user/role-logs')
+  async getAdminActionLogs(
+    @Req() req: Request & { user: JwtPayload },
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    if (req.user.role !== 'Admin') {
+      throw new Error('You do not have permission to access this resource');
+    }
+    return await this.usersService.getAdminActionLogs(page, limit);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -273,6 +273,7 @@ export class AuthService {
       mem_route: user.mem_route ?? '',
       permission: user.permision_admin,
       role: user.role,
+      admin_features: user.admin_features ?? null,
     };
 
     const payload_reflesh = {
@@ -333,6 +334,7 @@ export class AuthService {
       mem_route: user.mem_route ?? '',
       permission: user.permision_admin,
       role: user.role,
+      admin_features: user.admin_features ?? null,
     };
     const payload_reflesh = {
       username: user.mem_username,
@@ -387,6 +389,7 @@ export class AuthService {
       mem_route: user.mem_route ?? '',
       permission: user.permision_admin,
       role: user.role,
+      admin_features: user.admin_features ?? null,
     };
     const payload_reflesh = {
       username: user.mem_username,
@@ -465,6 +468,7 @@ export class AuthService {
           mem_route: user.mem_route ?? '',
           permission: user.permision_admin,
           role: user.role,
+          admin_features: user.admin_features ?? null,
         };
 
         const payload_reflesh = {

--- a/src/migrations/20260608000100-add-user-admin-features.ts
+++ b/src/migrations/20260608000100-add-user-admin-features.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserAdminFeatures20260608000100 implements MigrationInterface {
+  name = 'AddUserAdminFeatures20260608000100';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `users` ADD `admin_features` text NULL',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE `users` DROP COLUMN `admin_features`');
+  }
+}

--- a/src/migrations/20260608000200-create-admin-action-log.ts
+++ b/src/migrations/20260608000200-create-admin-action-log.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAdminActionLog20260608000200 implements MigrationInterface {
+  name = 'CreateAdminActionLog20260608000200';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE \`admin_action_log\` (
+        \`id\` int NOT NULL AUTO_INCREMENT,
+        \`admin_mem_code\` varchar(255) NOT NULL,
+        \`admin_username\` varchar(255) NOT NULL,
+        \`target_mem_code\` varchar(255) NOT NULL,
+        \`target_username\` varchar(255) NOT NULL,
+        \`action_type\` varchar(50) NOT NULL,
+        \`old_value\` text NULL,
+        \`new_value\` text NULL,
+        \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        PRIMARY KEY (\`id\`),
+        INDEX \`IDX_admin_action_log_admin_mem_code\` (\`admin_mem_code\`),
+        INDEX \`IDX_admin_action_log_target_mem_code\` (\`target_mem_code\`),
+        INDEX \`IDX_admin_action_log_created_at\` (\`created_at\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE `admin_action_log`');
+  }
+}

--- a/src/users/admin-action-log.entity.ts
+++ b/src/users/admin-action-log.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('admin_action_log')
+export class AdminActionLogEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index()
+  @Column()
+  admin_mem_code: string;
+
+  @Column()
+  admin_username: string;
+
+  @Index()
+  @Column()
+  target_mem_code: string;
+
+  @Column()
+  target_username: string;
+
+  @Column({ length: 50 })
+  action_type: 'role_change' | 'feature_change';
+
+  @Column({ type: 'text', nullable: true })
+  old_value: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  new_value: string | null;
+
+  @Index()
+  @CreateDateColumn()
+  created_at: Date;
+}

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -215,4 +215,10 @@ export class UserEntity {
 
   @Column({ type: 'enum', enum: ['User', 'Admin', 'Sales'], default: 'User' })
   role: 'User' | 'Admin' | 'Sales' = 'User';
+
+  // ECWC-309: per-user list of admin-menu feature keys (see AdminManage's
+  // MenuItem.feature on the frontend) the user is allowed to access,
+  // beyond the coarse role/permission gate. Admins bypass this list.
+  @Column({ type: 'simple-json', nullable: true, default: null })
+  admin_features!: string[] | null;
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserEntity } from './users.entity';
+import { AdminActionLogEntity } from './admin-action-log.entity';
 import { UsersListner } from './users.listener';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserEntity])],
+  imports: [TypeOrmModule.forFeature([UserEntity, AdminActionLogEntity])],
   controllers: [UsersListner],
   providers: [UsersService],
   exports: [UsersService],

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,15 +1,67 @@
 import { Injectable } from '@nestjs/common';
 import { UserEntity } from './users.entity';
-import { Repository } from 'typeorm';
+import { AdminActionLogEntity } from './admin-action-log.entity';
+import { Like, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as bcrypt from 'bcrypt';
+
+export interface AdminActor {
+  mem_code: string;
+  username: string;
+}
 
 @Injectable()
 export class UsersService {
   constructor(
     @InjectRepository(UserEntity)
     private readonly userRepo: Repository<UserEntity>,
+    @InjectRepository(AdminActionLogEntity)
+    private readonly actionLogRepo: Repository<AdminActionLogEntity>,
   ) {}
+
+  // ECWC-309: persist an audit-trail entry for role/permission/feature changes
+  // an admin makes to another user's account.
+  private async logAdminAction(
+    actor: AdminActor,
+    target: { mem_code: string; mem_username: string },
+    action_type: 'role_change' | 'feature_change',
+    old_value: unknown,
+    new_value: unknown,
+  ): Promise<void> {
+    try {
+      await this.actionLogRepo.save(
+        this.actionLogRepo.create({
+          admin_mem_code: actor.mem_code,
+          admin_username: actor.username,
+          target_mem_code: target.mem_code,
+          target_username: target.mem_username,
+          action_type,
+          old_value: JSON.stringify(old_value),
+          new_value: JSON.stringify(new_value),
+        }),
+      );
+    } catch (error) {
+      console.error('Error saving admin action log:', error);
+    }
+  }
+
+  // ECWC-309: list admin action logs (role/permission/feature changes) for the audit-trail page.
+  async getAdminActionLogs(
+    page: number,
+    limit: number,
+  ): Promise<{ data: AdminActionLogEntity[]; total: number; page: number; limit: number }> {
+    try {
+      const [data, total] = await this.actionLogRepo.findAndCount({
+        order: { created_at: 'DESC' },
+        take: limit,
+        skip: (page - 1) * limit,
+      });
+      return { data, total, page, limit };
+    } catch (error) {
+      console.error('Error retrieving admin action logs:', error);
+      throw new Error('Error retrieving admin action logs');
+    }
+  }
 
   async findOne(username: string): Promise<UserEntity> {
     console.log('Finding user with username:', username);
@@ -255,6 +307,8 @@ export class UsersService {
   async changeUserRole(
     mem_code: string,
     newRole: 'User' | 'Admin' | 'Sales',
+    permission?: boolean,
+    actor?: AdminActor,
   ): Promise<UserEntity> {
     try {
       const user = await this.userRepo.findOne({
@@ -267,13 +321,164 @@ export class UsersService {
         throw new Error('User not found');
       }
 
-      await this.userRepo.update({ mem_code: mem_code }, { role: newRole });
+      const oldRole = user.role;
+      const oldPermission = user.permision_admin;
+      const newPermission = permission === undefined ? oldPermission : permission;
+
+      await this.userRepo.update(
+        { mem_code: mem_code },
+        permission === undefined
+          ? { role: newRole }
+          : { role: newRole, permision_admin: permission },
+      );
       console.log(`Successfully updated role to ${newRole} for ${mem_code}`);
+
+      if (actor) {
+        await this.logAdminAction(
+          actor,
+          { mem_code: user.mem_code, mem_username: user.mem_username },
+          'role_change',
+          { role: oldRole, permision_admin: oldPermission },
+          { role: newRole, permision_admin: newPermission },
+        );
+      }
 
       return this.findOneByMemCode(mem_code);
     } catch (error) {
       console.error('Error updating user role:', error);
       throw new Error('Error updating user role');
+    }
+  }
+
+  // ECWC-309: list staff accounts (Admin/Sales) so the admin UI can manage
+  // role + permission together instead of editing them via raw DB access.
+  async getStaffUsers(): Promise<
+    {
+      mem_code: string;
+      mem_username: string;
+      mem_nameSite: string;
+      role: 'User' | 'Admin' | 'Sales';
+      permision_admin: boolean;
+      admin_features: string[] | null;
+    }[]
+  > {
+    try {
+      return await this.userRepo.find({
+        where: [{ role: 'Admin' }, { role: 'Sales' }],
+        select: [
+          'mem_code',
+          'mem_username',
+          'mem_nameSite',
+          'role',
+          'permision_admin',
+          'admin_features',
+        ],
+        order: { role: 'ASC', mem_code: 'ASC' },
+      });
+    } catch (error) {
+      console.error('Error retrieving staff users:', error);
+      throw new Error('Error retrieving staff users');
+    }
+  }
+
+  // ECWC-309: look up any user by mem_code (4-digit numeric only) so an admin
+  // can grant Admin/Sales role to accounts outside the existing staff list.
+  async findUserForRoleManageByMemCode(mem_code: string): Promise<{
+    mem_code: string;
+    mem_username: string;
+    mem_nameSite: string;
+    role: 'User' | 'Admin' | 'Sales';
+    permision_admin: boolean;
+    admin_features: string[] | null;
+  } | null> {
+    if (!/^\d{4}$/.test(mem_code)) {
+      throw new Error('mem_code must be a 4-digit number');
+    }
+    try {
+      return await this.userRepo.findOne({
+        where: { mem_code },
+        select: [
+          'mem_code',
+          'mem_username',
+          'mem_nameSite',
+          'role',
+          'permision_admin',
+          'admin_features',
+        ],
+      });
+    } catch (error) {
+      console.error('Error looking up user by mem_code:', error);
+      throw new Error('Error looking up user by mem_code');
+    }
+  }
+
+  // ECWC-309: typeahead search — prefix match on mem_code, restricted to
+  // 4-digit numeric accounts (same constraint as the exact lookup above).
+  async searchUsersForRoleManage(query: string): Promise<
+    {
+      mem_code: string;
+      mem_username: string;
+      mem_nameSite: string;
+      role: 'User' | 'Admin' | 'Sales';
+      permision_admin: boolean;
+      admin_features: string[] | null;
+    }[]
+  > {
+    const trimmed = query.trim();
+    if (!/^\d{1,4}$/.test(trimmed)) {
+      return [];
+    }
+    try {
+      const users = await this.userRepo.find({
+        where: { mem_code: Like(`${trimmed}%`) },
+        select: [
+          'mem_code',
+          'mem_username',
+          'mem_nameSite',
+          'role',
+          'permision_admin',
+          'admin_features',
+        ],
+        order: { mem_code: 'ASC' },
+        take: 20,
+      });
+      return users.filter((u) => /^\d{4}$/.test(u.mem_code));
+    } catch (error) {
+      console.error('Error searching users by mem_code:', error);
+      throw new Error('Error searching users by mem_code');
+    }
+  }
+
+  // ECWC-309: replace the per-user list of admin-menu feature keys they can access.
+  async updateUserFeatures(
+    mem_code: string,
+    features: string[],
+    actor?: AdminActor,
+  ): Promise<{ mem_code: string; admin_features: string[] }> {
+    try {
+      const user = await this.userRepo.findOne({ where: { mem_code } });
+      if (!user) {
+        throw new Error('User not found');
+      }
+
+      const oldFeatures = user.admin_features ?? [];
+      await this.userRepo.update({ mem_code }, { admin_features: features });
+      console.log(`Successfully updated admin_features for ${mem_code}`);
+
+      if (actor) {
+        await this.logAdminAction(
+          actor,
+          { mem_code: user.mem_code, mem_username: user.mem_username },
+          'feature_change',
+          oldFeatures,
+          features,
+        );
+      }
+
+      return { mem_code, admin_features: features };
+    } catch (error) {
+      console.error('Error updating user features:', error);
+      throw new Error('Error updating user features');
     }
   }
 }


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- ECWC-309

### 📌 ประเภทของ PR
- [x] ✨ Feature ใหม่
- [x] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
รองรับหน้า "จัดการสิทธิ์ผู้ใช้ (Role/Permission)" ฝั่ง frontend โดยเพิ่ม column `admin_features` (รายการฟีเจอร์เมนูหลังบ้านที่ผู้ใช้แต่ละคนเข้าถึงได้แบบละเอียดกว่า role เดิม), ตาราง `admin_action_log` สำหรับเก็บประวัติการเปลี่ยนแปลง role/permission/feature ที่ admin ทำกับบัญชีอื่น, และ endpoint สำหรับค้นหาผู้ใช้ด้วย mem_code (autocomplete)

ระหว่างพัฒนาตรวจพบช่องโหว่ privilege escalation: endpoint ที่สามารถมอบ role (รวมถึง Admin) หรือจัดการสิทธิ์รายฟีเจอร์ เช็คจาก `req.user.permission` (flag สิทธิ์เข้าหลังบ้านทั่วไป) แทนที่จะเช็คจาก `req.user.role === 'Admin'` จริงๆ ทำให้บัญชี Sales ที่มี `permision_admin: true` เรียก endpoint เหล่านี้แล้วตั้งตัวเองเป็น Admin ได้ — PR นี้แก้ช่องโหว่ดังกล่าวด้วย

### 🛠️ แก้ปัญหานั้นอย่างไร
- เพิ่ม column `admin_features` (`simple-json`, nullable) ใน `UserEntity` พร้อม migration `20260608000100-add-user-admin-features.ts` และส่งค่านี้เข้าไปใน JWT payload (`auth.service.ts`)
- เพิ่ม entity + migration ของตาราง `admin_action_log` (`20260608000200-create-admin-action-log.ts`) และ method `logAdminAction` / `getAdminActionLogs` ใน `UsersService` เพื่อบันทึกและอ่านประวัติการเปลี่ยนแปลง (เก็บ old/new value เป็น JSON, ไม่ block การทำงานหลักถ้าบันทึก log ล้มเหลว)
- เพิ่ม `searchUsersForRoleManage` (ค้นหาด้วย mem_code prefix, จำกัดเฉพาะรหัส 4 หลัก, สูงสุด 20 รายการ) และ endpoint `GET /ecom/admin/user/search`, `GET /ecom/admin/user/role-logs`
- ปรับ `changeUserRole` และ `updateUserFeatures` ให้รับ `actor` แล้วบันทึก log อัตโนมัติเมื่อมีการเปลี่ยนแปลง
- **แก้ช่องโหว่ privilege escalation**: เปลี่ยน guard ใน 6 endpoint (`change-role`, `staff-list`, `lookup`, `search`, `update-features`, `role-logs`) จาก `req.user.permission !== true` เป็น `req.user.role !== 'Admin'`

### 🧪 วิธี Test
1. **ต้องรัน migration ก่อนทดสอบ**: `20260608000100-add-user-admin-features.ts` และ `20260608000200-create-admin-action-log.ts`
2. เรียก `PUT /ecom/change-role/:mem_code` ด้วย token ของบัญชี Sales ที่มี `permision_admin: true` แต่ `role` ไม่ใช่ Admin → ต้องได้ 403/permission denied (ก่อนแก้จะอนุญาตให้ผ่าน)
3. เรียก `GET /ecom/admin/user/search?q=01` ด้วย token Admin → ได้รายชื่อผู้ใช้ mem_code ขึ้นต้นด้วย `01` ไม่เกิน 20 รายการ
4. เปลี่ยน role หรือ feature ของผู้ใช้ผ่าน endpoint ที่เกี่ยวข้อง แล้วเรียก `GET /ecom/admin/user/role-logs?page=1&limit=20` → ต้องเห็นรายการ log ใหม่พร้อมค่าเก่า/ใหม่ (`old_value`/`new_value`)

### 🔑 Environment Variables ใหม่
- ไม่มี

---
> ⚠️ **หมายเหตุสำคัญ**: ต้องรัน migration `20260608000100-add-user-admin-features.ts` และ `20260608000200-create-admin-action-log.ts` บน database ก่อน deploy — ยังไม่ได้รันบน database จริง