### PR TITLE
feat(ECWC-339): Delivery Preference setting สำหรับลูกค้าเส้นทางหาดใหญ่

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -54,6 +54,7 @@ import { ReviewRequestModule } from './review-request/review-request.module';
 import { ProductRequestModule } from './product-request/product-request.module';
 import { HappyHourModule } from './happy-hour/happy-hour.module';
 import { WatermarkAuditModule } from './watermark-audit/watermark-audit.module';
+import { DeliveryPreferenceModule } from './delivery-preference/delivery-preference.module';
 
 @Module({
   imports: [
@@ -121,6 +122,7 @@ import { WatermarkAuditModule } from './watermark-audit/watermark-audit.module';
     LineOaMonitorModule,
     ElasticsearchModule,
     HappyHourModule,
+    DeliveryPreferenceModule,
     MailerModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/src/delivery-preference/customer-delivery-preference.entity.ts
+++ b/src/delivery-preference/customer-delivery-preference.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryColumn, Column, UpdateDateColumn } from 'typeorm';
+
+@Entity({ name: 'customer_delivery_preference' })
+export class CustomerDeliveryPreferenceEntity {
+  @PrimaryColumn({ length: 50 })
+  mem_code: string;
+
+  @Column({ length: 30 })
+  preference: string;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/src/delivery-preference/delivery-preference-admin.controller.ts
+++ b/src/delivery-preference/delivery-preference-admin.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { DeliveryPreferenceService } from './delivery-preference.service';
+
+@UseGuards(JwtAuthGuard)
+@Controller('admin/delivery-preference')
+export class DeliveryPreferenceAdminController {
+  constructor(
+    private readonly deliveryPreferenceService: DeliveryPreferenceService,
+  ) {}
+
+  @Get('customers')
+  async listCustomers(
+    @Query('keyword') keyword?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.deliveryPreferenceService.listEligibleCustomers({
+      keyword,
+      page: page ? Number(page) : undefined,
+      limit: limit ? Number(limit) : undefined,
+    });
+  }
+
+  @Get('stats')
+  async getEligibleRouteStats() {
+    return this.deliveryPreferenceService.getEligibleRouteStats();
+  }
+}

--- a/src/delivery-preference/delivery-preference.constants.ts
+++ b/src/delivery-preference/delivery-preference.constants.ts
@@ -1,0 +1,17 @@
+export const DELIVERY_PREFERENCE_FEATURE_FLAG = 'delivery_preference_hatyai';
+
+export const DELIVERY_PREFERENCE_ENABLED_ROUTES = ['L1-1', 'L23'];
+
+export const DELIVERY_PREFERENCE_OPTIONS = [
+  { key: 'van_only', label: 'เฉพาะรถวังเภสัช' },
+  { key: 'van_or_delivery', label: 'รถวังเภสัช หรือ ขนส่งทั่วไป' },
+  { key: 'delivery_always', label: 'ขนส่งทั่วไปเท่านั้น' },
+] as const;
+
+export type DeliveryPreferenceKey =
+  (typeof DELIVERY_PREFERENCE_OPTIONS)[number]['key'];
+
+export const DELIVERY_PREFERENCE_KEYS: DeliveryPreferenceKey[] =
+  DELIVERY_PREFERENCE_OPTIONS.map((option) => option.key);
+
+export const WANG_SHIPPING_TYPE = 'wang';

--- a/src/delivery-preference/delivery-preference.controller.ts
+++ b/src/delivery-preference/delivery-preference.controller.ts
@@ -1,0 +1,44 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Put,
+  Req,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { JwtPayload } from '../app.controller';
+import { DeliveryPreferenceService } from './delivery-preference.service';
+import { SetPreferenceDto } from './dto/set-preference.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('ecom/delivery-preference')
+export class DeliveryPreferenceController {
+  constructor(
+    private readonly deliveryPreferenceService: DeliveryPreferenceService,
+  ) {}
+
+  @Get('checkout-options')
+  async getCheckoutOptions(@Req() req: Request & { user: JwtPayload }) {
+    return this.deliveryPreferenceService.getCheckoutOptions(
+      req.user.mem_code,
+      req.user.mem_route,
+    );
+  }
+
+  @Put('preference')
+  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
+  async setPreference(
+    @Req() req: Request & { user: JwtPayload },
+    @Body() dto: SetPreferenceDto,
+  ) {
+    return this.deliveryPreferenceService.setCustomerPreference(
+      req.user.mem_code,
+      req.user.mem_route,
+      dto.preference,
+    );
+  }
+}

--- a/src/delivery-preference/delivery-preference.module.ts
+++ b/src/delivery-preference/delivery-preference.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FeatureFlagsModule } from '../feature-flags/feature-flags.module';
+import { UserEntity } from '../users/users.entity';
+import { DeliveryPreferenceService } from './delivery-preference.service';
+import { DeliveryPreferenceController } from './delivery-preference.controller';
+import { DeliveryPreferenceAdminController } from './delivery-preference-admin.controller';
+import { CustomerDeliveryPreferenceEntity } from './customer-delivery-preference.entity';
+
+@Module({
+  imports: [
+    FeatureFlagsModule,
+    TypeOrmModule.forFeature([UserEntity, CustomerDeliveryPreferenceEntity]),
+  ],
+  providers: [DeliveryPreferenceService],
+  controllers: [
+    DeliveryPreferenceController,
+    DeliveryPreferenceAdminController,
+  ],
+  exports: [DeliveryPreferenceService],
+})
+export class DeliveryPreferenceModule {}

--- a/src/delivery-preference/delivery-preference.service.spec.ts
+++ b/src/delivery-preference/delivery-preference.service.spec.ts
@@ -1,0 +1,274 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DeliveryPreferenceService } from './delivery-preference.service';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { UserEntity } from '../users/users.entity';
+import { CustomerDeliveryPreferenceEntity } from './customer-delivery-preference.entity';
+import { DELIVERY_PREFERENCE_OPTIONS } from './delivery-preference.constants';
+
+describe('DeliveryPreferenceService', () => {
+  let service: DeliveryPreferenceService;
+  let featureFlagsService: { getFlag: jest.Mock };
+  let userRepo: {
+    createQueryBuilder: jest.Mock;
+    findOne: jest.Mock;
+    count: jest.Mock;
+  };
+  let userQueryBuilder: {
+    select: jest.Mock;
+    where: jest.Mock;
+    andWhere: jest.Mock;
+    orderBy: jest.Mock;
+    skip: jest.Mock;
+    take: jest.Mock;
+    getManyAndCount: jest.Mock;
+  };
+  let cacheRepo: {
+    createQueryBuilder: jest.Mock;
+    find: jest.Mock;
+    findOne: jest.Mock;
+    upsert: jest.Mock;
+  };
+  let cacheQueryBuilder: {
+    innerJoin: jest.Mock;
+    select: jest.Mock;
+    addSelect: jest.Mock;
+    where: jest.Mock;
+    groupBy: jest.Mock;
+    getRawMany: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    featureFlagsService = { getFlag: jest.fn() };
+    userQueryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+    userRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(userQueryBuilder),
+      findOne: jest.fn().mockResolvedValue(null),
+      count: jest.fn().mockResolvedValue(0),
+    };
+    cacheQueryBuilder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([]),
+    };
+    cacheRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(cacheQueryBuilder),
+      find: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn().mockResolvedValue(null),
+      upsert: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeliveryPreferenceService,
+        { provide: FeatureFlagsService, useValue: featureFlagsService },
+        { provide: getRepositoryToken(UserEntity), useValue: userRepo },
+        {
+          provide: getRepositoryToken(CustomerDeliveryPreferenceEntity),
+          useValue: cacheRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DeliveryPreferenceService>(DeliveryPreferenceService);
+  });
+
+  describe('getCheckoutOptions', () => {
+    it('is disabled when the feature flag is off', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(false);
+      const result = await service.getCheckoutOptions('mem-001', 'L1-1');
+      expect(result).toEqual({
+        enabled: false,
+        options: [],
+        currentPreference: null,
+      });
+      expect(cacheRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('is disabled when mem_route is not in the enabled routes', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(true);
+      const result = await service.getCheckoutOptions('mem-001', 'L16');
+      expect(result).toEqual({
+        enabled: false,
+        options: [],
+        currentPreference: null,
+      });
+    });
+
+    it('is enabled for an eligible route when the flag is on', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(true);
+      const result = await service.getCheckoutOptions('mem-001', 'L23');
+      expect(result.enabled).toBe(true);
+      expect(result.options).toEqual([...DELIVERY_PREFERENCE_OPTIONS]);
+    });
+
+    it('returns the cached preference when present', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(true);
+      cacheRepo.findOne.mockResolvedValue({
+        mem_code: 'mem-001',
+        preference: 'van_only',
+      });
+      const result = await service.getCheckoutOptions('mem-001', 'L23');
+      expect(result.currentPreference).toBe('van_only');
+    });
+  });
+
+  describe('setCustomerPreference', () => {
+    it('rejects when the feature flag is off', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(false);
+      const result = await service.setCustomerPreference(
+        'mem-001',
+        'L1-1',
+        'van_only',
+      );
+      expect(result).toEqual({ ok: false, reason: 'not_eligible' });
+      expect(cacheRepo.upsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects when mem_route is not eligible', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(true);
+      const result = await service.setCustomerPreference(
+        'mem-001',
+        'L16',
+        'van_only',
+      );
+      expect(result).toEqual({ ok: false, reason: 'not_eligible' });
+    });
+
+    it('rejects an unknown preference key', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(true);
+      const result = await service.setCustomerPreference(
+        'mem-001',
+        'L1-1',
+        'not_a_real_key',
+      );
+      expect(result).toEqual({ ok: false, reason: 'invalid_key' });
+    });
+
+    it('saves and returns ok when eligible and the key is valid', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(true);
+      const result = await service.setCustomerPreference(
+        'mem-001',
+        'L23',
+        'delivery_always',
+      );
+      expect(result).toEqual({ ok: true });
+      expect(cacheRepo.upsert).toHaveBeenCalledWith(
+        { mem_code: 'mem-001', preference: 'delivery_always' },
+        ['mem_code'],
+      );
+    });
+  });
+
+  describe('listEligibleCustomers', () => {
+    it('lists eligible-route customers without requiring a keyword', async () => {
+      userQueryBuilder.getManyAndCount.mockResolvedValue([
+        [{ mem_code: 'mem-001', mem_nameSite: 'ร้านทดสอบ', mem_route: 'L1-1' }],
+        1,
+      ]);
+      const result = await service.listEligibleCustomers();
+      expect(userQueryBuilder.andWhere).not.toHaveBeenCalled();
+      expect(result.items).toEqual([
+        {
+          mem_code: 'mem-001',
+          mem_nameSite: 'ร้านทดสอบ',
+          mem_route: 'L1-1',
+          currentPreference: null,
+        },
+      ]);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+    });
+
+    it('marks which customers already have a preference set', async () => {
+      userQueryBuilder.getManyAndCount.mockResolvedValue([
+        [
+          {
+            mem_code: 'mem-001',
+            mem_nameSite: 'ร้านทดสอบ 1',
+            mem_route: 'L1-1',
+          },
+          {
+            mem_code: 'mem-002',
+            mem_nameSite: 'ร้านทดสอบ 2',
+            mem_route: 'L23',
+          },
+        ],
+        2,
+      ]);
+      cacheRepo.find.mockResolvedValue([
+        { mem_code: 'mem-001', preference: 'van_only' },
+      ]);
+      const result = await service.listEligibleCustomers();
+      expect(result.items[0].currentPreference).toBe('van_only');
+      expect(result.items[1].currentPreference).toBeNull();
+    });
+
+    it('applies the keyword as an additional filter when provided', async () => {
+      userQueryBuilder.getManyAndCount.mockResolvedValue([[], 0]);
+      await service.listEligibleCustomers({ keyword: 'mem' });
+      expect(userQueryBuilder.andWhere).toHaveBeenCalledWith(
+        '(u.mem_code LIKE :kw OR u.mem_nameSite LIKE :kw)',
+        { kw: '%mem%' },
+      );
+    });
+
+    it('paginates using page and limit', async () => {
+      userQueryBuilder.getManyAndCount.mockResolvedValue([[], 0]);
+      const result = await service.listEligibleCustomers({
+        page: 2,
+        limit: 10,
+      });
+      expect(userQueryBuilder.skip).toHaveBeenCalledWith(10);
+      expect(userQueryBuilder.take).toHaveBeenCalledWith(10);
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(10);
+    });
+  });
+
+  describe('getEligibleRouteStats', () => {
+    it('returns zero counts when no customer has a preference set', async () => {
+      userRepo.count.mockResolvedValue(5);
+      cacheQueryBuilder.getRawMany.mockResolvedValue([]);
+      const result = await service.getEligibleRouteStats();
+      expect(result.totalEligibleCustomers).toBe(5);
+      expect(result.totalWithPreferenceSet).toBe(0);
+      expect(result.breakdown).toEqual(
+        DELIVERY_PREFERENCE_OPTIONS.map((o) => ({
+          key: o.key,
+          label: o.label,
+          count: 0,
+        })),
+      );
+    });
+
+    it('maps raw counts onto each known preference option', async () => {
+      userRepo.count.mockResolvedValue(10);
+      cacheQueryBuilder.getRawMany.mockResolvedValue([
+        { preference: 'van_only', count: '3' },
+        { preference: 'delivery_always', count: '2' },
+      ]);
+      const result = await service.getEligibleRouteStats();
+      expect(result.totalEligibleCustomers).toBe(10);
+      expect(result.totalWithPreferenceSet).toBe(5);
+      expect(result.breakdown.find((b) => b.key === 'van_only')?.count).toBe(3);
+      expect(
+        result.breakdown.find((b) => b.key === 'delivery_always')?.count,
+      ).toBe(2);
+      expect(
+        result.breakdown.find((b) => b.key === 'van_or_delivery')?.count,
+      ).toBe(0);
+    });
+  });
+});

