### PR TITLE
feat(ECWC-130): track search and add-to-cart events via Kafka

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -453,6 +453,7 @@ export class AppController {
     this.searchCartTrackingService.emitSearchEvent(mem_code, {
       search_query: data.keyword,
       result_count: result.totalCount,
+      result_pro_codes: result.products.map((product) => product.pro_code),
     });
     return result;
   }
@@ -646,8 +647,10 @@ export class AppController {
     const summaryCart = await this.shoppingCartService.summaryCart(
       data.mem_code,
     );
+    const addedProduct = cart.find((item) => item.pro_code === data.pro_code);
     this.searchCartTrackingService.emitAddToCartEvent(data.mem_code, {
       pro_code: data.pro_code,
+      pro_name: addedProduct?.pro_name,
       pro_unit: data.pro_unit,
       amount: data.amount,
       source: data.source,

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -91,6 +91,7 @@ import { BehaviorTrackingService } from './behavior-tracking/behavior-tracking.s
 import { TrackOrderService } from './track-order/track-order.service';
 import { NotifyRtService } from './notifyapp/notifyapp.service';
 import { CompanyDayAnalyticService } from './company-day-analytic/company-day-analytic.service';
+import { SearchCartTrackingService } from './search-cart-tracking/search-cart-tracking.service';
 
 export interface JwtPayload {
   username: string;
@@ -154,6 +155,7 @@ export class AppController {
     private readonly notifyRtService: NotifyRtService,
     private readonly trackOrderService: TrackOrderService,
     private readonly companyDayAnalyticService: CompanyDayAnalyticService,
+    private readonly searchCartTrackingService: SearchCartTrackingService,
   ) {}
 
   @Get('/ecom/get-data/:soh_running')
@@ -448,6 +450,10 @@ export class AppController {
         imageUrl: resultItem.pro_imgmain,
       });
     }
+    this.searchCartTrackingService.emitSearchEvent(mem_code, {
+      search_query: data.keyword,
+      result_count: result.totalCount,
+    });
     return result;
   }
 
@@ -607,6 +613,8 @@ export class AppController {
       cartVersion?: string | number;
       clientVersion?: string;
       company_day_source?: string;
+      source?: string;
+      search_query?: string;
     },
   ) {
     const priceCondition = req.user.price_option ?? 'C';
@@ -638,6 +646,13 @@ export class AppController {
     const summaryCart = await this.shoppingCartService.summaryCart(
       data.mem_code,
     );
+    this.searchCartTrackingService.emitAddToCartEvent(data.mem_code, {
+      pro_code: data.pro_code,
+      pro_unit: data.pro_unit,
+      amount: data.amount,
+      source: data.source,
+      search_query: data.search_query,
+    });
     return {
       cart,
       summaryCart: summaryCart.total,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -43,6 +43,7 @@ import { ProductReturnModule } from './product-return/product-return.module';
 import { BehaviorTrackingModule } from './behavior-tracking/behavior-tracking.module';
 import { NotifyRtModule } from './notifyapp/notifyapp.module';
 import { CompanyDayAnalyticModule } from './company-day-analytic/company-day-analytic.module';
+import { SearchCartTrackingModule } from './search-cart-tracking/search-cart-tracking.module';
 import { LineOaMonitorModule } from './line-oa-monitor/line-oa-monitor.module';
 import { envValidationSchema } from './env.validation';
 import { ElasticsearchModule } from './elasticsearch/elasticsearch.module';
@@ -118,6 +119,7 @@ import { WatermarkAuditModule } from './watermark-audit/watermark-audit.module';
     BehaviorTrackingModule,
     NotifyRtModule,
     CompanyDayAnalyticModule,
+    SearchCartTrackingModule,
     LineOaMonitorModule,
     ElasticsearchModule,
     HappyHourModule,

--- a/src/search-cart-tracking/search-cart-tracking.constants.ts
+++ b/src/search-cart-tracking/search-cart-tracking.constants.ts
@@ -1,0 +1,4 @@
+export const SEARCH_CART_TRACKING_KAFKA_CLIENT =
+  'SEARCH_CART_TRACKING_KAFKA_CLIENT';
+
+export const SEARCH_CART_TRACKING_TOPIC = 'search_cart_tracking';

--- a/src/search-cart-tracking/search-cart-tracking.module.ts
+++ b/src/search-cart-tracking/search-cart-tracking.module.ts
@@ -1,0 +1,79 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ClientsModule, Transport } from '@nestjs/microservices';
+import { SEARCH_CART_TRACKING_KAFKA_CLIENT } from './search-cart-tracking.constants';
+import { SearchCartTrackingService } from './search-cart-tracking.service';
+import { FeatureFlagsModule } from '../feature-flags/feature-flags.module';
+
+@Module({
+  imports: [
+    FeatureFlagsModule,
+    ClientsModule.registerAsync([
+      {
+        name: SEARCH_CART_TRACKING_KAFKA_CLIENT,
+        imports: [ConfigModule],
+        inject: [ConfigService],
+        useFactory: (configService: ConfigService) => {
+          try {
+            const brokers = (
+              configService.get<string>('KAFKA_SEARCH_CART_TRACKING_BROKERS') ||
+              configService.get<string>('KAFKA_BROKERS_SECOND') ||
+              'localhost:9093'
+            )
+              .split(',')
+              .map((broker) => broker.trim())
+              .filter(Boolean);
+
+            const groupId =
+              configService.get<string>(
+                'KAFKA_SEARCH_CART_TRACKING_GROUP_ID',
+              ) || 'consumer-search-cart-tracking';
+
+            const clientId =
+              configService.get<string>(
+                'KAFKA_SEARCH_CART_TRACKING_CLIENT_ID',
+              ) || 'backend-ecommerce-search-cart-tracking';
+
+            return {
+              transport: Transport.KAFKA,
+              options: {
+                client: {
+                  clientId,
+                  brokers,
+                  connectionTimeout: 5000,
+                  requestTimeout: 3000,
+                  retry: {
+                    retries: 0,
+                  },
+                },
+                consumer: {
+                  groupId,
+                  allowAutoTopicCreation: false,
+                },
+                subscribe: {
+                  fromBeginning: false,
+                },
+              },
+            };
+          } catch {
+            return {
+              transport: Transport.KAFKA,
+              options: {
+                client: {
+                  clientId: 'search-cart-tracking-fallback',
+                  brokers: ['localhost:9099'],
+                },
+                consumer: {
+                  groupId: 'search-cart-tracking-fallback',
+                },
+              },
+            };
+          }
+        },
+      },
+    ]),
+  ],
+  providers: [SearchCartTrackingService],
+  exports: [SearchCartTrackingService],
+})
+export class SearchCartTrackingModule {}

--- a/src/search-cart-tracking/search-cart-tracking.service.spec.ts
+++ b/src/search-cart-tracking/search-cart-tracking.service.spec.ts
@@ -43,6 +43,7 @@ describe('SearchCartTrackingService', () => {
       service.emitSearchEvent('MEM001', {
         search_query: 'พารา',
         result_count: 5,
+        result_pro_codes: ['P001', 'P002'],
       });
       await jest.advanceTimersByTimeAsync(0);
 
@@ -56,6 +57,7 @@ describe('SearchCartTrackingService', () => {
           mem_code: 'MEM001',
           search_query: 'พารา',
           result_count: 5,
+          result_pro_codes: ['P001', 'P002'],
         }),
       );
     });
@@ -66,6 +68,7 @@ describe('SearchCartTrackingService', () => {
       service.emitSearchEvent('MEM001', {
         search_query: 'zzznotfound123',
         result_count: 0,
+        result_pro_codes: [],
       });
       await jest.advanceTimersByTimeAsync(0);
 
@@ -75,6 +78,7 @@ describe('SearchCartTrackingService', () => {
           event: 'search',
           search_query: 'zzznotfound123',
           result_count: 0,
+          result_pro_codes: [],
         }),
       );
     });
