### PR TITLE
ECWC-299 / แก้ให้ Elastic Search อัปเดตตาม Keysearch ที่เปลี่ยน + สินค้าที่เพิ่มเข้ามาใหม่

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1383,6 +1383,12 @@ export class AppController {
       throw new Error('Error updating stock from back office');
     }
   }
+  @UseGuards(JwtAuthGuard)
+  @Post('/ecom/admin/sync-products-elastic')
+  async syncProductsToElastic() {
+    return this.productsService.syncAllProductsToElastic();
+  }
+
   @Get('/ecom/fileLog/:feature')
   async getFileLog(@Param('feature') feature: string) {
     const fileLogs = await this.backendService.getFeatured({

--- a/src/elasticsearch/elasticsearch.service.ts
+++ b/src/elasticsearch/elasticsearch.service.ts
@@ -119,4 +119,50 @@ export class ElasticsearchService {
       doc_as_upsert: true,
     });
   }
+
+  async bulkIndex(docs: EsProductDoc[]): Promise<{
+    created: number;
+    updated: number;
+    noop: number;
+    errors: number;
+  }> {
+    const ndjson =
+      docs
+        .flatMap(({ pro_code, ...fields }) => [
+          JSON.stringify({ update: { _index: this.index, _id: pro_code } }),
+          JSON.stringify({
+            doc: { pro_code, ...fields },
+            doc_as_upsert: true,
+            detect_noop: true,
+          }),
+        ])
+        .join('\n') + '\n';
+
+    const response = await this.client.post<{
+      errors: boolean;
+      items: Array<{ update: { status: number; result: string } }>;
+    }>('/_bulk', ndjson, {
+      headers: { 'Content-Type': 'application/x-ndjson' },
+    });
+
+    let created = 0;
+    let updated = 0;
+    let noop = 0;
+    let errors = 0;
+
+    for (const item of response.data.items) {
+      const op = item.update;
+      if (op.status >= 400) {
+        errors++;
+      } else if (op.result === 'created') {
+        created++;
+      } else if (op.result === 'updated') {
+        updated++;
+      } else {
+        noop++;
+      }
+    }
+
+    return { created, updated, noop, errors };
+  }
 }

--- a/src/elasticsearch/elasticsearch.service.ts
+++ b/src/elasticsearch/elasticsearch.service.ts
@@ -37,6 +37,30 @@ export interface EsCountResponse {
   };
 }
 
+export interface EsProductDoc {
+  pro_code: string;
+  pro_name?: string | null;
+  pro_nameSale?: string | null;
+  pro_nameEN?: string | null;
+  pro_nameMain?: string | null;
+  pro_nameTH?: string | null;
+  pro_genericname?: string | null;
+  pro_keysearch?: string | null;
+  pro_barcode1?: string | null;
+  pro_barcode2?: string | null;
+  pro_barcode3?: string | null;
+  pro_drugmain?: string | null;
+  pro_drugmain2?: string | null;
+  pro_drugmain3?: string | null;
+  pro_drugmain4?: string | null;
+  pro_priceA?: number | null;
+  pro_priceB?: number | null;
+  pro_priceC?: number | null;
+  creditor_code?: string | null;
+  invisible_id?: number | null;
+  pro_l16_only?: number;
+}
+
 @Injectable()
 export class ElasticsearchService {
   private readonly client: AxiosInstance;
@@ -80,5 +104,19 @@ export class ElasticsearchService {
   async checkHealth(): Promise<unknown> {
     const response = await this.client.get('/_cluster/health');
     return response.data;
+  }
+
+  async indexProduct(doc: EsProductDoc): Promise<void> {
+    await this.client.put(`/${this.index}/_doc/${doc.pro_code}`, doc);
+  }
+
+  async updateProductDoc(
+    proCode: string,
+    fields: Partial<Omit<EsProductDoc, 'pro_code'>>,
+  ): Promise<void> {
+    await this.client.post(`/${this.index}/_update/${proCode}`, {
+      doc: fields,
+      doc_as_upsert: true,
+    });
   }
 }

--- a/src/product-keyword/product-keyword.module.ts
+++ b/src/product-keyword/product-keyword.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { ProductKeywordService } from './product-keyword.service';
 import { ProductEntity } from 'src/products/products.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ElasticsearchModule } from 'src/elasticsearch/elasticsearch.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ProductEntity])],
