### PR TITLE
🧠 learn-from-reviews: proposed knowledge updates

### DIFF
--- a/.ai/ledger.json
+++ b/.ai/ledger.json
@@ -1,6 +1,6 @@
 {
   "repo": "wangpharma-org/Backend-Ecommerce",
-  "last_run": "2026-05-19",
+  "last_run": "2026-06-15",
   "approvers": [
     "62theories"
   ],
@@ -12,14 +12,19 @@
       "status": "proposed",
       "source_prs": [
         121,
-        137
+        137,
+        157,
+        178
       ],
       "reviewers": [
-        "MossOcelot"
+        "MossOcelot",
+        "62theories",
+        "Sasit-Nine"
       ],
+      "origin": "human",
       "confidence": "high",
       "first_seen": "2026-05-19",
-      "last_seen": "2026-05-19",
+      "last_seen": "2026-05-25",
       "approved_by": null,
       "approved_at": null,
       "promoted_from": "preference"
@@ -86,9 +91,46 @@
       "reviewers": [
         "MossOcelot"
       ],
+      "origin": "human",
       "confidence": "low",
       "first_seen": "2026-05-19",
       "last_seen": "2026-05-19",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "Q-002",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "source_prs": [
+        154
+      ],
+      "reviewers": [
+        "MossOcelot"
+      ],
+      "origin": "human",
+      "confidence": "low",
+      "first_seen": "2026-06-15",
+      "last_seen": "2026-06-15",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "Q-003",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "source_prs": [
+        139
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "origin": "human",
+      "confidence": "low",
+      "first_seen": "2026-06-15",
+      "last_seen": "2026-06-15",
       "approved_by": null,
       "approved_at": null
     }

--- a/.ai/quarantine.md
+++ b/.ai/quarantine.md
@@ -11,3 +11,38 @@ Format per entry: `### Q-NNN <statement>` then **Why:** / **Example:** / **Sourc
 **Promote to convention when:** seen again in ≥1 more PR by another reviewer.
 **Source:** PR#123 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/123
 **Added:** 2026-05-19  **Status:** quarantined (not team-agreed)
+
+### Q-002  Put authorization checks in a Guard or Decorator, not inline in the controller body
+**Why:** PR#154 — reviewer flagged manual `if (!req.user.permission && !isAdmin)` checks scattered in controller methods. This logic is hard to audit and easy to miss on new endpoints. Guards/Decorators are the NestJS-idiomatic pattern and are impossible to forget to add when using a Guard at the controller or method level.
+**Example:**
+```ts
+// ✗ no — easy to omit on new methods, not auditable
+if (req.user.role !== UserRole.Admin) throw new ForbiddenException();
+
+// ✓ use a Guard / custom decorator
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.Admin)
+async myEndpoint() { ... }
+```
+**Promote to convention when:** seen flagged again in ≥1 more PR by a different reviewer.
+**Source:** PR#154 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/154#discussion_r3265220194
+**Added:** 2026-06-15  **Status:** quarantined (1 PR, 1 reviewer)
+
+### Q-003  Avoid N+1 queries — batch-fetch related entities with `In()` then group into a Map
+**Why:** PR#139 — `getAllHotdealsWithProductNames()` called `transformProductWithUnits()` per hotdeal (N×2 DB calls). Reviewer explicitly requested batch fetch with `In([...proCodes])` + grouping into a map, noting the existing `getRewardsByTier` already did this correctly. Same anti-pattern appeared in `getHotdealByProCode()` and `getHotdealInfo()`.
+**Example:**
+```ts
+// ✗ no — N queries inside Promise.all still = N round trips
+const results = await Promise.all(items.map(item =>
+  this.productUnitRepo.findOne({ where: { pro_code: item.pro_code } })
+));
+
+// ✓ batch fetch once, group into Map
+const codes = items.map(i => i.pro_code);
+const units = await this.productUnitRepo.find({ where: { pro_code: In(codes) } });
+const unitMap = new Map(units.map(u => [u.pro_code, u]));
+const results = items.map(item => ({ ...item, unit: unitMap.get(item.pro_code) }));
+```
+**Promote to convention when:** seen flagged again in ≥1 more PR by a different reviewer.
+**Source:** PR#139 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/139#pullrequestreview-4252458762
+**Added:** 2026-06-15  **Status:** quarantined (1 PR, 1 reviewer)


### PR DESCRIPTION
## Summary

This PR is **auto-distilled** from merged-PR review feedback by the `learn-from-reviews` scheduled routine (run 2026-06-15). It is **propose-only** — no item becomes authoritative until @62theories approves this PR (the sole CODEOWNER and team lead whose approval is the team agreement). On merge, a human should flip approved items from `status:"proposed"` / `status:"quarantined"` to `status:"agreed"` and set `approved_by`.

---

## What changed

**37 merged PRs scanned** since last run (2026-05-19). All changes are confined to `.ai/` files.

### R-001 — no `console.log` (existing rule, ledger updated only)

New human corroboration found — ledger `source_prs` and `reviewers` updated; **no change to `rules.md`** (the rule text is already correct):
- PR#157: @62theories (CODEOWNER) CHANGES_REQUESTED — *"แก้จาก console.log เป็น lib ที่ไม่ block IO หน่อยครับ"*
- PR#178: @Sasit-Nine — 3 inline comments: *"เอา console.log ออก"*

R-001 now has 4 source PRs and 3 human reviewers including the CODEOWNER.

### Q-002 — Authorization checks belong in Guards/Decorators (new, quarantined)

- **Source:** PR#154, @MossOcelot (inline review comment)
- **Why quarantine:** 1 PR, 1 reviewer — conservative classification per SKILL.md
- **Promote to convention when:** flagged again in ≥1 more PR by a different reviewer

### Q-003 — Batch-fetch with `In()` + Map to avoid N+1 queries (new, quarantined)

- **Source:** PR#139, @Sasit-Nine (CHANGES_REQUESTED review)
- **Why quarantine:** 1 PR, 1 reviewer — conservative classification per SKILL.md
- **Promote to convention when:** flagged again in ≥1 more PR by a different reviewer

---

## All items are `status:proposed` / `status:quarantined`

`approved_by: null` on every item. Nothing is authoritative until @62theories reviews and approves this PR. On merge, please update each approved item in `ledger.json`:
- `"status": "agreed"`
- `"approved_by": "62theories"`
- `"approved_at": "YYYY-MM-DD"`

Items not approved should be left as-is or removed from `.ai/` files in a follow-up commit before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsffhU4aNzgCGEfTbMcrvg)_