@@ -86,6 +90,7 @@ describe('SearchCartTrackingService', () => {
       service.emitSearchEvent('MEM001', {
         search_query: 'พารา',
         result_count: 5,
+        result_pro_codes: ['P001'],
       });
       await jest.advanceTimersByTimeAsync(0);
 
@@ -99,6 +104,7 @@ describe('SearchCartTrackingService', () => {
 
       service.emitAddToCartEvent('MEM001', {
         pro_code: 'P001',
+        pro_name: 'พาราเซตามอล',
         pro_unit: 'ขวด',
         amount: 2,
         source: 'search',
@@ -112,6 +118,7 @@ describe('SearchCartTrackingService', () => {
           event: 'add_to_cart',
           mem_code: 'MEM001',
           pro_code: 'P001',
+          pro_name: 'พาราเซตามอล',
           pro_unit: 'ขวด',
           amount: 2,
           source: 'search',
@@ -145,6 +152,7 @@ describe('SearchCartTrackingService', () => {
         service.emitSearchEvent('MEM001', {
           search_query: 'พารา',
           result_count: 1,
+          result_pro_codes: ['P001'],
         }),
       ).not.toThrow();
       await jest.advanceTimersByTimeAsync(0);
@@ -161,6 +169,7 @@ describe('SearchCartTrackingService', () => {
       service.emitSearchEvent('MEM001', {
         search_query: 'พารา',
         result_count: 1,
+        result_pro_codes: ['P001'],
       });
 
       // initial attempt + 3 retries with 2s/4s/8s backoff
@@ -176,6 +185,7 @@ describe('SearchCartTrackingService', () => {
       service.emitSearchEvent('MEM001', {
         search_query: 'ฟ้าทะลายโจร',
         result_count: 2,
+        result_pro_codes: ['P002'],
       });
       await jest.advanceTimersByTimeAsync(0);
 

--- a/src/search-cart-tracking/search-cart-tracking.service.spec.ts
+++ b/src/search-cart-tracking/search-cart-tracking.service.spec.ts
@@ -1,0 +1,185 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SearchCartTrackingService } from './search-cart-tracking.service';
+import {
+  SEARCH_CART_TRACKING_KAFKA_CLIENT,
+  SEARCH_CART_TRACKING_TOPIC,
+} from './search-cart-tracking.constants';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+
+describe('SearchCartTrackingService', () => {
+  let service: SearchCartTrackingService;
+  let kafkaClient: { emit: jest.Mock };
+  let featureFlagsService: { getFlag: jest.Mock };
+
+  beforeEach(async () => {
+    kafkaClient = { emit: jest.fn() };
+    featureFlagsService = { getFlag: jest.fn().mockResolvedValue(true) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SearchCartTrackingService,
+        { provide: SEARCH_CART_TRACKING_KAFKA_CLIENT, useValue: kafkaClient },
+        { provide: FeatureFlagsService, useValue: featureFlagsService },
+      ],
+    }).compile();
+
+    service = module.get<SearchCartTrackingService>(
+      SearchCartTrackingService,
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('emitSearchEvent', () => {
+    it('emits a search event to Kafka when the feature flag is enabled', async () => {
+      jest.useFakeTimers();
+
+      service.emitSearchEvent('MEM001', {
+        search_query: 'พารา',
+        result_count: 5,
+      });
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(featureFlagsService.getFlag).toHaveBeenCalledWith(
+        'searchcarttracking',
+      );
+      expect(kafkaClient.emit).toHaveBeenCalledWith(
+        SEARCH_CART_TRACKING_TOPIC,
+        expect.objectContaining({
+          event: 'search',
+          mem_code: 'MEM001',
+          search_query: 'พารา',
+          result_count: 5,
+        }),
+      );
+    });
+
+    it('still emits when result_count is 0 (zero-result search)', async () => {
+      jest.useFakeTimers();
+
+      service.emitSearchEvent('MEM001', {
+        search_query: 'zzznotfound123',
+        result_count: 0,
+      });
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(kafkaClient.emit).toHaveBeenCalledWith(
+        SEARCH_CART_TRACKING_TOPIC,
+        expect.objectContaining({
+          event: 'search',
+          search_query: 'zzznotfound123',
+          result_count: 0,
+        }),
+      );
+    });
+
+    it('does not emit when the feature flag is disabled', async () => {
+      jest.useFakeTimers();
+      featureFlagsService.getFlag.mockResolvedValue(false);
+
+      service.emitSearchEvent('MEM001', {
+        search_query: 'พารา',
+        result_count: 5,
+      });
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(kafkaClient.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('emitAddToCartEvent', () => {
+    it('includes source and search_query when add-to-cart originates from search', async () => {
+      jest.useFakeTimers();
+
+      service.emitAddToCartEvent('MEM001', {
+        pro_code: 'P001',
+        pro_unit: 'ขวด',
+        amount: 2,
+        source: 'search',
+        search_query: 'พารา',
+      });
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(kafkaClient.emit).toHaveBeenCalledWith(
+        SEARCH_CART_TRACKING_TOPIC,
+        expect.objectContaining({
+          event: 'add_to_cart',
+          mem_code: 'MEM001',
+          pro_code: 'P001',
+          pro_unit: 'ขวด',
+          amount: 2,
+          source: 'search',
+          search_query: 'พารา',
+        }),
+      );
+    });
+
+    it('omits source and search_query when add-to-cart did not originate from search', async () => {
+      jest.useFakeTimers();
+
+      service.emitAddToCartEvent('MEM001', {
+        pro_code: 'P001',
+        pro_unit: 'ขวด',
+        amount: 1,
+      });
+      await jest.advanceTimersByTimeAsync(0);
+
+      const [, payload] = kafkaClient.emit.mock.calls[0];
+      expect(payload.source).toBeUndefined();
+      expect(payload.search_query).toBeUndefined();
+    });
+  });
+
+  describe('error handling', () => {
+    it('does not throw when the feature flag lookup fails', async () => {
+      jest.useFakeTimers();
+      featureFlagsService.getFlag.mockRejectedValue(new Error('db down'));
+
+      expect(() =>
+        service.emitSearchEvent('MEM001', {
+          search_query: 'พารา',
+          result_count: 1,
+        }),
+      ).not.toThrow();
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(kafkaClient.emit).not.toHaveBeenCalled();
+    });
+
+    it('retries with exponential backoff then marks Kafka unavailable after maxRetries', async () => {
+      jest.useFakeTimers();
+      kafkaClient.emit.mockImplementation(() => {
+        throw new Error('kafka unreachable');
+      });
+
+      service.emitSearchEvent('MEM001', {
+        search_query: 'พารา',
+        result_count: 1,
+      });
+
+      // initial attempt + 3 retries with 2s/4s/8s backoff
+      await jest.advanceTimersByTimeAsync(0);
+      await jest.advanceTimersByTimeAsync(2000);
+      await jest.advanceTimersByTimeAsync(4000);
+      await jest.advanceTimersByTimeAsync(8000);
+
+      expect(kafkaClient.emit).toHaveBeenCalledTimes(4);
+
+      // subsequent events are skipped while Kafka is marked unavailable
+      kafkaClient.emit.mockClear();
+      service.emitSearchEvent('MEM001', {
+        search_query: 'ฟ้าทะลายโจร',
+        result_count: 2,
+      });
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(kafkaClient.emit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/search-cart-tracking/search-cart-tracking.service.ts
+++ b/src/search-cart-tracking/search-cart-tracking.service.ts
@@ -1,0 +1,133 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ClientKafka } from '@nestjs/microservices';
+import { SEARCH_CART_TRACKING_KAFKA_CLIENT } from './search-cart-tracking.constants';
+import { SEARCH_CART_TRACKING_TOPIC } from './search-cart-tracking.constants';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+
+export interface SearchTrackingEvent {
+  event: 'search';
+  mem_code: string;
+  search_query: string;
+  result_count: number;
+  created_at: string;
+}
+
+export interface AddToCartTrackingEvent {
+  event: 'add_to_cart';
+  mem_code: string;
+  pro_code: string;
+  pro_unit: string;
+  amount: number;
+  source?: string;
+  search_query?: string;
+  created_at: string;
+}
+
+export type SearchCartTrackingEvent =
+  | SearchTrackingEvent
+  | AddToCartTrackingEvent;
+
+@Injectable()
+export class SearchCartTrackingService {
+  private readonly logger = new Logger(SearchCartTrackingService.name);
+  private isKafkaAvailable = true;
+  private readonly maxRetries = 3;
+
+  constructor(
+    @Inject(SEARCH_CART_TRACKING_KAFKA_CLIENT)
+    private readonly kafkaClient: ClientKafka,
+    private readonly featureFlagsService: FeatureFlagsService,
+  ) {}
+
+  emitSearchEvent(
+    memCode: string,
+    payload: { search_query: string; result_count: number },
+  ) {
+    const eventData: SearchTrackingEvent = {
+      event: 'search',
+      mem_code: memCode,
+      search_query: payload.search_query,
+      result_count: payload.result_count,
+      created_at: new Date().toISOString(),
+    };
+    setTimeout(() => void this.safeEmitEvent(eventData), 0);
+  }
+
+  emitAddToCartEvent(
+    memCode: string,
+    payload: {
+      pro_code: string;
+      pro_unit: string;
+      amount: number;
+      source?: string;
+      search_query?: string;
+    },
+  ) {
+    const eventData: AddToCartTrackingEvent = {
+      event: 'add_to_cart',
+      mem_code: memCode,
+      pro_code: payload.pro_code,
+      pro_unit: payload.pro_unit,
+      amount: payload.amount,
+      source: payload.source,
+      search_query: payload.search_query,
+      created_at: new Date().toISOString(),
+    };
+    setTimeout(() => void this.safeEmitEvent(eventData), 0);
+  }
+
+  private async safeEmitEvent(eventData: SearchCartTrackingEvent) {
+    try {
+      const isEnabled =
+        await this.featureFlagsService.getFlag('searchcarttracking');
+      if (!isEnabled) {
+        this.logger.debug(
+          'Search/cart tracking disabled by feature flag, skipping emit',
+        );
+        return;
+      }
+      if (!this.isKafkaAvailable) {
+        this.logger.warn(
+          'Kafka search/cart tracking unavailable, skipping event',
+        );
+        return;
+      }
+      await this.sendEventWithRetry(eventData);
+    } catch (error) {
+      this.logger.error('Failed to emit search/cart tracking event', error);
+    }
+  }
+
+  private async sendEventWithRetry(
+    eventData: SearchCartTrackingEvent,
+    attempt = 1,
+  ): Promise<void> {
+    try {
+      this.kafkaClient.emit(SEARCH_CART_TRACKING_TOPIC, eventData);
+      this.isKafkaAvailable = true;
+    } catch (error) {
+      this.logger.warn(
+        `Search/cart tracking emit failed (attempt ${attempt}/${this.maxRetries}):`,
+        error,
+      );
+      if (attempt <= this.maxRetries) {
+        const delay = Math.pow(2, attempt) * 1000;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        return this.sendEventWithRetry(eventData, attempt + 1);
+      } else {
+        this.isKafkaAvailable = false;
+        this.scheduleReconnect();
+        throw error;
+      }
+    }
+  }
+
+  private scheduleReconnect() {
+    setTimeout(() => {
+      this.logger.log(
+        'Re-enabling Kafka search/cart tracking after cooldown...',
+      );
+      this.isKafkaAvailable = true;
+    }, 60000);
+  }
+}

--- a/src/search-cart-tracking/search-cart-tracking.service.ts
+++ b/src/search-cart-tracking/search-cart-tracking.service.ts
@@ -9,6 +9,7 @@ export interface SearchTrackingEvent {
   mem_code: string;
   search_query: string;
   result_count: number;
+  result_pro_codes: string[];
   created_at: string;
 }
 
@@ -16,6 +17,7 @@ export interface AddToCartTrackingEvent {
   event: 'add_to_cart';
   mem_code: string;
   pro_code: string;
+  pro_name?: string;
   pro_unit: string;
   amount: number;
   source?: string;
@@ -41,13 +43,18 @@ export class SearchCartTrackingService {
 
   emitSearchEvent(
     memCode: string,
-    payload: { search_query: string; result_count: number },
+    payload: {
+      search_query: string;
+      result_count: number;
+      result_pro_codes: string[];
+    },
   ) {
     const eventData: SearchTrackingEvent = {
       event: 'search',
       mem_code: memCode,
       search_query: payload.search_query,
       result_count: payload.result_count,
+      result_pro_codes: payload.result_pro_codes,
       created_at: new Date().toISOString(),
     };
     setTimeout(() => void this.safeEmitEvent(eventData), 0);
@@ -57,6 +64,7 @@ export class SearchCartTrackingService {
     memCode: string,
     payload: {
       pro_code: string;
+      pro_name?: string;
       pro_unit: string;
       amount: number;
       source?: string;
@@ -67,6 +75,7 @@ export class SearchCartTrackingService {
       event: 'add_to_cart',
       mem_code: memCode,
       pro_code: payload.pro_code,
+      pro_name: payload.pro_name,
       pro_unit: payload.pro_unit,
       amount: payload.amount,
       source: payload.source,


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- ECWC-130

### 📌 ประเภทของ PR
- [x] ✨ Feature ใหม่

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
เพิ่มการ track event "ค้นหาสินค้า" และ "เพิ่มสินค้าลงตะกร้า" ส่งไปยัง Kafka topic `search_cart_tracking` เพื่อให้ wangpharma-sale-backend นำไปคำนวณ analytics (ECWC-132/133) เช่น คำค้นหายอดนิยม, คำค้นหาที่ไม่พบสินค้า, อัตราการเพิ่มลงตะกร้าจากผลการค้นหา

### 🛠️ แก้ปัญหานั้นอย่างไร
- เพิ่ม `SearchCartTrackingModule`/`SearchCartTrackingService` ที่ emit event แบบ fire-and-forget ผ่าน `ClientKafka`
- มี feature flag `searchcarttracking` เป็น kill switch และ retry แบบ exponential backoff (สูงสุด 3 ครั้ง) ถ้า emit ไม่สำเร็จ จะ cooldown 60 วินาทีก่อนลองใหม่
- เรียก `emitSearchEvent` ใน `/ecom/search-products` และ `emitAddToCartEvent` ใน `/ecom/product-add-cart`

### 🧪 วิธี Test
1. รัน unit test: `npx jest search-cart-tracking` (8 test cases ผ่านทั้งหมด)
2. เรียก `POST /ecom/search-products` และ `POST /ecom/product-add-cart` ผ่าน Ecommerce frontend แล้วตรวจสอบว่ามี message ใหม่ใน Kafka topic `search_cart_tracking`
3. ลองปิด feature flag `searchcarttracking` แล้วยืนยันว่าไม่มี event ถูก emit

### 🔑 Environment Variables ใหม่
- `KAFKA_SEARCH_CART_TRACKING_BROKERS` (optional, fallback: `KAFKA_BROKERS_SECOND` → `KAFKA_BROKERS` → `localhost:9092`)
- `KAFKA_SEARCH_CART_TRACKING_GROUP_ID` (optional, default: `consumer-search-cart-tracking`)
- `KAFKA_SEARCH_CART_TRACKING_CLIENT_ID` (optional, default: `backend-ecommerce-search-cart-tracking`)