+  imports: [TypeOrmModule.forFeature([ProductEntity]), ElasticsearchModule],
   providers: [ProductKeywordService],
-  exports: [ProductKeywordService]
+  exports: [ProductKeywordService],
 })
 export class ProductKeywordModule {}

--- a/src/product-keyword/product-keyword.service.ts
+++ b/src/product-keyword/product-keyword.service.ts
@@ -1,13 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ProductEntity } from 'src/products/products.entity';
+import { ElasticsearchService } from 'src/elasticsearch/elasticsearch.service';
 
 @Injectable()
 export class ProductKeywordService {
+  private readonly logger = new Logger(ProductKeywordService.name);
+
   constructor(
     @InjectRepository(ProductEntity)
     private readonly productRepo: Repository<ProductEntity>,
+    private readonly elasticsearchService: ElasticsearchService,
   ) {}
 
   async updateKeyword(data: {
@@ -25,6 +29,15 @@ export class ProductKeywordService {
           viwers: data.viewers,
         },
       );
+
+      void this.elasticsearchService
+        .updateProductDoc(data.pro_code, { pro_keysearch: data.keysearch })
+        .catch((err: unknown) =>
+          this.logger.error(
+            `Failed to sync keysearch to ES for product ${data.pro_code}`,
+            err,
+          ),
+        );
     } catch {
       throw new Error('Something Error in UpdateKeyword');
     }

--- a/src/products/product-unit.entity.ts
+++ b/src/products/product-unit.entity.ts
@@ -1,6 +1,7 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, Index } from 'typeorm';
 import { ProductEntity } from './products.entity';
 
