### PR TITLE
[ECWC-309] เพิ่ม endpoint force-logout session ที่เพิ่งใช้งานเมื่อเปลี่ยน role

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1799,11 +1799,8 @@ export class AppController {
 
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/session/logout-recent')
-  async logoutRecentSessions(
-    @Body() data: { mem_code: string; minutes?: number },
-  ) {
-    const minutes = data.minutes ?? 15;
-    await this.sessionsService.logoutRecentUserSessions(data.mem_code, minutes);
+  async logoutRecentSessions(@Body() data: { mem_code: string }) {
+    await this.sessionsService.logoutRecentUserSessions(data.mem_code);
     return { message: 'Recently active sessions logged out successfully' };
   }
 
@@ -4131,10 +4128,15 @@ export class AppController {
       throw new Error('You do not have permission to access this resource');
     }
     this.logger.log('Changing user role for mem_code:', mem_code);
-    return await this.usersService.changeUserRole(mem_code, newRole, permission, {
-      mem_code: req.user.mem_code,
-      username: req.user.username,
-    });
+    return await this.usersService.changeUserRole(
+      mem_code,
+      newRole,
+      permission,
+      {
+        mem_code: req.user.mem_code,
+        username: req.user.username,
+      },
+    );
   }
 
   @UseGuards(JwtAuthGuard)
@@ -4182,10 +4184,14 @@ export class AppController {
     if (req.user.role !== 'Admin') {
       throw new Error('You do not have permission to access this resource');
     }
-    return await this.usersService.updateUserFeatures(mem_code, features ?? [], {
-      mem_code: req.user.mem_code,
-      username: req.user.username,
-    });
+    return await this.usersService.updateUserFeatures(
+      mem_code,
+      features ?? [],
+      {
+        mem_code: req.user.mem_code,
+        username: req.user.username,
+      },
+    );
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1798,6 +1798,16 @@ export class AppController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Post('/ecom/session/logout-recent')
+  async logoutRecentSessions(
+    @Body() data: { mem_code: string; minutes?: number },
+  ) {
+    const minutes = data.minutes ?? 15;
+    await this.sessionsService.logoutRecentUserSessions(data.mem_code, minutes);
+    return { message: 'Recently active sessions logged out successfully' };
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Get('/ecom/session/validate/:session_token')
   async validateSession(@Param('session_token') session_token: string) {
     const isValid = await this.sessionsService.isSessionValid(session_token);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -9,13 +9,15 @@ import { HttpService } from '@nestjs/axios';
 import * as AWS from 'aws-sdk';
 import { RefreshTokenEntity } from './refresh-token.entity';
 import * as bcrypt from 'bcrypt';
-import { SALT_ROUNDS } from '../constants/app.constants'; 
+import { SALT_ROUNDS } from '../constants/app.constants';
 import { EmployeesService } from 'src/employees/employees.service';
 
 export interface SigninResponse {
   token: string;
   refresh_token: string;
 }
+
+export const ExpireSessionResponse = 15;
 
 @Injectable()
 export class AuthService {
@@ -224,7 +226,10 @@ export class AuthService {
             },
           );
         } else {
-          const hashedPassword = await bcrypt.hash(user.mem_password, SALT_ROUNDS);
+          const hashedPassword = await bcrypt.hash(
+            user.mem_password,
+            SALT_ROUNDS,
+          );
           const newUser = this.userRepo.create({
             mem_code: user.mem_code,
             mem_nameSite: user.mem_nameSite,
@@ -253,7 +258,10 @@ export class AuthService {
     if (!user) {
       throw new UnauthorizedException('User not found');
     }
-    const passwordMatch = await bcrypt.compare(data.password, user.mem_password);
+    const passwordMatch = await bcrypt.compare(
+      data.password,
+      user.mem_password,
+    );
     if (user && passwordMatch === false) {
       throw new UnauthorizedException('Invalid password');
     }
@@ -282,7 +290,7 @@ export class AuthService {
       mem_code: user.mem_code ?? '',
     };
     const access_token = await this.jwtService.signAsync(payload, {
-      expiresIn: '15m',
+      expiresIn: `${ExpireSessionResponse}m`,
     });
     const refreshTokenExpiresIn = data.source === 'mobile_app' ? '7d' : '18h';
     const refresh_token = await this.jwtService.signAsync(payload_reflesh, {
@@ -298,7 +306,8 @@ export class AuthService {
   }
 
   async signinWithLineUserId(lineUserId: string): Promise<SigninResponse> {
-    const notificationUrl = process.env.NOTIFICATION_SERVICE_URL ?? 'http://localhost:3005';
+    const notificationUrl =
+      process.env.NOTIFICATION_SERVICE_URL ?? 'http://localhost:3005';
 
     let memCode: string;
     try {
@@ -342,18 +351,24 @@ export class AuthService {
       mem_code: user.mem_code ?? '',
     };
 
-    const access_token = await this.jwtService.signAsync(payload, { expiresIn: '15m' });
+    const access_token = await this.jwtService.signAsync(payload, {
+      expiresIn: `${ExpireSessionResponse}m`,
+    });
     const refresh_token = await this.jwtService.signAsync(payload_reflesh, {
       secret: process.env.ACCESS_TOKEN_SECRET,
       expiresIn: '18h',
     });
 
-    await this.refreshTokenRepo.save({ mem_code: user.mem_code, refresh_token });
+    await this.refreshTokenRepo.save({
+      mem_code: user.mem_code,
+      refresh_token,
+    });
     return { token: access_token, refresh_token };
   }
 
   async signinWithLine(lineAccessToken: string): Promise<SigninResponse> {
-    const notificationUrl = process.env.NOTIFICATION_SERVICE_URL ?? 'http://localhost:3005';
+    const notificationUrl =
+      process.env.NOTIFICATION_SERVICE_URL ?? 'http://localhost:3005';
 
     let memCode: string;
     try {
@@ -365,7 +380,9 @@ export class AuthService {
       );
       memCode = res.data.mem_code;
     } catch {
-      throw new UnauthorizedException('LINE token ไม่ถูกต้องหรือยังไม่ได้ผูกบัญชี');
+      throw new UnauthorizedException(
+        'LINE token ไม่ถูกต้องหรือยังไม่ได้ผูกบัญชี',
+      );
     }
 
     const user = await this.userRepo.findOne({ where: { mem_code: memCode } });
@@ -397,13 +414,18 @@ export class AuthService {
       mem_code: user.mem_code ?? '',
     };
 
-    const access_token = await this.jwtService.signAsync(payload, { expiresIn: '15m' });
+    const access_token = await this.jwtService.signAsync(payload, {
+      expiresIn: `${ExpireSessionResponse}m`,
+    });
     const refresh_token = await this.jwtService.signAsync(payload_reflesh, {
       secret: process.env.ACCESS_TOKEN_SECRET,
       expiresIn: '18h',
     });
 
-    await this.refreshTokenRepo.save({ mem_code: user.mem_code, refresh_token });
+    await this.refreshTokenRepo.save({
+      mem_code: user.mem_code,
+      refresh_token,
+    });
     return { token: access_token, refresh_token };
   }
 
@@ -479,7 +501,9 @@ export class AuthService {
 
         const refreshTokenExpiresIn = source === 'mobile_app' ? '7d' : '18h';
         const [access_token, new_refresh_token] = await Promise.all([
-          this.jwtService.signAsync(tokenPayload, { expiresIn: '15m' }),
+          this.jwtService.signAsync(tokenPayload, {
+            expiresIn: `${ExpireSessionResponse}m`,
+          }),
           this.jwtService.signAsync(payload_reflesh, {
             secret: process.env.ACCESS_TOKEN_SECRET,
             expiresIn: refreshTokenExpiresIn,
@@ -507,9 +531,9 @@ export class AuthService {
 
     try {
       // Get users within transaction แทนที่จะใช้ this.userRepo.find
-      const users = await queryRunner.manager.find(UserEntity, {
+      const users = (await queryRunner.manager.find(UserEntity, {
         select: { mem_code: true, mem_password: true },
-      }) as Pick<UserEntity, 'mem_code' | 'mem_password'>[];
+      })) as Pick<UserEntity, 'mem_code' | 'mem_password'>[];
 
       let hashCount = 0;
       let skipCount = 0;
@@ -522,31 +546,39 @@ export class AuthService {
           skipCount++;
           continue;
         }
-        
+
         try {
           const hashedPassword = await bcrypt.hash(password, SALT_ROUNDS);
-          console.log(`Hash length: ${hashedPassword.length} for user: ${user.mem_code}`);
-          
+          console.log(
+            `Hash length: ${hashedPassword.length} for user: ${user.mem_code}`,
+          );
+
           //Update within transaction แทนที่จะใช้ this.userRepo.update
-          await queryRunner.manager.update(UserEntity, 
+          await queryRunner.manager.update(
+            UserEntity,
             { mem_code: user.mem_code },
-            { mem_password: hashedPassword }
+            { mem_password: hashedPassword },
           );
           hashCount++;
         } catch (updateError) {
           //เก็บ error แทนที่จะ throw ทันทีเพื่อrollback ได้
-          errors.push(`Error updating user ${user.mem_code}: ${updateError.message}`);
-          console.error(`Error updating user ${user.mem_code}:`, updateError.message);
+          errors.push(
+            `Error updating user ${user.mem_code}: ${updateError.message}`,
+          );
+          console.error(
+            `Error updating user ${user.mem_code}:`,
+            updateError.message,
+          );
         }
       }
 
-      //ตรวจสอบ errors และ rollback ถ้ามี 
+      //ตรวจสอบ errors และ rollback ถ้ามี
       if (errors.length > 0) {
         await queryRunner.rollbackTransaction(); //rollback
         return {
           success: false,
           message: 'Hash password failed - transaction rolled back',
-          errors: errors
+          errors: errors,
         };
       }
 
@@ -558,18 +590,17 @@ export class AuthService {
         message: `Hashed ${hashCount} passwords, skipped ${skipCount}`,
         total: users.length,
         hashed: hashCount,
-        skipped: skipCount
+        skipped: skipCount,
       };
-
     } catch (error) {
       //Rollback เมื่อเกิด error
       await queryRunner.rollbackTransaction();
       console.error('Transaction failed:', error);
-      
+
       return {
         success: false,
         message: 'Hash password failed',
-        error: error.message
+        error: error.message,
       };
     } finally {
       //ปลดปล่อย connection เสมอ กัน memory leak

--- a/src/sessions/sessions.service.ts
+++ b/src/sessions/sessions.service.ts
@@ -83,6 +83,25 @@ export class SessionsService {
     );
   }
 
+  // Logs out only sessions that are still actively refreshing (last_activity
+  // within `withinMinutes`), instead of every session for the user. The
+  // client refreshes its token every 15 minutes, so idle sessions older than
+  // that will pick up the new role/permissions on their own next refresh.
+  async logoutRecentUserSessions(
+    memCode: string,
+    withinMinutes: number,
+  ): Promise<void> {
+    const cutoff = new Date(Date.now() - withinMinutes * 60 * 1000);
+    await this.sessionsRepository
+      .createQueryBuilder()
+      .update(UserSessionsEntity)
+      .set({ is_active: false, logout_at: new Date() })
+      .where('mem_code = :memCode', { memCode })
+      .andWhere('is_active = :isActive', { isActive: true })
+      .andWhere('last_activity >= :cutoff', { cutoff })
+      .execute();
+  }
+
   @Cron('0 0 * * *')
   async cleanupInactiveSessions(daysOld: number = 30): Promise<void> {
     const cutoffDate = new Date();

--- a/src/sessions/sessions.service.ts
+++ b/src/sessions/sessions.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { UserSessionsEntity } from './sessions.entity';
 import { Cron } from '@nestjs/schedule';
 import * as dayjs from 'dayjs';
+import { ExpireSessionResponse } from '../auth/auth.service';
 
 @Injectable()
 export class SessionsService {
@@ -88,11 +89,8 @@ export class SessionsService {
   // within `withinMinutes`), instead of every session for the user. The
   // client refreshes its token every 15 minutes, so idle sessions older than
   // that will pick up the new role/permissions on their own next refresh.
-  async logoutRecentUserSessions(
-    memCode: string,
-    withinMinutes: number,
-  ): Promise<void> {
-    const cutoff = dayjs().subtract(withinMinutes, 'minute').toDate();
+  async logoutRecentUserSessions(memCode: string): Promise<void> {
+    const cutoff = dayjs().subtract(ExpireSessionResponse, 'minute').toDate();
     await this.sessionsRepository
       .createQueryBuilder()
       .update(UserSessionsEntity)

--- a/src/sessions/sessions.service.ts
+++ b/src/sessions/sessions.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserSessionsEntity } from './sessions.entity';
 import { Cron } from '@nestjs/schedule';
+import * as dayjs from 'dayjs';
 
 @Injectable()
 export class SessionsService {
@@ -91,7 +92,7 @@ export class SessionsService {
     memCode: string,
     withinMinutes: number,
   ): Promise<void> {
-    const cutoff = new Date(Date.now() - withinMinutes * 60 * 1000);
+    const cutoff = dayjs().subtract(withinMinutes, 'minute').toDate();
     await this.sessionsRepository
       .createQueryBuilder()
       .update(UserSessionsEntity)


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
<!-- ใส่ link ไปยัง task ใน Jira (ถ้ามี) -->
- ECWC-309

### 📌 ประเภทของ PR
<!-- เลือกข้อที่ตรง ลบที่ไม่เกี่ยวออก -->
- [x] ✨ Feature ใหม่

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
<!-- อธิบายสั้นๆ ว่า PR นี้ทำอะไร และ merge แล้วจะช่วยแก้ปัญหาอะไร -->
สิทธิ์ role/permission ของผู้ใช้ถูกฝังไว้ใน JWT ตอน login ดังนั้นเมื่อแอดมินเปลี่ยน role ของผู้ใช้ ผู้ใช้ที่กำลัง active อยู่จะยังใช้สิทธิ์เก่าจนกว่า token จะ refresh (สูงสุด ~15 นาที) PR นี้เพิ่ม endpoint ให้ force-logout เฉพาะ session ที่เพิ่งใช้งาน เพื่อบังคับให้ login ใหม่และได้สิทธิ์ที่อัปเดตทันที โดยไม่กระทบ session ที่ไม่ active อยู่แล้ว

### 🛠️ แก้ปัญหานั้นอย่างไร
<!-- อธิบายวิธีที่ใช้แก้ปัญหา -->
- เพิ่ม `SessionsService.logoutRecentUserSessions(memCode, withinMinutes)` ที่ logout เฉพาะ session ที่ `is_active = true` และ `last_activity` อยู่ภายใน `withinMinutes` นาทีล่าสุด (ไม่ใช่ logout ทั้งหมดแบบ `logout-all`)
- เพิ่ม endpoint `POST /ecom/session/logout-recent` รับ `{ mem_code, minutes? }` (default 15 นาที ตามรอบ refresh token ของระบบ)

### 🧪 วิธี Test
<!-- อธิบายวิธี test PR นี้ เช่น เรียก API อะไร / เข้า URL อะไร / ขั้นตอนทดสอบ -->
1. Login ด้วย user ทดสอบ แล้วปล่อยให้ใช้งาน (เพื่อให้มี `last_activity` ล่าสุด)
2. เรียก `POST /ecom/session/logout-recent` ด้วย `{ "mem_code": "<mem_code ของ user ทดสอบ>" }` (ต้องแนบ Bearer token ของแอดมิน)
3. ตรวจสอบว่า session ของ user ที่ `last_activity` ภายใน 15 นาที ถูก set `is_active = false` และ `logout_at` ถูกบันทึก ส่วน session ที่ไม่ active (last_activity เก่ากว่า 15 นาที) ไม่ถูกแตะต้อง

### 🔑 Environment Variables ใหม่
<!-- ถ้ามี env ใหม่ ให้ระบุชื่อและคำอธิบาย ถ้าไม่มีเขียน "ไม่มี" -->
- ไม่มี