--- a/src/delivery-preference/delivery-preference.service.ts
+++ b/src/delivery-preference/delivery-preference.service.ts
@@ -1,0 +1,213 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { UserEntity } from '../users/users.entity';
+import { CustomerDeliveryPreferenceEntity } from './customer-delivery-preference.entity';
+import {
+  DELIVERY_PREFERENCE_ENABLED_ROUTES,
+  DELIVERY_PREFERENCE_FEATURE_FLAG,
+  DELIVERY_PREFERENCE_KEYS,
+  DELIVERY_PREFERENCE_OPTIONS,
+  DeliveryPreferenceKey,
+} from './delivery-preference.constants';
+
+export interface CheckoutOptionsResult {
+  enabled: boolean;
+  options: { key: string; label: string }[];
+  currentPreference: DeliveryPreferenceKey | null;
+}
+
+export interface SetPreferenceResult {
+  ok: boolean;
+  reason?: 'not_eligible' | 'invalid_key';
+}
+
+export interface CustomerSearchResult {
+  mem_code: string;
+  mem_nameSite: string;
+  mem_route: string | null;
+  currentPreference: string | null;
+}
+
+export interface PaginatedCustomerList {
+  items: CustomerSearchResult[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export interface PreferenceBreakdownEntry {
+  key: string;
+  label: string;
+  count: number;
+}
+
+export interface EligibleRouteStatsResult {
+  totalEligibleCustomers: number;
+  totalWithPreferenceSet: number;
+  breakdown: PreferenceBreakdownEntry[];
+}
+
+@Injectable()
+export class DeliveryPreferenceService {
+  constructor(
+    private readonly featureFlagsService: FeatureFlagsService,
+    @InjectRepository(UserEntity)
+    private readonly userRepo: Repository<UserEntity>,
+    @InjectRepository(CustomerDeliveryPreferenceEntity)
+    private readonly cacheRepo: Repository<CustomerDeliveryPreferenceEntity>,
+  ) {}
+
+  isRouteEligible(memRoute?: string | null): boolean {
+    return !!memRoute && DELIVERY_PREFERENCE_ENABLED_ROUTES.includes(memRoute);
+  }
+
+  async getCheckoutOptions(
+    memCode: string,
+    memRoute?: string | null,
+  ): Promise<CheckoutOptionsResult> {
+    const flagEnabled = await this.featureFlagsService.getFlag(
+      DELIVERY_PREFERENCE_FEATURE_FLAG,
+    );
+    if (!flagEnabled || !this.isRouteEligible(memRoute)) {
+      return { enabled: false, options: [], currentPreference: null };
+    }
+
+    const cached = await this.cacheRepo.findOne({
+      where: { mem_code: memCode },
+    });
+
+    return {
+      enabled: true,
+      options: [...DELIVERY_PREFERENCE_OPTIONS],
+      currentPreference:
+        (cached?.preference as DeliveryPreferenceKey | undefined) ?? null,
+    };
+  }
+
+  private validatePreferenceKey(
+    memRoute: string | undefined | null,
+    preferenceKey: string,
+  ): SetPreferenceResult | null {
+    if (!this.isRouteEligible(memRoute)) {
+      return { ok: false, reason: 'not_eligible' };
+    }
+    if (
+      !DELIVERY_PREFERENCE_KEYS.includes(preferenceKey as DeliveryPreferenceKey)
+    ) {
+      return { ok: false, reason: 'invalid_key' };
+    }
+    return null;
+  }
+
+  async setCustomerPreference(
+    memCode: string,
+    memRoute: string | undefined | null,
+    preferenceKey: string,
+  ): Promise<SetPreferenceResult> {
+    const flagEnabled = await this.featureFlagsService.getFlag(
+      DELIVERY_PREFERENCE_FEATURE_FLAG,
+    );
+    if (!flagEnabled) {
+      return { ok: false, reason: 'not_eligible' };
+    }
+    const invalid = this.validatePreferenceKey(memRoute, preferenceKey);
+    if (invalid) {
+      return invalid;
+    }
+    await this.cacheRepo.upsert(
+      { mem_code: memCode, preference: preferenceKey },
+      ['mem_code'],
+    );
+    return { ok: true };
+  }
+
+  /**
+   * รายชื่อลูกค้าในเส้นทางหาดใหญ่ (DELIVERY_PREFERENCE_ENABLED_ROUTES) เสมอ
+   * — keyword เป็นตัวกรองเพิ่มเติม (ไม่บังคับ) ไม่ต้องค้นหาก่อนถึงจะเห็นรายชื่อ
+   */
+  async listEligibleCustomers(
+    params: { keyword?: string; page?: number; limit?: number } = {},
+  ): Promise<PaginatedCustomerList> {
+    const page = Math.max(1, params.page ?? 1);
+    const limit = Math.min(100, Math.max(1, params.limit ?? 20));
+    const trimmed = params.keyword?.trim();
+
+    const qb = this.userRepo
+      .createQueryBuilder('u')
+      .select(['u.mem_code', 'u.mem_nameSite', 'u.mem_route'])
+      .where('u.mem_route IN (:...routes)', {
+        routes: DELIVERY_PREFERENCE_ENABLED_ROUTES,
+      });
+
+    if (trimmed) {
+      qb.andWhere('(u.mem_code LIKE :kw OR u.mem_nameSite LIKE :kw)', {
+        kw: `%${trimmed}%`,
+      });
+    }
+
+    const [users, total] = await qb
+      .orderBy('u.mem_code', 'ASC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+
+    const memCodes = users.map((u) => u.mem_code);
+    const cachedPreferences = memCodes.length
+      ? await this.cacheRepo.find({ where: { mem_code: In(memCodes) } })
+      : [];
+    const preferenceByCode = new Map(
+      cachedPreferences.map((p) => [p.mem_code, p.preference]),
+    );
+
+    return {
+      items: users.map((u) => ({
+        mem_code: u.mem_code,
+        mem_nameSite: u.mem_nameSite,
+        mem_route: u.mem_route ?? null,
+        currentPreference: preferenceByCode.get(u.mem_code) ?? null,
+      })),
+      total,
+      page,
+      limit,
+    };
+  }
+
+  /**
+   * Breakdown ของ preference เฉพาะลูกค้าที่อยู่ในเส้นทางหาดใหญ่ (mem_route
+   * ใน DELIVERY_PREFERENCE_ENABLED_ROUTES)
+   */
+  async getEligibleRouteStats(): Promise<EligibleRouteStatsResult> {
+    const totalEligibleCustomers = await this.userRepo.count({
+      where: { mem_route: In(DELIVERY_PREFERENCE_ENABLED_ROUTES) },
+    });
+
+    const rows = await this.cacheRepo
+      .createQueryBuilder('cdp')
+      .innerJoin(UserEntity, 'u', 'u.mem_code = cdp.mem_code')
+      .select('cdp.preference', 'preference')
+      .addSelect('COUNT(*)', 'count')
+      .where('u.mem_route IN (:...routes)', {
+        routes: DELIVERY_PREFERENCE_ENABLED_ROUTES,
+      })
+      .groupBy('cdp.preference')
+      .getRawMany<{ preference: string; count: string }>();
+
+    const countByKey = new Map(
+      rows.map((r) => [r.preference, Number(r.count)]),
+    );
+    const breakdown: PreferenceBreakdownEntry[] =
+      DELIVERY_PREFERENCE_OPTIONS.map((option) => ({
+        key: option.key,
+        label: option.label,
+        count: countByKey.get(option.key) ?? 0,
+      }));
+    const totalWithPreferenceSet = breakdown.reduce(
+      (sum, entry) => sum + entry.count,
+      0,
+    );
+
+    return { totalEligibleCustomers, totalWithPreferenceSet, breakdown };
+  }
+}

--- a/src/delivery-preference/dto/set-preference.dto.ts
+++ b/src/delivery-preference/dto/set-preference.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class SetPreferenceDto {
+  @IsString()
+  @IsNotEmpty()
+  preference: string;
+}

--- a/src/migrations/20260618000100-add-delivery-preference.ts
+++ b/src/migrations/20260618000100-add-delivery-preference.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDeliveryPreference20260618000100 implements MigrationInterface {
+  name = 'AddDeliveryPreference20260618000100';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "INSERT INTO `feature_flag` (`feature_key`, `is_enabled`) VALUES ('delivery_preference_hatyai', false)",
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "DELETE FROM `feature_flag` WHERE `feature_key` = 'delivery_preference_hatyai'",
+    );
+  }
+}

--- a/src/migrations/20260618000200-create-customer-delivery-preference.ts
+++ b/src/migrations/20260618000200-create-customer-delivery-preference.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateCustomerDeliveryPreference20260618000200 implements MigrationInterface {
+  name = 'CreateCustomerDeliveryPreference20260618000200';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE \`customer_delivery_preference\` (
+        \`mem_code\` varchar(50) NOT NULL,
+        \`preference\` varchar(30) NOT NULL,
+        \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+        PRIMARY KEY (\`mem_code\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE `customer_delivery_preference`');
+  }
+}

--- a/src/shopping-order/shopping-order.service.spec.ts
+++ b/src/shopping-order/shopping-order.service.spec.ts
@@ -14,6 +14,7 @@ import { UserEntity } from 'src/users/users.entity';
 import { ShoppingCartService } from 'src/shopping-cart/shopping-cart.service';
 import { CompanyDayAnalyticService } from 'src/company-day-analytic/company-day-analytic.service';
 import { PromotionService } from 'src/promotion/promotion.service';
+import { HappyHourService } from 'src/happy-hour/happy-hour.service';
 
 const mockRepo = () => ({
   find: jest.fn(),
@@ -67,6 +68,7 @@ describe('ShoppingOrderService — unit helpers', () => {
         { provide: DataSource, useValue: { transaction: jest.fn(), createQueryRunner: jest.fn() } },
         { provide: CompanyDayAnalyticService, useValue: {} },
         { provide: PromotionService, useValue: {} },
+        { provide: HappyHourService, useValue: {} },
       ],
     }).compile();
 


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- https://nitipongjin-13063.atlassian.net/browse/ECWC-339 (subtask ของ ECWC-337)

### 📌 ประเภทของ PR
- [x] ✨ Feature ใหม่
- [ ] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
ลูกค้าในเส้นทางหาดใหญ่ที่เลือกขนส่งวังเภสัชตอน checkout สามารถระบุ preference เพิ่มเติมได้ว่าต้องการ "เฉพาะรถวังเภสัช" / "รถวังเภสัชหรือขนส่งทั่วไปก็ได้" / "ขนส่งทั่วไปเท่านั้น" — เก็บเป็น **customer-level setting** (ไม่ผูกกับ order ใด order หนึ่ง) เพื่อให้ทีมจัดส่ง/sale ใช้ประกอบการตัดสินใจวิธีจัดส่งของลูกค้ารายนั้นได้ในทุกครั้งที่สั่งซื้อ

### 🛠️ แก้ปัญหานั้นอย่างไร
- เพิ่ม module `delivery-preference` ใหม่ทั้งหมด — ไม่กระทบ flow เดิม
- เก็บ preference ไว้ใน table ใหม่ `customer_delivery_preference` (เป็น source of truth เดียว — เดิมวางแผนจะเชื่อม Sale Service แต่ทีมตัดสินใจไม่ต้องใช้ Sale Service แล้ว จึงเก็บเองทั้งหมด)
- คุมการเปิดใช้งานด้วย feature flag `delivery_preference_hatyai` (default **ปิด** ผ่าน migration seed) ผสมกับ route whitelist (`L1-1`, `L23` — เส้นทางหาดใหญ่)
- Endpoint ฝั่งลูกค้า: `GET /api/ecom/delivery-preference/checkout-options`, `PUT /api/ecom/delivery-preference/preference`
- Endpoint ฝั่ง admin (read-only โดยตั้งใจ — ดูได้ แก้ไม่ได้): `GET /api/admin/delivery-preference/customers` (paginated, filter ด้วย keyword ได้), `GET /api/admin/delivery-preference/stats` (สำหรับ pie chart breakdown)
- แก้ `shopping-order.service.spec.ts` เพิ่ม `HappyHourService` mock ที่ขาดไปจากก่อนหน้านี้ (พบระหว่างทำงานนี้)

### 🧪 วิธี Test
1. รัน migration: `npm run migration:run` (สร้างคอลัมน์/ตาราง + seed feature flag เป็น false)
2. เปิด flag ผ่าน endpoint เดิม `POST /api/ecom/feature-flag/update-flag` body `{ "flag": "delivery_preference_hatyai", "status": true }`
3. Login ด้วย user ที่ `mem_route` เป็น `L1-1` หรือ `L23` แล้วยิง `GET /api/ecom/delivery-preference/checkout-options` → ควรเห็น `enabled: true` + ตัวเลือก 3 แบบ
4. ยิง `PUT /api/ecom/delivery-preference/preference` body `{ "preference": "van_only" }` → บันทึกสำเร็จ
5. ยิง `GET /api/admin/delivery-preference/customers` (ต้อง login เป็น admin) → เห็นรายชื่อลูกค้าในเส้นทางหาดใหญ่พร้อมสถานะว่าใครตั้งค่าแล้ว
6. ยิง `GET /api/admin/delivery-preference/stats` → เห็นสรุปจำนวนต่อตัวเลือก
7. รัน `npm test -- delivery-preference` (14 tests ผ่านหมด)

### 🔑 Environment Variables ใหม่
- ไม่มี