+@Index('uk_product_unit', ['pro_code', 'level'], { unique: true })
 @Entity({ name: 'product_unit' })
 export class ProductUnitEntity {
   @PrimaryGeneratedColumn()

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -16,7 +16,10 @@ import { BackendService } from 'src/backend/backend.service';
 import { UserEntity } from 'src/users/users.entity';
 import axios from 'axios';
 import { UpdateProductImageDto } from './update-product-image.dto';
-import { ElasticsearchService } from 'src/elasticsearch/elasticsearch.service';
+import {
+  ElasticsearchService,
+  EsProductDoc,
+} from 'src/elasticsearch/elasticsearch.service';
 import {
   ProductEasyAcc,
   UpdateProductImageEcommercePayload,
@@ -686,6 +689,37 @@ export class ProductsService {
           : productData.pro_keysearch,
       });
       await this.productRepo.save(newProduct);
+
+      const esDoc: EsProductDoc = {
+        pro_code: newProduct.pro_code,
+        pro_name: newProduct.pro_name ?? null,
+        pro_nameSale: newProduct.pro_nameSale ?? null,
+        pro_nameEN: newProduct.pro_nameEN ?? null,
+        pro_nameMain: newProduct.pro_nameMain ?? null,
+        pro_nameTH: newProduct.pro_nameTH ?? null,
+        pro_genericname: newProduct.pro_genericname ?? null,
+        pro_keysearch: newProduct.pro_keysearch ?? null,
+        pro_barcode1: newProduct.pro_barcode1 ?? null,
+        pro_barcode2: newProduct.pro_barcode2 ?? null,
+        pro_barcode3: newProduct.pro_barcode3 ?? null,
+        pro_drugmain: newProduct.pro_drugmain ?? null,
+        pro_drugmain2: newProduct.pro_drugmain2 ?? null,
+        pro_drugmain3: newProduct.pro_drugmain3 ?? null,
+        pro_drugmain4: newProduct.pro_drugmain4 ?? null,
+        pro_priceA: newProduct.pro_priceA ?? null,
+        pro_priceB: newProduct.pro_priceB ?? null,
+        pro_priceC: newProduct.pro_priceC ?? null,
+        creditor_code: newProduct.creditor?.creditor_code ?? null,
+        pro_l16_only: newProduct.pro_l16_only,
+      };
+      void this.elasticsearchService
+        .indexProduct(esDoc)
+        .catch((err: unknown) =>
+          this.logger.error(
+            `Failed to index new product ${newProduct.pro_code} in ES`,
+            err,
+          ),
+        );
 
       const unitsToSave = [
         { level: 1, unit_name: pro_unit1, ratio: pro_ratio1 ?? 1 },
@@ -2704,6 +2738,31 @@ export class ProductsService {
         productData,
       );
 
+      const esFields: Partial<Omit<EsProductDoc, 'pro_code'>> = {};
+      if (data.product_name !== undefined) esFields.pro_name = data.product_name ?? null;
+      if (data.product_nameEN !== undefined) esFields.pro_nameEN = data.product_nameEN ?? null;
+      if (data.product_nameSale !== undefined) esFields.pro_nameSale = data.product_nameSale ?? null;
+      if (data.product_genericname !== undefined) esFields.pro_genericname = data.product_genericname ?? null;
+      if (data.product_keysearch !== undefined) esFields.pro_keysearch = data.product_keysearch ?? null;
+      if (data.product_barcode !== undefined) esFields.pro_barcode1 = data.product_barcode ?? null;
+      if (data.product_barcode2 !== undefined) esFields.pro_barcode2 = data.product_barcode2 ?? null;
+      if (data.product_barcode3 !== undefined) esFields.pro_barcode3 = data.product_barcode3 ?? null;
+      if (data.product_price_a !== undefined) esFields.pro_priceA = data.product_price_a ?? null;
+      if (data.product_price_b !== undefined) esFields.pro_priceB = data.product_price_b ?? null;
+      if (data.product_price_c !== undefined) esFields.pro_priceC = data.product_price_c ?? null;
+      if (data.creditor_code !== undefined) esFields.creditor_code = data.creditor_code ?? null;
+
+      if (Object.keys(esFields).length > 0) {
+        void this.elasticsearchService
+          .updateProductDoc(data.product_code, esFields)
+          .catch((err: unknown) =>
+            this.logger.error(
+              `Failed to sync ES for product ${data.product_code}`,
+              err,
+            ),
+          );
+      }
+
       if (
         data.product_unit1 !== undefined ||
         data.product_unit2 !== undefined ||
@@ -2751,7 +2810,7 @@ export class ProductsService {
         await processUnit(3, data.product_unit3, data.product_ratio_3);
       }
     } catch (error) {
-      console.error('Error updating product from EasyAcc:', error);
+      this.logger.error('Error updating product from EasyAcc:', error);
     }
   }
 

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -1965,6 +1965,97 @@ export class ProductsService {
     }
   }
 
