### PR TITLE
fix(ECWC-354): ระบุ type varchar ให้ column creditor_address ใน CreditorEntity

### DIFF
--- a/src/products/creditor.entity.ts
+++ b/src/products/creditor.entity.ts
@@ -15,7 +15,7 @@ export class CreditorEntity {
   @Column()
   creditor_name: string;
 
-  @Column({ nullable: true, default: null })
+  @Column({ type: 'varchar', nullable: true, default: null })
   creditor_address: string | null;
 
   @OneToMany(() => ProductEntity, (product) => product)


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- https://nitipongjin-13063.atlassian.net/browse/ECWC-354

### 📌 ประเภทของ PR
- [ ] ✨ Feature ใหม่
- [x] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
field `creditor_address` ใน `CreditorEntity` ไม่ได้ระบุ type ของ column ไว้อย่างชัดเจน ทำให้ TypeORM อนุมาน type เองซึ่งอาจไม่ตรงกับที่ต้องการ

### 🛠️ แก้ปัญหานั้นอย่างไร
ระบุ `type: 'varchar'` ให้กับ decorator `@Column()` ของ field `creditor_address` ใน `src/products/creditor.entity.ts`

### 🧪 วิธี Test
1. Pull branch นี้ขึ้นมา
2. ตรวจสอบว่า build ผ่าน (`npm run build`)
3. ตรวจสอบ schema/migration ที่เกี่ยวข้องกับ `creditor` table ว่า column `creditor_address` เป็น varchar ตามที่คาดหวัง

### 🔑 Environment Variables ใหม่
- ไม่มี