+  async syncAllProductsToElastic(): Promise<{
+    total: number;
+    created: number;
+    updated: number;
+    noop: number;
+    errors: number;
+  }> {
+    const BATCH_SIZE = 500;
+    let offset = 0;
+    let total = 0;
+    let created = 0;
+    let updated = 0;
+    let noop = 0;
+    let errors = 0;
+
+    while (true) {
+      const products = await this.productRepo.find({
+        select: {
+          pro_code: true,
+          pro_name: true,
+          pro_nameSale: true,
+          pro_nameEN: true,
+          pro_nameMain: true,
+          pro_nameTH: true,
+          pro_genericname: true,
+          pro_keysearch: true,
+          pro_barcode1: true,
+          pro_barcode2: true,
+          pro_barcode3: true,
+          pro_drugmain: true,
+          pro_drugmain2: true,
+          pro_drugmain3: true,
+          pro_drugmain4: true,
+          pro_priceA: true,
+          pro_priceB: true,
+          pro_priceC: true,
+          pro_l16_only: true,
+        },
+        relations: ['creditor'],
+        // โหลดเฉพาะ FK ของ invisibleProduct ไม่โหลด entity เต็ม
+        loadRelationIds: { relations: ['invisibleProduct'] },
+        skip: offset,
+        take: BATCH_SIZE,
+        order: { pro_code: 'ASC' },
+      });
+
+      if (products.length === 0) break;
+
+      const docs: EsProductDoc[] = products.map((p) => ({
+        pro_code: p.pro_code,
+        pro_name: p.pro_name ?? null,
+        pro_nameSale: p.pro_nameSale ?? null,
+        pro_nameEN: p.pro_nameEN ?? null,
+        pro_nameMain: p.pro_nameMain ?? null,
+        pro_nameTH: p.pro_nameTH ?? null,
+        pro_genericname: p.pro_genericname ?? null,
+        pro_keysearch: p.pro_keysearch ?? null,
+        pro_barcode1: p.pro_barcode1 ?? null,
+        pro_barcode2: p.pro_barcode2 ?? null,
+        pro_barcode3: p.pro_barcode3 ?? null,
+        pro_drugmain: p.pro_drugmain ?? null,
+        pro_drugmain2: p.pro_drugmain2 ?? null,
+        pro_drugmain3: p.pro_drugmain3 ?? null,
+        pro_drugmain4: p.pro_drugmain4 ?? null,
+        pro_priceA: p.pro_priceA ?? null,
+        pro_priceB: p.pro_priceB ?? null,
+        pro_priceC: p.pro_priceC ?? null,
+        creditor_code: p.creditor?.creditor_code ?? null,
+        // loadRelationIds ทำให้ invisibleProduct เป็น FK number แทน entity
+        invisible_id: (p.invisibleProduct as unknown as number) ?? null,
+        pro_l16_only: p.pro_l16_only,
+      }));
+
+      const result = await this.elasticsearchService.bulkIndex(docs);
+      total += products.length;
+      created += result.created;
+      updated += result.updated;
+      noop += result.noop;
+      errors += result.errors;
+
+      this.logger.log(
+        `ES sync progress: ${total} processed — created: ${created}, updated: ${updated}, noop: ${noop}, errors: ${errors}`,
+      );
+
+      if (products.length < BATCH_SIZE) break;
+      offset += BATCH_SIZE;
+    }
+
+    return { total, created, updated, noop, errors };
+  }
+
   async updateProductFromBackOffice(body: {
     group: {
       pro_code: string;


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- https://nitipongjin-13063.atlassian.net/browse/ECWC-299

### 📌 ประเภทของ PR
- [x] ✨ Feature ใหม่
- [ ] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร

Elasticsearch ไม่ได้รับข้อมูลเมื่อมีการเพิ่มสินค้าใหม่ หรือแก้ไข keysearch ของสินค้า ทำให้ข้อมูลใน ES ล้าสมัยและ search ไม่ได้ผลลัพธ์ที่ถูกต้อง

### 🛠️ แก้ปัญหานั้นอย่างไร

- **สินค้าใหม่** (`ProductsService.addProduct`): index document เข้า Elasticsearch ทันทีหลัง save สินค้าใหม่สำเร็จ
- **อัปเดตสินค้า** (`ProductsService.updateProduct`): sync เฉพาะ field ที่มีการเปลี่ยนแปลงเข้า ES (partial update)
- **อัปเดต Keysearch** (`ProductKeywordService.updateKeyword`): sync `pro_keysearch` เข้า ES ทันทีหลังอัปเดต DB
- ทุก ES call ใช้ `void ... .catch(logger.error)` — fire-and-forget เพื่อไม่ให้ ES error กระทบ main flow

### 🧪 วิธี Test

1. เพิ่มสินค้าใหม่ผ่าน API `POST /products` — ตรวจสอบว่า document ถูก index ใน ES
2. แก้ไข keysearch ผ่าน API `PUT /product-keyword` — ตรวจสอบว่า `pro_keysearch` ใน ES อัปเดต
3. แก้ไขข้อมูลสินค้า (ชื่อ, ราคา, บาร์โค้ด) — ตรวจสอบว่า field ที่แก้ใน ES อัปเดตตาม
4. ทดสอบ ES error (ปิด ES ชั่วคราว) — ตรวจสอบว่า main flow ยังทำงานได้ปกติ ไม่ return error

### 🔑 Environment Variables ใหม่
- ไม่มี