### PR TITLE
feat(ECWC-351): เพิ่ม Swagger/OpenAPI documentation ครบทุก endpoint

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,12 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(cd \"d:/WP/Wang-E-commerce/Backend-Ecommerce\" && npx tsc --noEmit -p tsconfig.json *)",
+      "Bash(cd \"D:/WP/Wang-E-commerce/Backend-Ecommerce/.claude/worktrees/swagger-docs\" && npx tsc --noEmit -p tsconfig.json *)",
+      "Bash(cd \"d:\\WP\\Wang-E-commerce\\Backend-Ecommerce\" && npm run build *)",
+      "Bash(cd \"d:\\WP\\Wang-E-commerce\\Backend-Ecommerce\" && npx jest delivery-preference *)"
+    ]
+  },
   "hooks": {
     "Stop": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,5 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 # Claude Code — personal Stop-hook scratch (learn-from-reviews complement)
 .claude/*.local.md
 .claude/.learning-seen.json
+.claude/settings.local.json
 

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,15 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "plugins": [
+      {
+        "name": "@nestjs/swagger",
+        "options": {
+          "introspectComments": true,
+          "classValidatorShim": true
+        }
+      }
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.6",
         "@nestjs/schedule": "^6.0.0",
+        "@nestjs/swagger": "^11.4.4",
         "@nestjs/typeorm": "^11.0.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.62.2",
@@ -3729,6 +3730,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.1.1.tgz",
@@ -4661,14 +4668,14 @@
       }
     },
     "node_modules/@nestjs/mapped-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
-      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
       "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.0 || ^0.14.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
         "reflect-metadata": "^0.1.12 || ^0.2.0"
       },
       "peerDependenciesMeta": {
@@ -4933,6 +4940,55 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.4.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.4.tgz",
+      "integrity": "sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "4.1.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.6"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@nestjs/testing": {
@@ -9747,6 +9803,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
@@ -24026,6 +24089,15 @@
       "optional": true,
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
+      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.6",
     "@nestjs/schedule": "^6.0.0",
+    "@nestjs/swagger": "^11.4.4",
     "@nestjs/typeorm": "^11.0.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.62.2",

--- a/src/app-version/app-version.controller.ts
+++ b/src/app-version/app-version.controller.ts
@@ -13,6 +13,14 @@ import {
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AppVersionService } from './app-version.service';
 import { CheckAppVersionDto } from './dto/check-app-version.dto';
@@ -24,6 +32,7 @@ interface JwtPayload {
   permission?: boolean;
 }
 
+@ApiTags('App Version')
 @Controller('app-version')
 @UsePipes(
   new ValidationPipe({
@@ -35,11 +44,30 @@ interface JwtPayload {
 export class AppVersionController {
   constructor(private readonly appVersionService: AppVersionService) {}
 
+  @ApiOperation({
+    summary:
+      'ตรวจสอบว่าเวอร์ชันแอปปัจจุบันได้รับอนุญาตให้ใช้งานหรือไม่ (public)',
+  })
+  @ApiBody({ type: CheckAppVersionDto })
+  @ApiResponse({
+    status: 200,
+    description: 'ผลการตรวจสอบเวอร์ชันแอป (allowed/forceUpdate/storeUrl/message)',
+  })
   @Post('check')
   async checkVersion(@Body() data: CheckAppVersionDto) {
     return this.appVersionService.checkVersion(data);
   }
 
+  @ApiOperation({
+    summary:
+      'ตรวจสอบเวอร์ชันแอปแบบ legacy client (public, รูปแบบ response เก่า)',
+  })
+  @ApiBody({ type: LegacyCheckAppVersionDto })
+  @ApiResponse({
+    status: 200,
+    description:
+      'ผลการตรวจสอบเวอร์ชันแอปในรูปแบบ legacy (isLastest/latestVersion/forceUpdate/storeUrl/note)',
+  })
   @Post('version/get')
   async checkVersionLegacy(@Body() data: LegacyCheckAppVersionDto) {
     const result = await this.appVersionService.checkVersion({
@@ -63,6 +91,11 @@ export class AppVersionController {
     };
   }
 
+  @ApiOperation({ summary: 'ดึงรายการ app version blacklist ทั้งหมด (admin)' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, description: 'รายการ app version blacklist ทั้งหมด' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @UseGuards(JwtAuthGuard)
   @Get()
   async findAll(@Req() req: { user?: JwtPayload }) {
@@ -70,6 +103,12 @@ export class AppVersionController {
     return this.appVersionService.findAll();
   }
 
+  @ApiOperation({ summary: 'สร้าง app version blacklist ใหม่ (admin)' })
+  @ApiBearerAuth()
+  @ApiBody({ type: CreateAppVersionDto })
+  @ApiResponse({ status: 201, description: 'สร้าง app version blacklist สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @UseGuards(JwtAuthGuard)
   @Post()
   async create(
@@ -80,6 +119,13 @@ export class AppVersionController {
     return this.appVersionService.create(data);
   }
 
+  @ApiOperation({ summary: 'แก้ไข app version blacklist ตาม id (admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'id ของ app version blacklist' })
+  @ApiBody({ type: UpdateAppVersionDto })
+  @ApiResponse({ status: 200, description: 'แก้ไข app version blacklist สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @UseGuards(JwtAuthGuard)
   @Patch(':id')
   async update(
@@ -91,6 +137,12 @@ export class AppVersionController {
     return this.appVersionService.update(id, data);
   }
 
+  @ApiOperation({ summary: 'ลบ app version blacklist ตาม id (admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'id ของ app version blacklist' })
+  @ApiResponse({ status: 200, description: 'ลบ app version blacklist สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @UseGuards(JwtAuthGuard)
   @Delete(':id')
   async remove(

--- a/src/app-version/app-version.controller.ts
+++ b/src/app-version/app-version.controller.ts
@@ -23,10 +23,12 @@ import {
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AppVersionService } from './app-version.service';
-import { CheckAppVersionDto } from './dto/check-app-version.dto';
-import { CreateAppVersionDto } from './dto/create-app-version.dto';
-import { LegacyCheckAppVersionDto } from './dto/legacy-check-app-version.dto';
-import { UpdateAppVersionDto } from './dto/update-app-version.dto';
+import {
+  CheckAppVersionDto,
+  CreateAppVersionDto,
+  LegacyCheckAppVersionDto,
+  UpdateAppVersionDto,
+} from 'src/common/dto-index';
 
 interface JwtPayload {
   permission?: boolean;

--- a/src/app-version/app-version.controller.ts
+++ b/src/app-version/app-version.controller.ts
@@ -13,6 +13,14 @@ import {
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AppVersionService } from './app-version.service';
 import { CheckAppVersionDto } from './dto/check-app-version.dto';
@@ -24,6 +32,7 @@ interface JwtPayload {
   permission?: boolean;
 }
 
+@ApiTags('App Version')
 @Controller('app-version')
 @UsePipes(
   new ValidationPipe({
@@ -35,11 +44,30 @@ interface JwtPayload {
 export class AppVersionController {
   constructor(private readonly appVersionService: AppVersionService) {}
 
+  @ApiOperation({
+    summary:
+      'ตรวจสอบว่าเวอร์ชันแอปปัจจุบันได้รับอนุญาตให้ใช้งานหรือไม่ (public)',
+  })
+  @ApiBody({ type: CheckAppVersionDto })
+  @ApiResponse({
+    status: 200,
+    description: 'ผลการตรวจสอบเวอร์ชันแอป (allowed/forceUpdate/storeUrl/message)',
+  })
   @Post('check')
   async checkVersion(@Body() data: CheckAppVersionDto) {
     return this.appVersionService.checkVersion(data);
   }
 
+  @ApiOperation({
+    summary:
+      'ตรวจสอบเวอร์ชันแอปแบบ legacy client (public, รูปแบบ response เก่า)',
+  })
+  @ApiBody({ type: LegacyCheckAppVersionDto })
+  @ApiResponse({
+    status: 200,
+    description:
+      'ผลการตรวจสอบเวอร์ชันแอปในรูปแบบ legacy (isLastest/latestVersion/forceUpdate/storeUrl/note)',
+  })
   @Post('version/get')
   async checkVersionLegacy(@Body() data: LegacyCheckAppVersionDto) {
     const result = await this.appVersionService.checkVersion({
@@ -63,6 +91,11 @@ export class AppVersionController {
     };
   }
 
+  @ApiOperation({ summary: 'ดึงรายการ app version blacklist ทั้งหมด (admin)' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, description: 'รายการ app version blacklist ทั้งหมด' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @UseGuards(JwtAuthGuard)
   @Get()
   async findAll(@Req() req: { user?: JwtPayload }) {
@@ -70,6 +103,12 @@ export class AppVersionController {
     return this.appVersionService.findAll();
   }
 
+  @ApiOperation({ summary: 'สร้าง app version blacklist ใหม่ (admin)' })
+  @ApiBearerAuth()
+  @ApiBody({ type: CreateAppVersionDto })
+  @ApiResponse({ status: 201, description: 'สร้าง app version blacklist สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @UseGuards(JwtAuthGuard)
   @Post()
   async create(
@@ -80,6 +119,13 @@ export class AppVersionController {
     return this.appVersionService.create(data);
   }
 
+  @ApiOperation({ summary: 'แก้ไข app version blacklist ตาม id (admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'id ของ app version blacklist', example: '1' })
+  @ApiBody({ type: UpdateAppVersionDto })
+  @ApiResponse({ status: 200, description: 'แก้ไข app version blacklist สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @UseGuards(JwtAuthGuard)
   @Patch(':id')
   async update(
@@ -91,6 +137,12 @@ export class AppVersionController {
     return this.appVersionService.update(id, data);
   }
 
+  @ApiOperation({ summary: 'ลบ app version blacklist ตาม id (admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'id ของ app version blacklist', example: '1' })
+  @ApiResponse({ status: 200, description: 'ลบ app version blacklist สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @UseGuards(JwtAuthGuard)
   @Delete(':id')
   async remove(

--- a/src/app-version/app-version.controller.ts
+++ b/src/app-version/app-version.controller.ts
@@ -121,7 +121,7 @@ export class AppVersionController {
 
   @ApiOperation({ summary: 'แก้ไข app version blacklist ตาม id (admin)' })
   @ApiBearerAuth()
-  @ApiParam({ name: 'id', description: 'id ของ app version blacklist' })
+  @ApiParam({ name: 'id', description: 'id ของ app version blacklist', example: '1' })
   @ApiBody({ type: UpdateAppVersionDto })
   @ApiResponse({ status: 200, description: 'แก้ไข app version blacklist สำเร็จ' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -139,7 +139,7 @@ export class AppVersionController {
 
   @ApiOperation({ summary: 'ลบ app version blacklist ตาม id (admin)' })
   @ApiBearerAuth()
-  @ApiParam({ name: 'id', description: 'id ของ app version blacklist' })
+  @ApiParam({ name: 'id', description: 'id ของ app version blacklist', example: '1' })
   @ApiResponse({ status: 200, description: 'ลบ app version blacklist สำเร็จ' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Insufficient permissions' })

--- a/src/app-version/dto/check-app-version.dto.ts
+++ b/src/app-version/dto/check-app-version.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsEnum, IsNotEmpty, IsString, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { AppPlatform } from '../app-version.entity';
 import {
   APP_VERSION_PATTERN,
@@ -8,16 +9,29 @@ import {
 } from './app-version-validation';
 
 export class CheckAppVersionDto {
+  @ApiProperty({
+    enum: AppPlatform,
+    example: AppPlatform.ANDROID,
+    description: 'Required; แพลตฟอร์มของแอป (android หรือ ios)',
+  })
   @Transform(normalizePlatform)
   @IsEnum(AppPlatform)
   os!: AppPlatform;
 
+  @ApiProperty({
+    description: 'Required; not empty; เวอร์ชันปัจจุบันของแอปที่ client ใช้งานอยู่',
+    example: '1.2.3',
+  })
   @Transform(trimString)
   @IsString()
   @IsNotEmpty()
   @Matches(APP_VERSION_PATTERN)
   version!: string;
 
+  @ApiProperty({
+    description: 'Required; not empty; หมายเลข build ของแอปที่ client ใช้งานอยู่',
+    example: '123',
+  })
   @Transform(trimString)
   @IsString()
   @IsNotEmpty()

--- a/src/app-version/dto/check-app-version.dto.ts
+++ b/src/app-version/dto/check-app-version.dto.ts
@@ -11,14 +11,15 @@ import {
 export class CheckAppVersionDto {
   @ApiProperty({
     enum: AppPlatform,
-    description: 'แพลตฟอร์มของแอป (android หรือ ios)',
+    example: AppPlatform.ANDROID,
+    description: 'Required; แพลตฟอร์มของแอป (android หรือ ios)',
   })
   @Transform(normalizePlatform)
   @IsEnum(AppPlatform)
   os!: AppPlatform;
 
   @ApiProperty({
-    description: 'เวอร์ชันปัจจุบันของแอปที่ client ใช้งานอยู่',
+    description: 'Required; not empty; เวอร์ชันปัจจุบันของแอปที่ client ใช้งานอยู่',
     example: '1.2.3',
   })
   @Transform(trimString)
@@ -28,7 +29,7 @@ export class CheckAppVersionDto {
   version!: string;
 
   @ApiProperty({
-    description: 'หมายเลข build ของแอปที่ client ใช้งานอยู่',
+    description: 'Required; not empty; หมายเลข build ของแอปที่ client ใช้งานอยู่',
     example: '123',
   })
   @Transform(trimString)

--- a/src/app-version/dto/check-app-version.dto.ts
+++ b/src/app-version/dto/check-app-version.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsEnum, IsNotEmpty, IsString, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { AppPlatform } from '../app-version.entity';
 import {
   APP_VERSION_PATTERN,
@@ -8,16 +9,28 @@ import {
 } from './app-version-validation';
 
 export class CheckAppVersionDto {
+  @ApiProperty({
+    enum: AppPlatform,
+    description: 'แพลตฟอร์มของแอป (android หรือ ios)',
+  })
   @Transform(normalizePlatform)
   @IsEnum(AppPlatform)
   os!: AppPlatform;
 
+  @ApiProperty({
+    description: 'เวอร์ชันปัจจุบันของแอปที่ client ใช้งานอยู่',
+    example: '1.2.3',
+  })
   @Transform(trimString)
   @IsString()
   @IsNotEmpty()
   @Matches(APP_VERSION_PATTERN)
   version!: string;
 
+  @ApiProperty({
+    description: 'หมายเลข build ของแอปที่ client ใช้งานอยู่',
+    example: '123',
+  })
   @Transform(trimString)
   @IsString()
   @IsNotEmpty()

--- a/src/app-version/dto/create-app-version.dto.ts
+++ b/src/app-version/dto/create-app-version.dto.ts
@@ -21,14 +21,15 @@ import {
 export class CreateAppVersionDto {
   @ApiProperty({
     enum: AppPlatform,
-    description: 'แพลตฟอร์มของแอป (android หรือ ios) ที่ต้องการขึ้น blacklist',
+    example: AppPlatform.ANDROID,
+    description: 'Required; แพลตฟอร์มของแอป (android หรือ ios) ที่ต้องการขึ้น blacklist',
   })
   @Transform(normalizePlatform)
   @IsEnum(AppPlatform)
   platform!: AppPlatform;
 
   @ApiProperty({
-    description: 'เวอร์ชันของแอปที่ต้องการ block/บังคับอัปเดต',
+    description: 'Required; not empty; เวอร์ชันของแอปที่ต้องการ block/บังคับอัปเดต',
     example: '1.0.0',
   })
   @Transform(trimString)
@@ -38,7 +39,8 @@ export class CreateAppVersionDto {
   version!: string;
 
   @ApiPropertyOptional({
-    description: 'ข้อความที่จะแสดงให้ผู้ใช้เห็นเมื่อเวอร์ชันถูก block',
+    description: 'Optional; empty string allowed; ข้อความที่จะแสดงให้ผู้ใช้เห็นเมื่อเวอร์ชันถูก block',
+    example: 'เวอร์ชันนี้ไม่รองรับ กรุณาอัปเดตแอป',
     maxLength: 500,
   })
   @Transform(normalizeOptionalString)
@@ -48,7 +50,7 @@ export class CreateAppVersionDto {
   message?: string;
 
   @ApiProperty({
-    description: 'URL ของ store ให้ผู้ใช้ไปอัปเดตแอป',
+    description: 'Required; not empty; URL ของ store ให้ผู้ใช้ไปอัปเดตแอป',
     example: 'https://play.google.com/store/apps/details?id=com.example.app',
   })
   @Transform(trimString)
@@ -61,7 +63,8 @@ export class CreateAppVersionDto {
   storeUrl!: string;
 
   @ApiPropertyOptional({
-    description: 'สถานะการเปิดใช้งาน entry นี้',
+    description: 'Optional; defaults to true; สถานะการเปิดใช้งาน entry นี้',
+    example: true,
     default: true,
   })
   @IsOptional()

--- a/src/app-version/dto/create-app-version.dto.ts
+++ b/src/app-version/dto/create-app-version.dto.ts
@@ -9,6 +9,7 @@ import {
   Matches,
   MaxLength,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AppPlatform } from '../app-version.entity';
 import {
   APP_VERSION_PATTERN,
@@ -18,22 +19,40 @@ import {
 } from './app-version-validation';
 
 export class CreateAppVersionDto {
+  @ApiProperty({
+    enum: AppPlatform,
+    example: AppPlatform.ANDROID,
+    description: 'Required; แพลตฟอร์มของแอป (android หรือ ios) ที่ต้องการขึ้น blacklist',
+  })
   @Transform(normalizePlatform)
   @IsEnum(AppPlatform)
   platform!: AppPlatform;
 
+  @ApiProperty({
+    description: 'Required; not empty; เวอร์ชันของแอปที่ต้องการ block/บังคับอัปเดต',
+    example: '1.0.0',
+  })
   @Transform(trimString)
   @IsString()
   @IsNotEmpty()
   @Matches(APP_VERSION_PATTERN)
   version!: string;
 
+  @ApiPropertyOptional({
+    description: 'Optional; empty string allowed; ข้อความที่จะแสดงให้ผู้ใช้เห็นเมื่อเวอร์ชันถูก block',
+    example: 'เวอร์ชันนี้ไม่รองรับ กรุณาอัปเดตแอป',
+    maxLength: 500,
+  })
   @Transform(normalizeOptionalString)
   @IsOptional()
   @IsString()
   @MaxLength(500)
   message?: string;
 
+  @ApiProperty({
+    description: 'Required; not empty; URL ของ store ให้ผู้ใช้ไปอัปเดตแอป',
+    example: 'https://play.google.com/store/apps/details?id=com.example.app',
+  })
   @Transform(trimString)
   @IsString()
   @IsNotEmpty()
@@ -43,6 +62,11 @@ export class CreateAppVersionDto {
   })
   storeUrl!: string;
 
+  @ApiPropertyOptional({
+    description: 'Optional; defaults to true; สถานะการเปิดใช้งาน entry นี้',
+    example: true,
+    default: true,
+  })
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;

--- a/src/app-version/dto/create-app-version.dto.ts
+++ b/src/app-version/dto/create-app-version.dto.ts
@@ -9,6 +9,7 @@ import {
   Matches,
   MaxLength,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AppPlatform } from '../app-version.entity';
 import {
   APP_VERSION_PATTERN,
@@ -18,22 +19,38 @@ import {
 } from './app-version-validation';
 
 export class CreateAppVersionDto {
+  @ApiProperty({
+    enum: AppPlatform,
+    description: 'แพลตฟอร์มของแอป (android หรือ ios) ที่ต้องการขึ้น blacklist',
+  })
   @Transform(normalizePlatform)
   @IsEnum(AppPlatform)
   platform!: AppPlatform;
 
+  @ApiProperty({
+    description: 'เวอร์ชันของแอปที่ต้องการ block/บังคับอัปเดต',
+    example: '1.0.0',
+  })
   @Transform(trimString)
   @IsString()
   @IsNotEmpty()
   @Matches(APP_VERSION_PATTERN)
   version!: string;
 
+  @ApiPropertyOptional({
+    description: 'ข้อความที่จะแสดงให้ผู้ใช้เห็นเมื่อเวอร์ชันถูก block',
+    maxLength: 500,
+  })
   @Transform(normalizeOptionalString)
   @IsOptional()
   @IsString()
   @MaxLength(500)
   message?: string;
 
+  @ApiProperty({
+    description: 'URL ของ store ให้ผู้ใช้ไปอัปเดตแอป',
+    example: 'https://play.google.com/store/apps/details?id=com.example.app',
+  })
   @Transform(trimString)
   @IsString()
   @IsNotEmpty()
@@ -43,6 +60,10 @@ export class CreateAppVersionDto {
   })
   storeUrl!: string;
 
+  @ApiPropertyOptional({
+    description: 'สถานะการเปิดใช้งาน entry นี้',
+    default: true,
+  })
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;

--- a/src/app-version/dto/legacy-check-app-version.dto.ts
+++ b/src/app-version/dto/legacy-check-app-version.dto.ts
@@ -11,14 +11,15 @@ import {
 export class LegacyCheckAppVersionDto {
   @ApiProperty({
     enum: AppPlatform,
-    description: 'แพลตฟอร์มของแอป (android หรือ ios)',
+    example: AppPlatform.ANDROID,
+    description: 'Required; แพลตฟอร์มของแอป (android หรือ ios)',
   })
   @Transform(normalizePlatform)
   @IsEnum(AppPlatform)
   os!: AppPlatform;
 
   @ApiProperty({
-    description: 'เวอร์ชันปัจจุบันของแอปที่ client ใช้งานอยู่ (legacy client)',
+    description: 'Required; not empty; เวอร์ชันปัจจุบันของแอปที่ client ใช้งานอยู่ (legacy client)',
     example: '1.2.3',
   })
   @Transform(trimString)

--- a/src/app-version/dto/legacy-check-app-version.dto.ts
+++ b/src/app-version/dto/legacy-check-app-version.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsEnum, IsNotEmpty, IsString, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { AppPlatform } from '../app-version.entity';
 import {
   APP_VERSION_PATTERN,
@@ -8,10 +9,18 @@ import {
 } from './app-version-validation';
 
 export class LegacyCheckAppVersionDto {
+  @ApiProperty({
+    enum: AppPlatform,
+    description: 'แพลตฟอร์มของแอป (android หรือ ios)',
+  })
   @Transform(normalizePlatform)
   @IsEnum(AppPlatform)
   os!: AppPlatform;
 
+  @ApiProperty({
+    description: 'เวอร์ชันปัจจุบันของแอปที่ client ใช้งานอยู่ (legacy client)',
+    example: '1.2.3',
+  })
   @Transform(trimString)
   @IsString()
   @IsNotEmpty()

--- a/src/app-version/dto/legacy-check-app-version.dto.ts
+++ b/src/app-version/dto/legacy-check-app-version.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsEnum, IsNotEmpty, IsString, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { AppPlatform } from '../app-version.entity';
 import {
   APP_VERSION_PATTERN,
@@ -8,10 +9,19 @@ import {
 } from './app-version-validation';
 
 export class LegacyCheckAppVersionDto {
+  @ApiProperty({
+    enum: AppPlatform,
+    example: AppPlatform.ANDROID,
+    description: 'Required; แพลตฟอร์มของแอป (android หรือ ios)',
+  })
   @Transform(normalizePlatform)
   @IsEnum(AppPlatform)
   os!: AppPlatform;
 
+  @ApiProperty({
+    description: 'Required; not empty; เวอร์ชันปัจจุบันของแอปที่ client ใช้งานอยู่ (legacy client)',
+    example: '1.2.3',
+  })
   @Transform(trimString)
   @IsString()
   @IsNotEmpty()

--- a/src/app-version/dto/update-app-version.dto.ts
+++ b/src/app-version/dto/update-app-version.dto.ts
@@ -20,7 +20,8 @@ import {
 export class UpdateAppVersionDto {
   @ApiPropertyOptional({
     enum: AppPlatform,
-    description: 'แพลตฟอร์มของแอป (android หรือ ios) ที่ต้องการแก้ไข',
+    example: AppPlatform.ANDROID,
+    description: 'Optional; แพลตฟอร์มของแอป (android หรือ ios) ที่ต้องการแก้ไข',
   })
   @Transform(normalizePlatform)
   @IsOptional()
@@ -28,7 +29,7 @@ export class UpdateAppVersionDto {
   platform?: AppPlatform;
 
   @ApiPropertyOptional({
-    description: 'เวอร์ชันของแอปที่ต้องการ block/บังคับอัปเดต',
+    description: 'Optional; เวอร์ชันของแอปที่ต้องการ block/บังคับอัปเดต',
     example: '1.0.0',
   })
   @Transform(trimString)
@@ -38,7 +39,8 @@ export class UpdateAppVersionDto {
   version?: string;
 
   @ApiPropertyOptional({
-    description: 'ข้อความที่จะแสดงให้ผู้ใช้เห็นเมื่อเวอร์ชันถูก block',
+    description: 'Optional; empty string allowed; ข้อความที่จะแสดงให้ผู้ใช้เห็นเมื่อเวอร์ชันถูก block',
+    example: 'เวอร์ชันนี้ไม่รองรับ กรุณาอัปเดตแอป',
     maxLength: 500,
   })
   @Transform(normalizeOptionalString)
@@ -48,7 +50,7 @@ export class UpdateAppVersionDto {
   message?: string;
 
   @ApiPropertyOptional({
-    description: 'URL ของ store ให้ผู้ใช้ไปอัปเดตแอป',
+    description: 'Optional; URL ของ store ให้ผู้ใช้ไปอัปเดตแอป',
     example: 'https://play.google.com/store/apps/details?id=com.example.app',
   })
   @Transform(trimString)
@@ -61,7 +63,8 @@ export class UpdateAppVersionDto {
   storeUrl?: string;
 
   @ApiPropertyOptional({
-    description: 'สถานะการเปิดใช้งาน entry นี้',
+    description: 'Optional; สถานะการเปิดใช้งาน entry นี้',
+    example: true,
   })
   @IsOptional()
   @IsBoolean()

--- a/src/app-version/dto/update-app-version.dto.ts
+++ b/src/app-version/dto/update-app-version.dto.ts
@@ -8,6 +8,7 @@ import {
   Matches,
   MaxLength,
 } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { AppPlatform } from '../app-version.entity';
 import {
   APP_VERSION_PATTERN,
@@ -17,23 +18,39 @@ import {
 } from './app-version-validation';
 
 export class UpdateAppVersionDto {
+  @ApiPropertyOptional({
+    enum: AppPlatform,
+    description: 'แพลตฟอร์มของแอป (android หรือ ios) ที่ต้องการแก้ไข',
+  })
   @Transform(normalizePlatform)
   @IsOptional()
   @IsEnum(AppPlatform)
   platform?: AppPlatform;
 
+  @ApiPropertyOptional({
+    description: 'เวอร์ชันของแอปที่ต้องการ block/บังคับอัปเดต',
+    example: '1.0.0',
+  })
   @Transform(trimString)
   @IsOptional()
   @IsString()
   @Matches(APP_VERSION_PATTERN)
   version?: string;
 
+  @ApiPropertyOptional({
+    description: 'ข้อความที่จะแสดงให้ผู้ใช้เห็นเมื่อเวอร์ชันถูก block',
+    maxLength: 500,
+  })
   @Transform(normalizeOptionalString)
   @IsOptional()
   @IsString()
   @MaxLength(500)
   message?: string;
 
+  @ApiPropertyOptional({
+    description: 'URL ของ store ให้ผู้ใช้ไปอัปเดตแอป',
+    example: 'https://play.google.com/store/apps/details?id=com.example.app',
+  })
   @Transform(trimString)
   @IsOptional()
   @IsString()
@@ -43,6 +60,9 @@ export class UpdateAppVersionDto {
   })
   storeUrl?: string;
 
+  @ApiPropertyOptional({
+    description: 'สถานะการเปิดใช้งาน entry นี้',
+  })
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;

--- a/src/app-version/dto/update-app-version.dto.ts
+++ b/src/app-version/dto/update-app-version.dto.ts
@@ -8,6 +8,7 @@ import {
   Matches,
   MaxLength,
 } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { AppPlatform } from '../app-version.entity';
 import {
   APP_VERSION_PATTERN,
@@ -17,23 +18,41 @@ import {
 } from './app-version-validation';
 
 export class UpdateAppVersionDto {
+  @ApiPropertyOptional({
+    enum: AppPlatform,
+    example: AppPlatform.ANDROID,
+    description: 'Optional; แพลตฟอร์มของแอป (android หรือ ios) ที่ต้องการแก้ไข',
+  })
   @Transform(normalizePlatform)
   @IsOptional()
   @IsEnum(AppPlatform)
   platform?: AppPlatform;
 
+  @ApiPropertyOptional({
+    description: 'Optional; เวอร์ชันของแอปที่ต้องการ block/บังคับอัปเดต',
+    example: '1.0.0',
+  })
   @Transform(trimString)
   @IsOptional()
   @IsString()
   @Matches(APP_VERSION_PATTERN)
   version?: string;
 
+  @ApiPropertyOptional({
+    description: 'Optional; empty string allowed; ข้อความที่จะแสดงให้ผู้ใช้เห็นเมื่อเวอร์ชันถูก block',
+    example: 'เวอร์ชันนี้ไม่รองรับ กรุณาอัปเดตแอป',
+    maxLength: 500,
+  })
   @Transform(normalizeOptionalString)
   @IsOptional()
   @IsString()
   @MaxLength(500)
   message?: string;
 
+  @ApiPropertyOptional({
+    description: 'Optional; URL ของ store ให้ผู้ใช้ไปอัปเดตแอป',
+    example: 'https://play.google.com/store/apps/details?id=com.example.app',
+  })
   @Transform(trimString)
   @IsOptional()
   @IsString()
@@ -43,6 +62,10 @@ export class UpdateAppVersionDto {
   })
   storeUrl?: string;
 
+  @ApiPropertyOptional({
+    description: 'Optional; สถานะการเปิดใช้งาน entry นี้',
+    example: true,
+  })
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -22,6 +22,15 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { Response } from 'express';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import axios from 'axios';
 import { AppService } from './app.service';
 import { AuthService, SigninResponse } from './auth/auth.service';
@@ -39,10 +48,89 @@ import { JwtAuthGuard } from './auth/jwt-auth.guard';
 import { FeatureFlagsService } from './feature-flags/feature-flags.service';
 import { BannerService } from './banner/banner.service';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { HotdealInput, HotdealService } from './hotdeal/hotdeal.service';
+import { HotdealService } from './hotdeal/hotdeal.service';
 import { PromotionService } from './promotion/promotion.service';
 import type { PromotionEntityWithTransformedData } from './promotion/promotion.service';
-import { UserEntity } from 'src/users/users.entity';
+import { UpdateUserDataDto } from 'src/users/dto/update-user-data.dto';
+import { UpdateBannerDto } from 'src/banner/dto/update-banner.dto';
+import { UploadBannerDto } from 'src/banner/dto/upload-banner.dto';
+import { CreateBannerFromUrlDto } from 'src/banner/dto/create-banner-from-url.dto';
+import { UploadImageUserDto } from 'src/users/dto/upload-image-user.dto';
+import { UpdateFlagDto } from 'src/feature-flags/dto/update-flag.dto';
+import { UploadPoItemDto } from 'src/products/dto/upload-po-item.dto';
+import { UploadProductFlashSaleItemDto } from 'src/products/dto/upload-product-flashsale-item.dto';
+import { UploadProductL16Dto } from 'src/products/dto/upload-product-l16.dto';
+import { GetFlashSaleDto } from 'src/products/dto/get-flashsale.dto';
+import { AddToFavoriteDto } from 'src/favorite/dto/add-to-favorite.dto';
+import { DeleteFavoriteDto } from 'src/favorite/dto/delete-favorite.dto';
+import { SigninDto } from 'src/auth/dto/signin.dto';
+import { SearchProductsDto } from 'src/products/dto/search-products.dto';
+import { SearchCategoryProductsDto } from 'src/products/dto/search-category-products.dto';
+import { ProductForYouDto } from 'src/products/dto/product-for-you.dto';
+import { SubmitOrderDto } from 'src/shopping-order/dto/submit-order.dto';
+import { GetProductDetailDto } from 'src/products/dto/get-product-detail.dto';
+import { AddProductCartDto } from 'src/shopping-cart/dto/add-product-cart.dto';
+import { TrackCompanyDayViewDto } from 'src/company-day-analytic/dto/track-company-day-view.dto';
+import { CheckProductCartAllDto } from 'src/shopping-cart/dto/check-product-cart-all.dto';
+import { DeleteProductCartDto } from 'src/shopping-cart/dto/delete-product-cart.dto';
+import { CheckProductCartDto } from 'src/shopping-cart/dto/check-product-cart.dto';
+import { AddPromotionDto } from 'src/promotion/dto/add-promotion.dto';
+import { UpdatePromoPosterDto } from 'src/promotion/dto/update-promo-poster.dto';
+import { AddTierDto } from 'src/promotion/dto/add-tier.dto';
+import { UpdatePromotionStatusDto } from 'src/promotion/dto/update-promotion-status.dto';
+import { DeleteTierDto } from 'src/promotion/dto/delete-tier.dto';
+import { DeletePromotionDto } from 'src/promotion/dto/delete-promotion.dto';
+import { DuplicatePromotionDto } from 'src/promotion/dto/duplicate-promotion.dto';
+import { AddPromotionConditionDto } from 'src/promotion/dto/add-promotion-condition.dto';
+import { DeletePromotionConditionDto } from 'src/promotion/dto/delete-promotion-condition.dto';
+import { AddPromotionRewardDto } from 'src/promotion/dto/add-promotion-reward.dto';
+import { GetProductByCreditorDto } from 'src/promotion/dto/get-product-by-creditor.dto';
+import { DeletePromotionRewardDto } from 'src/promotion/dto/delete-promotion-reward.dto';
+import { UpdatePromotionDto } from 'src/promotion/dto/update-promotion.dto';
+import { EditPromotionRewardDto } from 'src/promotion/dto/edit-promotion-reward.dto';
+import { GetProductTierDto } from 'src/promotion/dto/get-product-tier.dto';
+import { AddCreditorDto } from 'src/products/dto/add-creditor.dto';
+import { EditTierDto } from 'src/promotion/dto/edit-tier.dto';
+import { ImportWangdayDto } from 'src/wangday/dto/import-wangday.dto';
+import { SaveHotdealDto } from 'src/hotdeal/dto/save-hotdeal.dto';
+import { DeleteHotdealDto } from 'src/hotdeal/dto/delete-hotdeal.dto';
+import { CheckHotdealMatchDto } from 'src/hotdeal/dto/check-hotdeal-match.dto';
+import { UseCodeForCheckRewardDto } from 'src/promotion/dto/use-code-for-check-reward.dto';
+import { GenerateCodePromotionDto } from 'src/promotion/dto/generate-code-promotion.dto';
+import { UpdateProductFromBackOfficeDto, UpdateStockFromBackOfficeDto } from 'src/products/dto/back-office.dto';
+import { UpdateCustomerDataDto, RefreshTokenDto } from 'src/auth/dto/auth.dto';
+import { AddLotItemDto } from 'src/lot/dto/add-lots.dto';
+import {
+  AddFlashsaleDto,
+  AddProductToFlashsaleDto,
+  DeleteProductFlashsaleDto,
+  EditProductInFlashsaleDto,
+  GetFlashsaleByDateDto,
+  ChangeStatusFlashsaleDto,
+  DeleteFlashsaleDto,
+  EditFlashsaleDto,
+} from 'src/flashsale/dto/flashsale.dto';
+import { UploadLogFileDto } from 'src/backend/dto/upload-log-file.dto';
+import {
+  AddInvisibleTopicDto,
+  AddInvisibleProductDto,
+  DeleteInvisibleProductDto,
+  DeleteInvisibleTopicDto,
+} from 'src/invisible-product/dto/invisible-product.dto';
+import { CreateAddressBodyDto } from 'src/edit-address/dto/create-address.dto';
+import { SaveModalContentDto } from 'src/modalmain/dto/save-modal-content.dto';
+import { AddProductFreeDto, DeleteProductFreeDto, EditProductFreeDto } from 'src/fix-free/dto/fix-free.dto';
+import { CreateSessionDto, LogoutSessionDto, MemCodeDto } from 'src/sessions/dto/sessions.dto';
+import {
+  RequestOtpDto,
+  ValidateOtpDto,
+  ChangePasswordDto,
+  ResetPasswordDto,
+} from 'src/change-password/dto/change-password.dto';
+import { NewArrivalItemDto } from 'src/new-arrivals/dto/new-arrival-item.dto';
+import { ImportDataInvoiceDto, ImportDataRtDto } from 'src/debtor/dto/debtor.dto';
+import { UpdateKeysearchDto } from 'src/product-keyword/dto/update-keysearch.dto';
+import { objectSchema, arraySchema } from 'src/common/swagger-helpers';
 import { BackendService } from './backend/backend.service';
 import { DebtorService } from './debtor/debtor.service';
 import { LotService } from './lot/lot.service';
@@ -54,10 +142,6 @@ import { NewArrivalsService } from './new-arrivals/new-arrivals.service';
 import { UsersService } from './users/users.service';
 import { ChangePasswordService } from './change-password/change-password.service';
 import { FixFreeService } from './fix-free/fix-free.service';
-import type {
-  ImportDataRequestInvoice,
-  ImportDataRequestRT,
-} from './debtor/debtor.service';
 import { DebtorEntity } from './debtor/debtor.entity';
 import { ReductionRT } from './debtor/reduct-rt.entity';
 import { SessionsService } from './sessions/sessions.service';
@@ -91,7 +175,6 @@ import { BehaviorTrackingService } from './behavior-tracking/behavior-tracking.s
 import { TrackOrderService } from './track-order/track-order.service';
 import { NotifyRtService } from './notifyapp/notifyapp.service';
 import { CompanyDayAnalyticService } from './company-day-analytic/company-day-analytic.service';
-import { SearchCartTrackingService } from './search-cart-tracking/search-cart-tracking.service';
 
 export interface JwtPayload {
   username: string;
@@ -155,14 +238,27 @@ export class AppController {
     private readonly notifyRtService: NotifyRtService,
     private readonly trackOrderService: TrackOrderService,
     private readonly companyDayAnalyticService: CompanyDayAnalyticService,
-    private readonly searchCartTrackingService: SearchCartTrackingService,
   ) {}
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Send order data to old system' })
+  @ApiParam({ name: 'soh_running', description: 'Order running number', example: 'SO-67010001' })
+  @ApiResponse({ status: 200, description: 'Data sent to old system' })
   @Get('/ecom/get-data/:soh_running')
   async apiForOldSystem(@Param('soh_running') soh_running: string) {
     return this.shoppingOrderService.sendDataToOldSystem(soh_running);
   }
 
+  @ApiTags('Banner & Contract Log')
+  @ApiOperation({ summary: 'Get banner image URLs by location' })
+  @ApiQuery({
+    name: 'location',
+    required: false,
+    description: 'Banner placement location. Omit to get banners for all locations.',
+    enum: ['store_carousel', 'landing_hero', 'popup', 'sidebar'],
+    example: 'landing_hero',
+  })
+  @ApiResponse({ status: 200, description: 'Banner image URLs' })
   @Get('/ecom/image-banner')
   async getImageUrl(
     @Query('location')
@@ -171,61 +267,70 @@ export class AppController {
     return this.bannerService.GetImageUrl(location);
   }
 
+  @ApiTags('Banner & Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a banner by id' })
+  @ApiParam({ name: 'id', description: 'Banner id', example: '12' })
+  @ApiResponse({ status: 200, description: 'Banner deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/banner/:id')
   async deleteBanner(@Param('id') id: string) {
     return this.bannerService.deleteBannerById(Number(id));
   }
 
+  @ApiTags('Banner & Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a banner by id' })
+  @ApiParam({ name: 'id', description: 'Banner id', example: '12' })
+  @ApiBody({
+    description: 'Partial banner fields to update — any subset of BannerEntity columns; omitted fields are left unchanged.',
+    type: UpdateBannerDto,
+  })
+  @ApiResponse({ status: 200, description: 'Banner updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Patch('/ecom/banner/:id')
-  async updateBanner(
-    @Param('id') id: string,
-    @Body() data: Partial<BannerEntity>,
-  ) {
+  async updateBanner(@Param('id') id: string, @Body() data: UpdateBannerDto) {
     return this.bannerService.updateBanner(Number(id), data);
   }
 
+  @ApiTags('User & Employee Management')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get user data by member code' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'User data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/user-data/:mem_code')
   async getUserData(@Param('mem_code') mem_code: string) {
     return this.authService.fetchUserData(mem_code);
   }
 
+  @ApiTags('User & Employee Management')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update user data' })
+  @ApiBody({ type: UpdateUserDataDto })
+  @ApiResponse({ status: 201, description: 'User data updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/user-data/update')
-  async updateUserData(@Body() data: UserEntity) {
+  async updateUserData(@Body() data: UpdateUserDataDto) {
     return this.authService.updateUserData(data);
   }
 
+  @ApiTags('Banner & Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload banner image with metadata' })
+  @ApiBody({ type: UploadBannerDto })
+  @ApiResponse({ status: 201, description: 'Banner uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/upload-file')
   @UseInterceptors(FileInterceptor('file'))
   async uploadBanner(
     @UploadedFile() file: Express.Multer.File,
-    @Body()
-    data: {
-      date_start: Date;
-      date_end: Date;
-      banner_name?: string;
-      banner_location?: 'store_carousel' | 'landing_hero' | 'popup' | 'sidebar';
-      link_url?: string;
-      display_type?: 'image_only' | 'text_only' | 'image_with_text';
-      title?: string;
-      subtitle?: string;
-      description?: string;
-      cta_text?: string;
-      cta_url?: string;
-      cta_secondary_text?: string;
-      cta_secondary_url?: string;
-      text_color?: 'light' | 'dark';
-      text_position?: 'left' | 'center' | 'right';
-      bg_gradient?: string;
-      is_drug?: boolean;
-      advertise_code?: string;
-      creditor?: string;
-      product_list?: string;
-    },
+    @Body() data: UploadBannerDto,
   ) {
     this.logger.log('=== Controller uploadBanner ===');
     this.logger.log('File:', file ? file.originalname : 'No file');
@@ -234,18 +339,15 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Banner & Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create banner from image URL' })
+  @ApiBody({ type: CreateBannerFromUrlDto })
+  @ApiResponse({ status: 201, description: 'Banner created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/banner/from-url')
-  async createBannerFromUrl(
-    @Body()
-    body: {
-      img_url: string;
-      banner_name?: string;
-      banner_location?: 'store_carousel' | 'landing_hero' | 'popup' | 'sidebar';
-      date_start: Date;
-      date_end: Date;
-    },
-  ) {
+  async createBannerFromUrl(@Body() body: CreateBannerFromUrlDto) {
     const banner = await this.bannerService.createBannerFromUrl(body.img_url, {
       date_start: body.date_start,
       date_end: body.date_end,
@@ -255,12 +357,18 @@ export class AppController {
     return { success: true, data: banner };
   }
 
+  @ApiTags('User & Employee Management')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload user profile image' })
+  @ApiBody({ type: UploadImageUserDto })
+  @ApiResponse({ status: 201, description: 'User image uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/user/upload-file')
   @UseInterceptors(FileInterceptor('file'))
   async uploadImageUser(
     @UploadedFile() file: Express.Multer.File,
-    @Body() data: { mem_code: string; type: string; old_url: string },
+    @Body() data: UploadImageUserDto,
   ) {
     return await this.authService.UploadImage(
       file,
@@ -270,28 +378,49 @@ export class AppController {
     );
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get a feature flag status' })
+  @ApiParam({ name: 'flag', description: 'Feature flag name', example: 'new_checkout' })
+  @ApiResponse({ status: 200, description: 'Feature flag status' })
   @Get('/ecom/feature-flag/:flag')
   async checkFlag(@Param('flag') flag: string) {
     return this.featureFlagsService.getFlag(flag);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all feature flags' })
+  @ApiResponse({ status: 200, description: 'All feature flags' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/feature-flags')
   async getAllFlags() {
     return this.featureFlagsService.getAllFlags();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a feature flag status' })
+  @ApiBody({ type: UpdateFlagDto })
+  @ApiResponse({ status: 201, description: 'Feature flag updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/feature-flag/update-flag')
-  async updateFlag(@Body() data: { flag: string; status: boolean }) {
+  async updateFlag(@Body() data: UpdateFlagDto) {
     return this.featureFlagsService.updateFlag(data);
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload product PO data' })
+  @ApiBody({ type: [UploadPoItemDto] })
+  @ApiResponse({ status: 201, description: 'PO uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/products/insert-po')
   async uploadPO(
     @Req() req: Request & { user: JwtPayload },
-    @Body() data: { pro_code: string; month: number }[],
+    @Body() data: UploadPoItemDto[],
   ) {
     const permission = req.user.permission;
     if (permission === true) {
@@ -301,11 +430,17 @@ export class AppController {
     }
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload products for flash sale' })
+  @ApiBody({ type: [UploadProductFlashSaleItemDto] })
+  @ApiResponse({ status: 201, description: 'Flash sale products uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/products/upload-product-flashsale')
   async uploadProductFlashSale(
     @Req() req: Request & { user: JwtPayload },
-    @Body() data: { productCode: string; quantity: number }[],
+    @Body() data: UploadProductFlashSaleItemDto[],
   ) {
     const permission = req.user.permission;
     if (permission === true) {
@@ -315,15 +450,17 @@ export class AppController {
     }
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload product L16-only status' })
+  @ApiBody({ type: UploadProductL16Dto })
+  @ApiResponse({ status: 201, description: 'Product L16 status uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/admin/product-l16/upload')
   async uploadProductL16Only(
     @Req() req: Request & { user: JwtPayload },
-    @Body()
-    body: {
-      data: { pro_code: string; status: number | string }[];
-      filename: string;
-    },
+    @Body() body: UploadProductL16Dto,
   ) {
     const permission = req.user.permission;
     if (permission === true) {
@@ -333,6 +470,11 @@ export class AppController {
     }
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Export product L16 status' })
+  @ApiResponse({ status: 200, description: 'Product L16 status export' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/product-l16/export')
   async exportProductL16Status(@Req() req: Request & { user: JwtPayload }) {
@@ -344,6 +486,11 @@ export class AppController {
     }
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List flash sale product codes' })
+  @ApiResponse({ status: 200, description: 'Flash sale product codes' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/products/flashsale-procode')
   async listProcodeFlashSale(@Req() req: Request & { user: JwtPayload }) {
@@ -355,6 +502,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get favorite product list' })
+  @ApiParam({ name: 'mem_code', description: 'Member code (unused, taken from JWT)', example: 'M00123' })
+  @ApiQuery({ name: 'sort_by', required: false, description: 'Optional sort order key; omit for default order', example: 'name' })
+  @ApiResponse({ status: 200, description: 'Favorite list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/favorite/:mem_code')
   async getListFavorite(
@@ -369,11 +523,17 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get flash sale product list' })
+  @ApiBody({ type: GetFlashSaleDto })
+  @ApiResponse({ status: 201, description: 'Flash sale list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/flashsale/get-list')
   async getDataFlashSale(
     @Req() req: Request & { user: JwtPayload },
-    @Body() data: { limit: number; mem_code: string },
+    @Body() data: GetFlashSaleDto,
   ) {
     const mem_code = req.user.mem_code;
     const func = await this.productsService.getFlashSale(
@@ -393,17 +553,29 @@ export class AppController {
     return func;
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add product to favorites' })
+  @ApiBody({ type: AddToFavoriteDto })
+  @ApiResponse({ status: 201, description: 'Added to favorites' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/favorite/add')
-  async addToFavorite(@Body() data: { mem_code: string; pro_code: string }) {
+  async addToFavorite(@Body() data: AddToFavoriteDto) {
     return await this.favoriteService.addToFavorite(data);
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a favorite product' })
+  @ApiBody({ type: DeleteFavoriteDto })
+  @ApiResponse({ status: 201, description: 'Favorite deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/favorite/delete')
   async deleteFavorite(
     @Req() req: Request & { user: JwtPayload },
-    @Body() data: { fav_id: number; mem_code: string; sort_by?: number },
+    @Body() data: DeleteFavoriteDto,
   ) {
     return await this.favoriteService.deleteFavorite({
       ...data,
@@ -412,9 +584,13 @@ export class AppController {
     });
   }
 
+  @ApiTags('Auth & Session')
+  @ApiOperation({ summary: 'User login' })
+  @ApiBody({ type: SigninDto })
+  @ApiResponse({ status: 201, description: 'Login successful' })
   @Post('/ecom/login')
   async signin(
-    @Body() data: { username: string; password: string },
+    @Body() data: SigninDto,
     @Req() req: Request,
   ): Promise<SigninResponse> {
     const xClient = req.headers['x-client'] as string;
@@ -424,19 +600,17 @@ export class AppController {
     });
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search products via Elasticsearch' })
+  @ApiBody({ type: SearchProductsDto })
+  @ApiResponse({ status: 201, description: 'Search results' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/search-products')
   async searchProducts(
     @Req() req: Request & { user: JwtPayload },
-    @Body()
-    data: {
-      keyword: string;
-      offset: number;
-      mem_code: string;
-      sort_by?: number;
-      limit: number;
-      creditor_codes?: string[];
-    },
+    @Body() data: SearchProductsDto,
   ) {
     const mem_code = req.user.mem_code;
     const result = await this.productsService.searchProductsElastic({
@@ -450,27 +624,20 @@ export class AppController {
         imageUrl: resultItem.pro_imgmain,
       });
     }
-    this.searchCartTrackingService.emitSearchEvent(mem_code, {
-      search_query: data.keyword,
-      result_count: result.totalCount,
-      result_pro_codes: result.products.map((product) => product.pro_code),
-    });
     return result;
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search products by category' })
+  @ApiBody({ type: SearchCategoryProductsDto })
+  @ApiResponse({ status: 201, description: 'Category search results' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/category-products')
   async searchCategoryProducts(
     @Req() req: Request & { user: JwtPayload },
-    @Body()
-    data: {
-      keyword: string;
-      offset: number;
-      category: number;
-      mem_code: string;
-      sort_by?: number;
-      limit: number;
-    },
+    @Body() data: SearchCategoryProductsDto,
   ) {
     const mem_code = req.user.mem_code;
     return await this.productsService.searchCategoryProducts({
@@ -480,11 +647,17 @@ export class AppController {
     });
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get recommended products for user' })
+  @ApiBody({ type: ProductForYouDto })
+  @ApiResponse({ status: 201, description: 'Recommended products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-for-u')
   async productForYou(
     @Req() req: Request & { user: JwtPayload },
-    @Body() data: { keyword: string; pro_code: string },
+    @Body() data: ProductForYouDto,
   ) {
     const mem_code = req.user.mem_code;
     return await this.productsService.productForYou({
@@ -494,32 +667,18 @@ export class AppController {
     });
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Submit a shopping order' })
+  @ApiBody({ type: SubmitOrderDto })
+  @ApiResponse({ status: 201, description: 'Order submitted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/submit-order')
   async submitOrder(
     @Ip() ip: string,
     @Req() req: Request & { user: JwtPayload },
-    @Body()
-    data: {
-      emp_code?: string;
-      mem_code: string;
-      total_price: number;
-      listFree:
-        | [
-            {
-              pro_code: string;
-              amount: number;
-              pro_unit1: string;
-              pro_point: number;
-              unit_enum: '1' | '2' | '3';
-            },
-          ]
-        | null;
-      priceOption: string;
-      paymentOptions: string;
-      shippingOptions: string;
-      addressed: string;
-    },
+    @Body() data: SubmitOrderDto,
   ) {
     const mem_code = req.user.mem_code;
     try {
@@ -538,17 +697,29 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get cart item count' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'Cart item count' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/cart/count/:mem_code')
   async CountCart(@Param('mem_code') mem_code: string) {
     return await this.shoppingCartService.getCartItemCount(mem_code);
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get product detail' })
+  @ApiBody({ type: GetProductDetailDto })
+  @ApiResponse({ status: 201, description: 'Product detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-detail')
   async GetProductDetail(
     @Req() req: Request & { user: JwtPayload },
-    @Body() data: { pro_code: string; mem_code: string },
+    @Body() data: GetProductDetailDto,
   ) {
     this.logger.log('data in controller:', data);
     const mem_code = req.user.mem_code;
@@ -564,6 +735,12 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List point-redeemable products' })
+  @ApiParam({ name: 'sortBy', description: 'Sort order key, e.g. "name" or "point"', example: 'name' })
+  @ApiResponse({ status: 200, description: 'Product coin list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-coin/:sortBy')
   async productCoin(
@@ -599,24 +776,17 @@ export class AppController {
   //   }
   // }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add product to cart' })
+  @ApiBody({ type: AddProductCartDto })
+  @ApiResponse({ status: 201, description: 'Product added to cart' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-add-cart')
   async addProductCart(
     @Req() req: Request & { user: JwtPayload },
-    @Body()
-    data: {
-      mem_code: string;
-      pro_code: string;
-      pro_unit: string;
-      amount: number;
-      // pro_freebie: number;
-      flashsale_end: string;
-      cartVersion?: string | number;
-      clientVersion?: string;
-      company_day_source?: string;
-      source?: string;
-      search_query?: string;
-    },
+    @Body() data: AddProductCartDto,
   ) {
     const priceCondition = req.user.price_option ?? 'C';
     const payload: {
@@ -647,15 +817,6 @@ export class AppController {
     const summaryCart = await this.shoppingCartService.summaryCart(
       data.mem_code,
     );
-    const addedProduct = cart.find((item) => item.pro_code === data.pro_code);
-    this.searchCartTrackingService.emitAddToCartEvent(data.mem_code, {
-      pro_code: data.pro_code,
-      pro_name: addedProduct?.pro_name,
-      pro_unit: data.pro_unit,
-      amount: data.amount,
-      source: data.source,
-      search_query: data.search_query,
-    });
     return {
       cart,
       summaryCart: summaryCart.total,
@@ -664,33 +825,34 @@ export class AppController {
     };
   }
 
+  @ApiTags('Tracking & Analytics')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Track company day promotion view' })
+  @ApiBody({ type: TrackCompanyDayViewDto })
+  @ApiResponse({ status: 201, description: 'View tracked' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/company-day/view')
   trackCompanyDayView(
     @Req() req: Request & { user: JwtPayload },
-    @Body()
-    data: {
-      promo_id: number;
-      promo_name: string;
-      tier: string;
-      source: string;
-    },
+    @Body() data: TrackCompanyDayViewDto,
   ) {
     const mem_code = req.user.mem_code;
     void this.companyDayAnalyticService.emitEvent('view', mem_code, data);
     return { success: true };
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check/uncheck all cart items' })
+  @ApiBody({ type: CheckProductCartAllDto })
+  @ApiResponse({ status: 201, description: 'Cart items updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-check-all-cart')
   async checkProductCartAll(
     @Req() req: Request & { user: JwtPayload },
-    @Body()
-    data: {
-      mem_code: string;
-      type: string;
-      clientVersion?: string;
-    },
+    @Body() data: CheckProductCartAllDto,
   ) {
     const priceOption = req.user.price_option ?? 'C';
     const payload: {
@@ -713,16 +875,17 @@ export class AppController {
     };
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete product from cart' })
+  @ApiBody({ type: DeleteProductCartDto })
+  @ApiResponse({ status: 201, description: 'Product removed from cart' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-delete-cart')
   async deleteProductCart(
     @Req() req: Request & { user: JwtPayload },
-    @Body()
-    data: {
-      mem_code: string;
-      pro_code: string;
-      clientVersion?: string;
-    },
+    @Body() data: DeleteProductCartDto,
   ) {
     const priceOption = req.user.price_option ?? 'C';
     const payload: {
@@ -744,17 +907,17 @@ export class AppController {
     };
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check/uncheck a single cart item' })
+  @ApiBody({ type: CheckProductCartDto })
+  @ApiResponse({ status: 201, description: 'Cart item updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-check-cart')
   async checkProductCart(
     @Req() req: Request & { user: JwtPayload },
-    @Body()
-    data: {
-      mem_code: string;
-      pro_code: string;
-      type: string;
-      clientVersion?: string;
-    },
+    @Body() data: CheckProductCartDto,
   ) {
     this.logger.log('Check cart data:', data);
     const priceOption = req.user.price_option ?? 'C';
@@ -779,6 +942,12 @@ export class AppController {
     };
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get cart snapshot with summary' })
+  @ApiParam({ name: 'mem_code', description: 'Member code (unused, taken from JWT)', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'Cart snapshot' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-cart/:mem_code')
   async getProductCart(@Req() req: Request & { user: JwtPayload }) {
@@ -806,6 +975,12 @@ export class AppController {
     };
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Soft delete a cart item' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Cart item soft deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/delete-cart-item/:pro_code')
   async softDeleteCartItem(
@@ -818,12 +993,24 @@ export class AppController {
     );
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get a single product for cart' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Product detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-cart/get-one/:pro_code')
   async getProductCartOne(@Param('pro_code') pro_code: string) {
     return this.productsService.getProductOne(pro_code);
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get last 6 orders by member' })
+  @ApiParam({ name: 'memCode', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'Last 6 orders' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/last6/:memCode')
   async getLast6Orders(
@@ -840,6 +1027,12 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all orders by member' })
+  @ApiParam({ name: 'memCode', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'All member orders' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/all-order-member/:memCode')
   async AllOrderByMember(
@@ -857,6 +1050,12 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get a single order by running number' })
+  @ApiParam({ name: 'soh_runing', description: 'Order running number', example: 'SO-67010001' })
+  @ApiResponse({ status: 200, description: 'Order detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/some-order/:soh_runing')
   async SomeOrderByMember(
@@ -872,19 +1071,18 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a promotion with poster' })
+  @ApiBody({ type: AddPromotionDto })
+  @ApiResponse({ status: 201, description: 'Promotion created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/add')
   @UseInterceptors(FileInterceptor('file'))
   async addPromotion(
     @UploadedFile() file: Express.Multer.File,
-    @Body()
-    data: {
-      promo_name: string;
-      creditor_code: string;
-      start_date: Date;
-      end_date: Date;
-      status: string;
-    },
+    @Body() data: Omit<AddPromotionDto, 'file'>,
   ) {
     return this.promotionService.addPromotion({
       ...data,
@@ -894,12 +1092,18 @@ export class AppController {
     });
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update promotion poster image' })
+  @ApiBody({ type: UpdatePromoPosterDto })
+  @ApiResponse({ status: 201, description: 'Poster updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/update-poster')
   @UseInterceptors(FileInterceptor('file'))
   async updatePromoPoster(
     @UploadedFile() file: Express.Multer.File,
-    @Body() data: { promo_id: string },
+    @Body() data: Omit<UpdatePromoPosterDto, 'file'>,
   ) {
     return this.promotionService.updatePromoPoster({
       promo_id: Number(data.promo_id),
@@ -907,32 +1111,41 @@ export class AppController {
     });
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all promotions' })
+  @ApiResponse({ status: 200, description: 'Promotion list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/list')
   async getPromotions() {
     return this.promotionService.getAllPromotions();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get promotion detail by id' })
+  @ApiParam({ name: 'promo_id', description: 'Promotion id', example: '12' })
+  @ApiResponse({ status: 200, description: 'Promotion detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/detail/:promo_id')
   async getPromotion(@Param('promo_id') promo_id: string) {
     return this.promotionService.getPromotionById(Number(promo_id));
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a tier to a promotion' })
+  @ApiBody({ type: AddTierDto })
+  @ApiResponse({ status: 201, description: 'Tier added' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/add-tier')
   @UseInterceptors(FileInterceptor('file'))
   async addTier(
     @UploadedFile() file: Express.Multer.File,
-    @Body()
-    data: {
-      promo_id: number;
-      tier_name: string;
-      min_amount: number;
-      description?: string;
-      detail?: string;
-      is_unit_based?: string;
-    },
+    @Body() data: Omit<AddTierDto, 'file'>,
   ) {
     return this.promotionService.addTierToPromotion({
       promo_id: data.promo_id,
@@ -945,78 +1158,119 @@ export class AppController {
     });
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update promotion status' })
+  @ApiBody({ type: UpdatePromotionStatusDto })
+  @ApiResponse({ status: 201, description: 'Status updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/update-status')
-  async updatePromotionStatus(
-    @Body() data: { promo_id: number; status: boolean },
-  ) {
+  async updatePromotionStatus(@Body() data: UpdatePromotionStatusDto) {
     return this.promotionService.updateStatus(data.promo_id, data.status);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a tier' })
+  @ApiBody({ type: DeleteTierDto })
+  @ApiResponse({ status: 201, description: 'Tier deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/delete-tier')
-  async deleteTier(@Body() data: { tier_id: number }) {
+  async deleteTier(@Body() data: DeleteTierDto) {
     return this.promotionService.deleteTier(data.tier_id);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a promotion' })
+  @ApiBody({ type: DeletePromotionDto })
+  @ApiResponse({ status: 201, description: 'Promotion deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/delete')
-  async deletePromotion(@Body() data: { promo_id: number }) {
+  async deletePromotion(@Body() data: DeletePromotionDto) {
     return this.promotionService.deletePromotion(data.promo_id);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List promotions available for duplicate' })
+  @ApiResponse({ status: 200, description: 'Promotions for duplicate' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/list-for-duplicate')
   async getPromotionsForDuplicate() {
     return this.promotionService.getPromotionsForDuplicate();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Duplicate a promotion' })
+  @ApiBody({ type: DuplicatePromotionDto })
+  @ApiResponse({ status: 201, description: 'Promotion duplicated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/duplicate')
-  async duplicatePromotion(
-    @Body() data: { promo_id: number; start_date: Date; end_date: Date },
-  ) {
+  async duplicatePromotion(@Body() data: DuplicatePromotionDto) {
     return this.promotionService.duplicatePromotion(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a promotion condition' })
+  @ApiBody({ type: AddPromotionConditionDto })
+  @ApiResponse({ status: 201, description: 'Condition created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/condition/add')
-  async addPromotionCondition(
-    @Body()
-    data: {
-      tier_id: number;
-      product_gcode: string;
-    },
-  ) {
+  async addPromotionCondition(@Body() data: AddPromotionConditionDto) {
     return this.promotionService.createCondition(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a promotion condition' })
+  @ApiBody({ type: DeletePromotionConditionDto })
+  @ApiResponse({ status: 201, description: 'Condition deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/condition/delete')
-  async deletePromotionCondition(@Body() data: { cond_id: number }) {
+  async deletePromotionCondition(@Body() data: DeletePromotionConditionDto) {
     return this.promotionService.deleteCondition(data.cond_id);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List conditions by tier' })
+  @ApiParam({ name: 'tier_id', description: 'Tier id', example: '5' })
+  @ApiResponse({ status: 200, description: 'Conditions list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/condition/list/:tier_id')
   async listPromotionConditions(@Param('tier_id') tier_id: string) {
     return this.promotionService.getConditionsByTier(Number(tier_id));
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a promotion reward' })
+  @ApiBody({ type: AddPromotionRewardDto })
+  @ApiResponse({ status: 201, description: 'Reward created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/reward/add')
-  async addPromotionReward(
-    @Body()
-    data: {
-      tier_id: number;
-      product_gcode: string;
-      qty: number;
-      unit: string;
-    },
-  ) {
+  async addPromotionReward(@Body() data: AddPromotionRewardDto) {
     return this.promotionService.createReward(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List rewards by tier' })
+  @ApiParam({ name: 'tier_id', description: 'Tier id', example: '5' })
+  @ApiResponse({ status: 200, description: 'Rewards list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/reward/list/:tier_id')
   async listPromotionRewards(
@@ -1030,76 +1284,113 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get products by creditor' })
+  @ApiBody({ type: GetProductByCreditorDto })
+  @ApiResponse({ status: 201, description: 'Products by creditor' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/product/creditor')
-  async getProductByCreditor(@Body() data: { creditor_code: string }) {
+  async getProductByCreditor(@Body() data: GetProductByCreditorDto) {
     return this.productsService.getProductByCreditor(data.creditor_code);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get products for promotion key search' })
+  @ApiResponse({ status: 200, description: 'Key search products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/product/keysearch')
   async getProductForKeySearch() {
     return this.productsService.getProductForKeySearch();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get flash sale products for key search' })
+  @ApiResponse({ status: 200, description: 'Flash sale key search products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/product/keysearch-flashsale')
   async getProductForKeySearchForFlashSale() {
     return this.productsService.getProductForKeySearchForFlashSale();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get recommend products for key search' })
+  @ApiResponse({ status: 200, description: 'Recommend key search products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/product/keysearch-recommend')
   async getProductForKeySearchForRecommend() {
     return this.productsService.getProductForKeySearchForRecommend();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiOperation({ summary: 'Get replace products for key search' })
+  @ApiResponse({ status: 200, description: 'Replace key search products' })
   // @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/product/keysearch-replace')
   async getProductForKeySearchForReplace() {
     return this.productsService.getProductForKeySearchForReplace();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get a tier by id' })
+  @ApiParam({ name: 'tier_id', description: 'Tier id', example: '5' })
+  @ApiResponse({ status: 200, description: 'Tier detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/tiers/:tier_id')
   async getTierByID(@Param('tier_id') tier_id: number) {
     return this.promotionService.getTierOneById(tier_id);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a promotion reward' })
+  @ApiBody({ type: DeletePromotionRewardDto })
+  @ApiResponse({ status: 201, description: 'Reward deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/reward/delete')
-  async deletePromotionReward(@Body() data: { reward_id: number }) {
+  async deletePromotionReward(@Body() data: DeletePromotionRewardDto) {
     return this.promotionService.deleteReward(data.reward_id);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a promotion' })
+  @ApiBody({ type: UpdatePromotionDto })
+  @ApiResponse({ status: 201, description: 'Promotion updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/update/promotion')
-  async updatePromotion(
-    @Body()
-    data: {
-      promo_id: number;
-      promo_name?: string;
-      start_date?: Date;
-      end_date?: Date;
-      status?: boolean;
-    },
-  ) {
+  async updatePromotion(@Body() data: UpdatePromotionDto) {
     return this.promotionService.updatePromotion(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Edit a promotion reward' })
+  @ApiBody({ type: EditPromotionRewardDto })
+  @ApiResponse({ status: 201, description: 'Reward edited' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/update/edit-reward')
-  async editReward(
-    @Body()
-    data: {
-      reward_id: number;
-      qty: number;
-      unit: string;
-    },
-  ) {
+  async editReward(@Body() data: EditPromotionRewardDto) {
     return this.promotionService.editReward(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all tiers for customer' })
+  @ApiResponse({ status: 200, description: 'Tiers for customer' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/get-tier-for-customer')
   async getTierAll(@Req() req: Request & { user: JwtPayload }) {
@@ -1109,56 +1400,55 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all tier products' })
+  @ApiResponse({ status: 200, description: 'All tier products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/get-tier-products-all')
   async getTierProducts() {
     return this.promotionService.getAllTiersProduct();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get tier products for customer' })
+  @ApiBody({ type: GetProductTierDto })
+  @ApiResponse({ status: 201, description: 'Tier products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/get-tier-product-for-customer')
-  async getProductTier(
-    @Body() data: { tier_id: number; mem_code: string; sort_by?: number },
-  ) {
+  async getProductTier(@Body() data: GetProductTierDto) {
     return this.promotionService.tierProducts(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiOperation({ summary: 'Add a creditor' })
+  @ApiBody({ type: AddCreditorDto })
+  @ApiResponse({ status: 201, description: 'Creditor added' })
   @Post('/ecom/promotion/creditor/add-creditor')
-  async addCreditor(
-    @Body() data: { creditor_code: string; creditor_name: string },
-  ) {
+  async addCreditor(@Body() data: AddCreditorDto) {
     return this.productsService.addCreditor(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiOperation({ summary: 'Edit a tier' })
+  @ApiBody({ type: EditTierDto })
+  @ApiResponse({ status: 201, description: 'Tier edited' })
   @Post('/ecom/promotion/edit-tier')
-  async editTier(
-    @Body()
-    data: {
-      tier_id: number;
-      tier_name?: string;
-      min_amount?: number;
-      description?: string;
-      detail?: string;
-    },
-  ) {
+  async editTier(@Body() data: EditTierDto) {
     return await this.promotionService.updateTier(data);
   }
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Import wangday data from Excel' })
+  @ApiBody({ type: ImportWangdayDto })
+  @ApiResponse({ status: 201, description: 'Wangday data imported' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/wangday/import')
-  async importWangday(
-    @Body()
-    body: {
-      data: {
-        date: string;
-        sh_running: string;
-        wang_code: string;
-        sumprice: string;
-      }[];
-      isLastChunk: boolean;
-      isFirstChunk: boolean;
-      fileName: string;
-    },
-  ) {
+  async importWangday(@Body() body: ImportWangdayDto) {
     try {
       // แปลง key ภาษาไทยเป็น key ที่ entity ใช้
       const rows = (body.data || []).map((item) => {
@@ -1202,16 +1492,28 @@ export class AppController {
     }
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get monthly wangday sum by code' })
+  @ApiParam({ name: 'wang_code', description: 'Wang code', example: 'W001' })
+  @ApiResponse({ status: 200, description: 'Monthly wangday sum' })
   @Get('/ecom/wangday/monthly/:wang_code')
   async getWangdayMonthly(@Param('wang_code') wang_code: string) {
     const result = await this.wangdayService.getMonthlySumByWangCode(wang_code);
     return result;
   }
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get all wangday sum price by code' })
+  @ApiParam({ name: 'wang_code', description: 'Wang code', example: 'W001' })
+  @ApiResponse({ status: 200, description: 'Wangday sum price' })
   @Get('/ecom/wangsumprice/:wang_code')
   async getWangSumPrice(@Param('wang_code') wang_code: string) {
     return this.wangdayService.getAllWangSumPrice(wang_code);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiOperation({ summary: 'Search main products for hotdeal' })
+  @ApiParam({ name: 'keyword', description: 'Search keyword', example: 'paracetamol' })
+  @ApiResponse({ status: 201, description: 'Matched products' })
   @Post('/ecom/admin/hotdeal/search-product-main/:keyword')
   async searchProductMain(@Param('keyword') keyword: string) {
     const result = await this.hotdealService.searchProduct(keyword);
@@ -1224,17 +1526,15 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create or update a hotdeal' })
+  @ApiBody({ type: SaveHotdealDto })
+  @ApiResponse({ status: 201, description: 'Hotdeal saved' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/admin/hotdeal/save-hotdeal')
-  async saveHotdeal(
-    @Body()
-    body: {
-      data: HotdealInput;
-      id?: number;
-      order?: number;
-      special_deal?: boolean;
-    },
-  ) {
+  async saveHotdeal(@Body() body: SaveHotdealDto) {
     this.logger.log('Saving Hotdeal:', body);
     return this.hotdealService.saveHotdeal(
       body.data,
@@ -1244,17 +1544,34 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiOperation({ summary: 'Get all hotdeals with product names' })
+  @ApiResponse({ status: 200, description: 'List of hotdeals' })
   @Get('/ecom/admin/hotdeal/all-hotdeals')
   async getAllHotdeals() {
     return this.hotdealService.getAllHotdealsWithProductNames();
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a hotdeal' })
+  @ApiBody({ type: DeleteHotdealDto })
+  @ApiResponse({ status: 200, description: 'Hotdeal deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/admin/hotdeal/delete')
-  async deleteHotdeal(@Body() data: { id: number; pro_code: string }) {
+  async deleteHotdeal(@Body() data: DeleteHotdealDto) {
     return this.hotdealService.deleteHotdeal(data.id, data.pro_code);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get hotdeals (simple list) for current member' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
+  @ApiQuery({ name: 'special_deal', required: false, type: String, description: '"true" or "false"', example: 'false' })
+  @ApiResponse({ status: 200, description: 'List of hotdeals' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/hotdeal/simple-list')
   async getAllHotdealsSimple(
@@ -1276,6 +1593,13 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get product-pro deals (simple list) for current member' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
+  @ApiResponse({ status: 200, description: 'List of product-pro deals' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-pro/simple-list')
   async getProductProSimpleList(
@@ -1291,6 +1615,13 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get "buy more get 1" deals (simple list) for current member' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
+  @ApiResponse({ status: 200, description: 'List of buy-more-get-1 deals' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/buy-more-get-1/simple-list')
   async getBuyMoreGetOneSimpleList(
@@ -1306,16 +1637,12 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiOperation({ summary: 'Check which cart items match active hotdeals' })
+  @ApiBody({ type: CheckHotdealMatchDto })
+  @ApiResponse({ status: 201, description: 'Matched hotdeals' })
   @Post('/ecom/hotdeal/check-hotdeal-match')
-  async checkHotdealMatch(
-    @Body()
-    body: {
-      hotDeal: {
-        pro_code: string;
-        shopping_cart: { pro1_unit: string; pro1_amount: string }[];
-      }[];
-    },
-  ) {
+  async checkHotdealMatch(@Body() body: CheckHotdealMatchDto) {
     try {
       const allResults = await Promise.all(
         (body.hotDeal || []).map(async (deal) => {
@@ -1335,11 +1662,17 @@ export class AppController {
     }
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Apply a promo code and check reward in cart' })
+  @ApiBody({ type: UseCodeForCheckRewardDto })
+  @ApiResponse({ status: 201, description: 'Reward checked' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/code/use')
   async useCodeForCheckReward(
     @Req() req: Request & { user: JwtPayload },
-    @Body() body: { code_text: string },
+    @Body() body: UseCodeForCheckRewardDto,
   ) {
     const mem_code = req.user.mem_code;
     const price_option = req.user.price_option ?? 'C';
@@ -1350,11 +1683,17 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Generate a promo code for a member (requires permission)' })
+  @ApiBody({ type: GenerateCodePromotionDto })
+  @ApiResponse({ status: 201, description: 'Promo code generated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/code/generate')
   async generateCodePromotion(
     @Req() req: Request & { user: JwtPayload },
-    @Body() data: { mem_code: string },
+    @Body() data: GenerateCodePromotionDto,
   ) {
     const permission = req.user.permission;
     if (permission !== true) {
@@ -1363,33 +1702,23 @@ export class AppController {
     return this.promotionService.generateCodePromotion(data.mem_code);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiOperation({ summary: 'Get hotdeal/freebie detail by product code' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Hotdeal detail' })
   @Get('/ecom/hotdeal/get-hotdeal-from-code/:pro_code')
   async getHotdealFromCode(@Param('pro_code') pro_code: string) {
     return await this.hotdealService.getHotdealFromCode(pro_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Bulk update products from back office import file' })
+  @ApiBody({ type: UpdateProductFromBackOfficeDto })
+  @ApiResponse({ status: 201, description: 'Products updated' })
   @Post('/ecom/admin/update-product-from-back-office')
   async updateProductFromBackOffice(
     @Body()
-    body: {
-      group: {
-        pro_code: string;
-        pro_name: string;
-        priceA: number;
-        priceB: number;
-        priceC: number;
-        ratio1: number;
-        ratio2: number;
-        ratio3: number;
-        unit1: string;
-        unit2: string;
-        unit3: string;
-        supplier: string;
-        pro_lowest_stock: number;
-        order_quantity: number;
-      }[];
-      filename: string;
-    },
+    body: UpdateProductFromBackOfficeDto,
   ) {
     try {
       return this.productsService.updateProductFromBackOffice({
@@ -1402,35 +1731,34 @@ export class AppController {
     }
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Bulk upsert customer accounts' })
+  @ApiBody({ type: [UpdateCustomerDataDto] })
+  @ApiResponse({ status: 201, description: 'Customers upserted' })
   @Post('/ecom/update-customer-data')
   async updateCustomerData(
     @Body()
-    data: {
-      mem_code: string;
-      mem_nameSite: string;
-      mem_username: string;
-      mem_password: string;
-      mem_price: string;
-      emp_saleoffice: string;
-      latest_purchase: string;
-      emp_id_ref?: string;
-    }[],
+    data: UpdateCustomerDataDto[],
   ) {
     return this.authService.upsertUser(data);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get last shopping head running number' })
+  @ApiResponse({ status: 200, description: 'Last sh_running value' })
   @Get('/ecom/last-sh-running')
   async getLastShRunning() {
     return this.shoppingHeadService.getLastSHRunnning();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Bulk update stock from back office import file' })
+  @ApiBody({ type: UpdateStockFromBackOfficeDto })
+  @ApiResponse({ status: 201, description: 'Stock updated' })
   @Post('/ecom/admin/update-stock-from-back-office')
   async updateStockFromBackOffice(
     @Body()
-    body: {
-      group: { pro_code: string; stock: number }[];
-      filename: string;
-    },
+    body: UpdateStockFromBackOfficeDto,
   ) {
     try {
       return await this.productsService.updateStock(body);
@@ -1439,12 +1767,21 @@ export class AppController {
       throw new Error('Error updating stock from back office');
     }
   }
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Reindex all products to Elasticsearch' })
+  @ApiResponse({ status: 201, description: 'Sync started/completed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/admin/sync-products-elastic')
   async syncProductsToElastic() {
     return this.productsService.syncAllProductsToElastic();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get file log entries by feature' })
+  @ApiParam({ name: 'feature', description: 'Feature name', example: 'wangday-import' })
+  @ApiResponse({ status: 200, description: 'File log entries' })
   @Get('/ecom/fileLog/:feature')
   async getFileLog(@Param('feature') feature: string) {
     const fileLogs = await this.backendService.getFeatured({
@@ -1453,18 +1790,35 @@ export class AppController {
     return fileLogs;
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all debtor records for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of debtor records' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/debtor/:mem_code')
   async getDebtor(@Param('mem_code') mem_code: string) {
     return await this.debtorService.getAllDebtors(mem_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get favorite product count for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'Favorite count' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/favorite/count/:mem_code')
   async getCountFavorite(@Param('mem_code') mem_code: string) {
     return await this.favoriteService.getCountFavorite(mem_code);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all searchable product keywords for current member' })
+  @ApiResponse({ status: 200, description: 'List of product keywords' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product/keysearch-all')
   async getKeySearch(@Req() req: Request & { user: JwtPayload }) {
@@ -1475,54 +1829,68 @@ export class AppController {
     );
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add product lot/expiry records' })
+  @ApiBody({ type: [AddLotItemDto] })
+  @ApiResponse({ status: 201, description: 'Lots added' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/lot/add-lots')
   async addLots(
     @Body()
-    data: {
-      lot: string;
-      mfg: string;
-      exp: string;
-      pro_code: string;
-    }[],
+    data: AddLotItemDto[],
   ) {
     return this.lotService.addLots(data);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a daily flash sale promotion' })
+  @ApiBody({ type: AddFlashsaleDto })
+  @ApiResponse({ status: 201, description: 'Flash sale created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/add-flashsale')
   async addDailyFlashsale(
     @Body()
-    data: {
-      promotion_name: string;
-      date: string;
-      time_start: string;
-      time_end: string;
-      is_active: boolean;
-    },
+    data: AddFlashsaleDto,
   ) {
     return await this.flashsaleService.addFlashSale(data);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a product to a daily flash sale' })
+  @ApiBody({ type: AddProductToFlashsaleDto })
+  @ApiResponse({ status: 201, description: 'Product added to flash sale' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/add-product')
   async addProductToDailyFlashsale(
     @Body()
-    data: {
-      promotion_id: number;
-      pro_code: string;
-      limit: number;
-    },
+    data: AddProductToFlashsaleDto,
   ) {
     return await this.flashsaleService.addProductToFlashSale(data);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all daily flash sale promotions' })
+  @ApiResponse({ status: 200, description: 'List of flash sales' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/daily-flashsale/list')
   async getAllDailyFlashsales() {
     return await this.flashsaleService.getAllFlashSales();
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get products in a daily flash sale' })
+  @ApiParam({ name: 'promotion_id', description: 'Flash sale promotion id', example: '3' })
+  @ApiResponse({ status: 200, description: 'List of products in flash sale' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/daily-flashsale/products/:promotion_id')
   async getProductsInDailyFlashsale(
@@ -1531,25 +1899,43 @@ export class AppController {
     return await this.flashsaleService.getProductsInFlashSale(promotion_id);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a product from a daily flash sale' })
+  @ApiBody({ type: DeleteProductFlashsaleDto })
+  @ApiResponse({ status: 200, description: 'Product removed from flash sale' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/daily-flashsale/delete-product')
   async deleteProductDailyFlashsale(@Body('id') id: number) {
     return await this.flashsaleService.deleteProduct(id);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Edit a product in a daily flash sale' })
+  @ApiBody({ type: EditProductInFlashsaleDto })
+  @ApiResponse({ status: 201, description: 'Product updated in flash sale' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/edit-product')
   async editProductInDailyFlashSale(
-    @Body() data: { id: number; limit: number },
+    @Body() data: EditProductInFlashsaleDto,
   ) {
     return await this.flashsaleService.editProductInFlashSale(data);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get active flash sale for current member' })
+  @ApiBody({ type: GetFlashsaleByDateDto })
+  @ApiResponse({ status: 201, description: 'Flash sale data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/get-flashsale')
   async getFlashsaleByDate(
     @Req() req: Request & { user: JwtPayload },
-    @Body() data: { limit: number; mem_code: string },
+    @Body() data: GetFlashsaleByDateDto,
   ) {
     const mem_code = req.user.mem_code;
     return await this.flashsaleService.getFlashSale(
@@ -1559,10 +1945,16 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Change active status of a daily flash sale' })
+  @ApiBody({ type: ChangeStatusFlashsaleDto })
+  @ApiResponse({ status: 201, description: 'Status changed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/change-status')
   async changeStatusDailyFlashsale(
-    @Body() data: { id: number; is_active: boolean },
+    @Body() data: ChangeStatusFlashsaleDto,
   ) {
     return await this.flashsaleService.changeStatus({
       promotion_id: data.id,
@@ -1570,61 +1962,87 @@ export class AppController {
     });
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a daily flash sale' })
+  @ApiBody({ type: DeleteFlashsaleDto })
+  @ApiResponse({ status: 200, description: 'Flash sale deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/daily-flashsale/delete-flashsale')
   async deleteDailyFlashsale(@Body('id') id: number) {
     return await this.flashsaleService.deleteFlashSale(id);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upsert a file log entry' })
+  @ApiBody({ type: UploadLogFileDto })
+  @ApiResponse({ status: 201, description: 'File log upserted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/upload-log-file')
-  async uploadLogFile(@Body() data: { feature: string; filename: string }) {
+  async uploadLogFile(@Body() data: UploadLogFileDto) {
     return await this.backendService.upsertFileLog({
       feature: data.feature,
       filename: data.filename,
     });
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get the log file for a feature' })
+  @ApiParam({ name: 'feature', description: 'Feature name', example: 'wangday-import' })
+  @ApiResponse({ status: 200, description: 'Log file content' })
   @Get('/ecom/get-upload-log-file/:feature')
   async getUploadLogFile(@Param('feature') feature: string) {
     return await this.backendService.getLogfile(feature);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Edit a daily flash sale promotion' })
+  @ApiBody({ type: EditFlashsaleDto })
+  @ApiResponse({ status: 201, description: 'Flash sale updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/edit-flashsale')
   async editDailyFlashsale(
     @Body()
-    data: {
-      promotion_id: number;
-      promotion_name: string;
-      date: string;
-      time_start: string;
-      time_end: string;
-      is_active: boolean;
-    },
+    data: EditFlashsaleDto,
   ) {
     return await this.flashsaleService.EditFlashSale(data);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add an invisible-product topic for a creditor' })
+  @ApiBody({ type: AddInvisibleTopicDto })
+  @ApiResponse({ status: 201, description: 'Topic added' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/invisible-product/add-invisible-topic')
   async addInvisibleTopic(
     @Body()
-    data: {
-      invisible_name: string;
-      date_end: string;
-      creditor_code: string;
-    },
+    data: AddInvisibleTopicDto,
   ) {
     return await this.invisibleService.addInvisibleTopic(data);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all invisible-product topics' })
+  @ApiResponse({ status: 200, description: 'List of invisible-product topics' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/invisible-product/get-invisible-topic-all')
   async getInvisibleTopic() {
     return await this.invisibleService.handleGetInvisibleTopics();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get invisible products by creditor code' })
+  @ApiParam({ name: 'creditor_code', description: 'Creditor code', example: 'C00123' })
+  @ApiResponse({ status: 200, description: 'List of products' })
   @Get('/ecom/invisible/product/creditor/:creditor_code')
   async getInvisibleProductByCreditor(
     @Param('creditor_code') creditor_code: string,
@@ -1632,6 +2050,10 @@ export class AppController {
     return this.productsService.getProductByCreditor(creditor_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get invisible products by invisible topic id' })
+  @ApiParam({ name: 'invisible_id', description: 'Invisible topic id', example: 1 })
+  @ApiResponse({ status: 200, description: 'List of products' })
   @Get('/ecom/invisible/product/creditor/list/:invisible_id')
   async getInvisibleProductByInvisibleID(
     @Param('invisible_id') invisible_id: number,
@@ -1639,24 +2061,39 @@ export class AppController {
     return this.invisibleService.handleGetInvisibleProducts(invisible_id);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a product to an invisible-product topic' })
+  @ApiBody({ type: AddInvisibleProductDto })
+  @ApiResponse({ status: 201, description: 'Product added to topic' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/invisible-product/add-product')
   async addInvisibleProduct(
     @Body()
-    data: {
-      invisible_id: number;
-      pro_code: string;
-    },
+    data: AddInvisibleProductDto,
   ) {
     return await this.invisibleService.updateProductInvisible(data);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a product from invisible-product topics' })
+  @ApiBody({ type: DeleteInvisibleProductDto })
+  @ApiResponse({ status: 201, description: 'Product removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/invisible-product/delete-product')
   async deleteInvisibleProduct(@Body('pro_code') pro_code: string) {
     return await this.invisibleService.removeProductInvisible(pro_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete an invisible-product topic' })
+  @ApiBody({ type: DeleteInvisibleTopicDto })
+  @ApiResponse({ status: 200, description: 'Topic deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/invisible-product/delete-topic')
   async deleteInvisibleTopic(@Body('invisible_id') invisible_id: string) {
@@ -1665,65 +2102,76 @@ export class AppController {
     );
   }
 
+  @ApiTags('Address')
+  @ApiOperation({ summary: 'Get an address by id' })
+  @ApiParam({ name: 'addressId', description: 'Address id', example: 5 })
+  @ApiResponse({ status: 201, description: 'Address detail' })
   // @UseGuards(JwtAuthGuard)
   @Post('/ecom/address/edit-address/:addressId')
   async editAddress(@Param('addressId') addressId: number) {
     return this.editAddressService.getAddressById(addressId);
   }
 
+  @ApiTags('Address')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new address for a member' })
+  @ApiBody({ type: CreateAddressBodyDto })
+  @ApiResponse({ status: 201, description: 'Address created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/address/create-address')
   async createAddress(
     @Body()
-    addressData: {
-      name?: string;
-      fullName: string;
-      mem_address?: string;
-      mem_village?: string;
-      mem_alley?: string;
-      mem_road?: string;
-      mem_province: string;
-      mem_amphur: string;
-      mem_tumbon: string;
-      mem_post: string;
-      phoneNumber: string;
-      Note?: string;
-      defaults?: boolean;
-      mem_code: string;
-    },
+    addressData: CreateAddressBodyDto,
   ) {
     return this.editAddressService.createAddress(addressData);
   }
 
+  @ApiTags('Address')
+  @ApiOperation({ summary: 'Update an existing address' })
+  @ApiParam({ name: 'id', description: 'Address id', example: 5 })
+  @ApiBody({ type: EditAddress })
+  @ApiResponse({ status: 200, description: 'Address updated' })
   // @UseGuards(JwtAuthGuard)
   @Put('/ecom/address/update-address/:id')
   async updateAddress(@Param('id') id: number, @Body() address: EditAddress) {
     return this.editAddressService.updateAddress(id, address);
   }
 
+  @ApiTags('Address')
+  @ApiOperation({ summary: 'Get all addresses for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of addresses' })
   @Get('/ecom/address/:mem_code')
   async getAddressByUser(@Param('mem_code') mem_code: string) {
     return await this.editAddressService.getAddressesByUser(mem_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Save modal/popup content' })
+  @ApiBody({ type: SaveModalContentDto })
+  @ApiResponse({ status: 201, description: 'Modal content saved' })
   @Post('/ecom/admin/modal-content/save')
   async saveModalContent(
     @Body()
-    body: {
-      id: number;
-      title: string;
-      content?: string;
-      show: boolean;
-    },
+    body: SaveModalContentDto,
   ) {
     return this.modalContentService.saveModalContent(body);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get modal/popup content' })
+  @ApiResponse({ status: 200, description: 'Modal content' })
   @Get('/ecom/admin/modal-content/get')
   async getModalContent() {
     return this.modalContentService.getModalContent();
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all "fix free" (point-redeemable) products' })
+  @ApiResponse({ status: 200, description: 'List of free products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-free/all')
   async getAllProductFree() {
@@ -1734,21 +2182,39 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a product to the "fix free" point-redeemable list' })
+  @ApiBody({ type: AddProductFreeDto })
+  @ApiResponse({ status: 201, description: 'Product added' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-free/add')
-  async addProductFree(@Body() data: { pro_code: string; pro_point: number }) {
+  async addProductFree(@Body() data: AddProductFreeDto) {
     return await this.fixFreeService.addProductFree(data);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a product from the "fix free" list' })
+  @ApiBody({ type: DeleteProductFreeDto })
+  @ApiResponse({ status: 200, description: 'Product removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/product-free/delete')
-  async deleteProductFree(@Body() data: { pro_code: string }) {
+  async deleteProductFree(@Body() data: DeleteProductFreeDto) {
     return await this.fixFreeService.removeProductFree(data.pro_code);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Edit the point cost of a "fix free" product' })
+  @ApiBody({ type: EditProductFreeDto })
+  @ApiResponse({ status: 201, description: 'Product point updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-free/edit')
-  async editProductFree(@Body() data: { pro_code: string; pro_point: number }) {
+  async editProductFree(@Body() data: EditProductFreeDto) {
     return await this.fixFreeService.editPoint(data.pro_code, data.pro_point);
   }
 
@@ -1757,8 +2223,12 @@ export class AppController {
   //   return { ip };
   // }
 
+  @ApiTags('Auth')
+  @ApiOperation({ summary: 'Refresh an access token' })
+  @ApiBody({ type: RefreshTokenDto })
+  @ApiResponse({ status: 201, description: 'New access token issued' })
   @Post('/ecom/refresh_token')
-  async refreshToken(@Body() body: { token: string }, @Req() req: Request) {
+  async refreshToken(@Body() body: RefreshTokenDto, @Req() req: Request) {
     return this.authService.refreshToken(
       body.token,
       req.headers['x-client'] as string,
@@ -1766,17 +2236,18 @@ export class AppController {
   }
 
   // Session Management APIs
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a login session for current member' })
+  @ApiBody({ type: CreateSessionDto })
+  @ApiResponse({ status: 201, description: 'Session created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/session/create')
   async createSession(
     @Req() req: Request & { user: JwtPayload },
     @Body()
-    data: {
-      session_token: string;
-      ip_address?: string;
-      user_agent?: string;
-      device_type?: string;
-    },
+    data: CreateSessionDto,
   ) {
     const mem_code = req.user.mem_code;
     return await this.sessionsService.createSession(
@@ -1788,18 +2259,36 @@ export class AppController {
     );
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get an active session by token' })
+  @ApiParam({ name: 'session_token', description: 'Session token', example: 'a1b2c3d4e5' })
+  @ApiResponse({ status: 200, description: 'Active session' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/session/active/:session_token')
   async getActiveSession(@Param('session_token') session_token: string) {
     return await this.sessionsService.findActiveSession(session_token);
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all active sessions for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of active sessions' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/session/user-sessions/:mem_code')
   async getUserActiveSessions(@Param('mem_code') mem_code: string) {
     return await this.sessionsService.findUserActiveSessions(mem_code);
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update last activity timestamp of a session' })
+  @ApiParam({ name: 'session_token', description: 'Session token', example: 'a1b2c3d4e5' })
+  @ApiResponse({ status: 200, description: 'Session activity updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/session/update-activity/:session_token')
   async updateSessionActivity(@Param('session_token') session_token: string) {
@@ -1807,27 +2296,51 @@ export class AppController {
     return { message: 'Session activity updated successfully' };
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Logout a single session' })
+  @ApiBody({ type: LogoutSessionDto })
+  @ApiResponse({ status: 201, description: 'Logout successful' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/session/logout')
-  async logoutSession(@Body() data: { session_token: string }) {
+  async logoutSession(@Body() data: LogoutSessionDto) {
     await this.sessionsService.logoutSession(data.session_token);
     return { message: 'Logout successful' };
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Logout all sessions of a member' })
+  @ApiBody({ type: MemCodeDto })
+  @ApiResponse({ status: 201, description: 'All sessions logged out' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/session/logout-all')
-  async logoutAllSessions(@Body() data: { mem_code: string }) {
+  async logoutAllSessions(@Body() data: MemCodeDto) {
     await this.sessionsService.logoutAllUserSessions(data.mem_code);
     return { message: 'All sessions logged out successfully' };
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Logout recently active sessions of a member' })
+  @ApiBody({ type: MemCodeDto })
+  @ApiResponse({ status: 201, description: 'Recently active sessions logged out' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/session/logout-recent')
-  async logoutRecentSessions(@Body() data: { mem_code: string }) {
+  async logoutRecentSessions(@Body() data: MemCodeDto) {
     await this.sessionsService.logoutRecentUserSessions(data.mem_code);
     return { message: 'Recently active sessions logged out successfully' };
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Validate whether a session token is still active' })
+  @ApiParam({ name: 'session_token', description: 'Session token', example: 'a1b2c3d4e5' })
+  @ApiResponse({ status: 200, description: 'Validation result' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/session/validate/:session_token')
   async validateSession(@Param('session_token') session_token: string) {
@@ -1835,6 +2348,12 @@ export class AppController {
     return { is_valid: isValid };
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Count active sessions of a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'Active session count' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/session/count/:mem_code')
   async countActiveSessions(@Param('mem_code') mem_code: string) {
@@ -1842,6 +2361,10 @@ export class AppController {
     return { active_sessions_count: count };
   }
 
+  @ApiTags('Password')
+  @ApiOperation({ summary: 'Check whether a member has an email on file for password reset' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'Email check result' })
   @Get('/ecom/password/check-email/:mem_code')
   async checkEmail(@Param('mem_code') mem_code: string): Promise<{
     RefKey?: string;
@@ -1853,6 +2376,10 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Password')
+  @ApiOperation({ summary: 'Request an OTP for password reset' })
+  @ApiBody({ type: RequestOtpDto })
+  @ApiResponse({ status: 201, description: 'OTP request result' })
   @Post('/ecom/password/request-otp')
   async requestOtp(@Body('mem_code') mem_code: string): Promise<{
     valid: boolean;
@@ -1863,29 +2390,31 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Password')
+  @ApiOperation({ summary: 'Validate an OTP for password reset' })
+  @ApiBody({ type: ValidateOtpDto })
+  @ApiResponse({ status: 201, description: 'OTP validation result' })
   @Post('/ecom/password/validate-otp')
   async validateOtp(
     @Body()
-    data: {
-      mem_username: string;
-      otp: string;
-      timeNow: string;
-    },
+    data: ValidateOtpDto,
   ): Promise<{ valid: boolean; message: string; block?: boolean }> {
     const result = await this.changePasswordService.validateOtp(data);
     return result;
   }
 
+  @ApiTags('Password')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Change password for current member' })
+  @ApiBody({ type: ChangePasswordDto })
+  @ApiResponse({ status: 200, description: 'Password change result' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/password/change-password')
   async changePassword(
     @Req() req: Request & { user: JwtPayload },
     @Body()
-    body: {
-      new_password: string;
-      old_password: string;
-      logout_all_devices?: boolean;
-    },
+    body: ChangePasswordDto,
   ): Promise<{ success: boolean; message: string }> {
     try {
       const mem_username = req.user.username;
@@ -1907,30 +2436,26 @@ export class AppController {
     }
   }
 
+  @ApiTags('Password')
+  @ApiOperation({ summary: 'Reset password using a validated OTP' })
+  @ApiBody({ type: ResetPasswordDto })
+  @ApiResponse({ status: 200, description: 'Password reset result' })
   @Put('/ecom/password/reset-password')
   async resetPassword(
     @Body()
-    body: {
-      mem_username: string;
-      new_password: string;
-      otp: string;
-    },
+    body: ResetPasswordDto,
   ): Promise<{ success: boolean; message: string }> {
     return this.changePasswordService.forgotPasswordUpdate(body);
   }
 
+  @ApiTags('Products')
+  @ApiOperation({ summary: 'Bulk add new-arrival product batches' })
+  @ApiBody({ type: [NewArrivalItemDto] })
+  @ApiResponse({ status: 201, description: 'New arrivals added' })
   @Post('/ecom/new-arrivals')
   async NewArrivals(
     @Body()
-    data: {
-      pro_code: string;
-      LOT: string;
-      MFG: string;
-      EXP: string;
-      createdAt: Date;
-      amount: number;
-      unit: string;
-    }[],
+    data: NewArrivalItemDto[],
   ) {
     try {
       await this.newArrivalsService.addNewArrival(data);
@@ -1941,6 +2466,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get up to 30 new-arrival products for current member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code (unused, taken from JWT)', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of new-arrival products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/new-arrivals/list/:mem_code')
   async getNewArrivalsLimit30(@Req() req: Request & { user: JwtPayload }) {
@@ -1951,11 +2482,20 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiOperation({ summary: 'Find a hotdeal by product code' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Hotdeal detail' })
   @Get('/ecom/hotdeal/find/:pro_code')
   find(@Param('pro_code') pro_code: string): Promise<any> {
     return this.hotdealService.find(pro_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get wangday data grouped by product (requires permission)' })
+  @ApiResponse({ status: 200, description: 'Wangday data by product' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/wangday')
   async getProductWangday(@Req() req: Request & { user: JwtPayload }): Promise<{
@@ -1972,6 +2512,11 @@ export class AppController {
     return await this.wangdayService.getProductWangday();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all company-day promotions (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of promotions' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/company-days')
   async getCompanyDays(@Req() req: Request & { user: JwtPayload }): Promise<{
@@ -1984,6 +2529,11 @@ export class AppController {
     return await this.promotionService.getPromotions();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all banners (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of banners' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/banner')
   async getBanner(
@@ -1996,6 +2546,11 @@ export class AppController {
     return await this.bannerService.findAllBanners();
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all hotdeals (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of hotdeals' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/hotdeals')
   async getHotdeals(
@@ -2008,6 +2563,11 @@ export class AppController {
     return await this.hotdealService.findAllHotdeals();
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all flash sales (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of flash sales' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/flashsales')
   async getFlashsales(@Req() req: Request & { user: JwtPayload }) {
@@ -2017,6 +2577,11 @@ export class AppController {
     }
     return await this.flashsaleService.findAllFlashSales();
   }
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all "fix free" products (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of free products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/product-free')
   async getProductFree(
@@ -2029,6 +2594,11 @@ export class AppController {
     return await this.productsService.findProductFree();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all promotional products (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of promotional products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/product-promotion')
   async getProductPromotion(@Req() req: Request & { user: JwtPayload }) {
@@ -2039,11 +2609,17 @@ export class AppController {
     return await this.productsService.findProductPromotion();
   }
 
+  @ApiTags('Debtor / Reduction')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Bulk import reduction invoice data' })
+  @ApiBody({ type: [ImportDataInvoiceDto] })
+  @ApiResponse({ status: 201, description: 'Invoices imported' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/reduct-invoice/add-invoice')
   async importData(
     @Body()
-    data: ImportDataRequestInvoice[],
+    data: ImportDataInvoiceDto[],
   ): Promise<{ message: string }> {
     try {
       const importedInvoices = await this.debtorService.importDataInvoice(data);
@@ -2056,11 +2632,17 @@ export class AppController {
     }
   }
 
+  @ApiTags('Debtor / Reduction')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Bulk import reduction RT (return) data' })
+  @ApiBody({ type: [ImportDataRtDto] })
+  @ApiResponse({ status: 201, description: 'RT entries imported' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/reduct-invoice/add-rt')
   async importDataRT(
     @Body()
-    data: ImportDataRequestRT[],
+    data: ImportDataRtDto[],
   ): Promise<{ message: string }> {
     try {
       const importedRTs = await this.debtorService.importDataRT(data);
@@ -2073,6 +2655,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Debtor / Reduction')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Find a reduction invoice by invoice id for current member' })
+  @ApiParam({ name: 'invoice', description: 'Invoice number', example: 'INV00123' })
+  @ApiResponse({ status: 200, description: 'Debtor/invoice record' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/reduct-invoice/invoice/id/:invoice')
   async findReductionInvoices(
@@ -2089,6 +2677,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Debtor / Reduction')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Find a reduction RT (return) record by id for current member' })
+  @ApiParam({ name: 'rt', description: 'RT (return) number', example: 'RT00123' })
+  @ApiResponse({ status: 200, description: 'Reduction RT record' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/reduct-invoice/rt/id/:rt')
   async findReductionRTs(
@@ -2105,20 +2699,37 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update search keywords for a product' })
+  @ApiBody({ type: UpdateKeysearchDto })
+  @ApiResponse({ status: 201, description: 'Keyword updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/keysearch/update-product-keysearch')
   async updateKeysearch(
-    @Body() data: { pro_code: string; keysearch: string; viewers: number },
+    @Body() data: UpdateKeysearchDto,
   ) {
     await this.productKeySearch.updateKeyword(data);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get keysearch info for one product' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Keysearch info' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/keysearch/get-one/:pro_code')
   async keysearchProductGetOne(@Param('pro_code') pro_code: string) {
     return await this.productKeySearch.getProductOne(pro_code);
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check/refresh latest purchase date for current member' })
+  @ApiResponse({ status: 200, description: 'Check result' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/usercheck_latest_purchase')
   async checkLatestPurchase(@Req() req: Request & { user: JwtPayload }) {
@@ -2130,12 +2741,36 @@ export class AppController {
     return { message: 'Check initiated' };
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all employees' })
+  @ApiResponse({ status: 200, description: 'List of employees' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/user/employee/list')
   async getEmployeeList() {
     return this.employeesService.getAllEmployees();
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create or update an employee record' })
+  @ApiBody({
+    schema: objectSchema({
+      emp_code: { type: 'string', example: 'E00123', description: 'Required; not empty' },
+      data: objectSchema({
+        emp_code: { type: 'string', example: 'E00123', description: 'Required; not empty' },
+        emp_nickname: { type: 'string', example: 'นัท', description: 'Optional; empty string allowed', optional: true },
+        emp_firstname: { type: 'string', example: 'สมชาย', description: 'Optional; empty string allowed', optional: true },
+        emp_lastname: { type: 'string', example: 'ใจดี', description: 'Optional; empty string allowed', optional: true },
+        emp_mobile: { type: 'string', example: '0812345678', description: 'Optional; empty string allowed', optional: true },
+        emp_email: { type: 'string', example: 'somchai@example.com', description: 'Optional; empty string allowed', optional: true },
+        emp_ID_line: { type: 'string', example: 'somchai_line', description: 'Optional; empty string allowed', optional: true },
+      }),
+    }),
+  })
+  @ApiResponse({ status: 200, description: 'Employee upserted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/user/employee/upsert-employee')
   async upsertEmployee(
@@ -2168,6 +2803,17 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Bulk update daily sale amount for products' })
+  @ApiBody({
+    schema: arraySchema({
+      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      amount: { type: 'number', example: 25, description: 'Required' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Sale amounts updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product/pro-sale-amount-update')
   async updateProductProSaleAmount(
@@ -2176,6 +2822,18 @@ export class AppController {
     return await this.productsService.updateSaleDayly(data);
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update or clear VIP tag for a member (requires permission)' })
+  @ApiBody({
+    schema: objectSchema({
+      mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+      message: { type: 'string', example: 'อนุมัติ VIP แล้ว', description: 'Required; not empty' },
+      tagVIP: { type: 'string', example: 'VIP', description: 'Optional; empty string/omit clears the tag', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 200, description: 'VIP tag updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/user/employee/user-vip')
   async updateAndDeleteUserVIP(
@@ -2198,6 +2856,11 @@ export class AppController {
     );
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all VIP-tagged members' })
+  @ApiResponse({ status: 200, description: 'List of VIP members' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/user/employee/user-vip-list')
   async getUserVIPList(): Promise<
@@ -2217,6 +2880,11 @@ export class AppController {
     }));
   }
 
+  @ApiTags('Shopping Cart')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get total item count in cart for current member' })
+  @ApiResponse({ status: 200, description: 'Cart item total' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/cart/summary')
   async summaryCart(
@@ -2227,24 +2895,52 @@ export class AppController {
     return data.total;
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all recommend tags' })
+  @ApiResponse({ status: 200, description: 'List of recommend tags' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/recommend/tags')
   async getRecommendTags() {
     return await this.recommendService.getAllTags();
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Insert a recommend tag' })
+  @ApiBody({ schema: objectSchema({ tag: { type: 'string', example: 'สินค้าขายดี', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Tag inserted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/insertTag')
   async insertRecommendTag(@Body() data: { tag: string }) {
     return await this.recommendService.insertTag(data.tag);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get products under a recommend tag' })
+  @ApiParam({ name: 'tag_id', description: 'Recommend tag id', example: 1 })
+  @ApiResponse({ status: 200, description: 'List of products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/recommend/products/:tag_id')
   async getRecommendProductsByTag(@Param('tag_id') tag_id: number) {
     return await this.recommendService.getProductsByTag(tag_id);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Attach a recommend tag to a product' })
+  @ApiBody({
+    schema: objectSchema({
+      tag_id: { type: 'number', example: 1, description: 'Required' },
+      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Tag attached to product' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/updateTagToProduct')
   async updateTagToProduct(@Body() data: { tag_id: number; pro_code: string }) {
@@ -2254,6 +2950,17 @@ export class AppController {
     );
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update display rank for a recommended product' })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      rank: { type: 'number', example: 1, description: 'Required' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Rank updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/updateRank')
   async updateRecommendRank(@Body() data: { pro_code: string; rank: number }) {
@@ -2261,24 +2968,54 @@ export class AppController {
     return await this.recommendService.UpdateRank(data.pro_code, data.rank);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove all recommend tags from a product' })
+  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Tags removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/removeTagFromProduct')
   async removeTagFromProduct(@Body() data: { pro_code: string }) {
     return await this.recommendService.DeleteTagFromProduct(data.pro_code);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete display rank for a recommended product' })
+  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Rank deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/deleteRank')
   async deleteRecommendRank(@Body() data: { pro_code: string }) {
     return await this.recommendService.DeleteRank(data.pro_code);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a recommend tag' })
+  @ApiBody({ schema: objectSchema({ tag_id: { type: 'number', example: 1, description: 'Required' } }) })
+  @ApiResponse({ status: 201, description: 'Tag deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/deleteTag')
   async deleteRecommendTag(@Body() data: { tag_id: number }) {
     return await this.recommendService.deleteTag(data.tag_id);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get recommended products by recommend ids for current member' })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: { type: 'array', items: { type: 'string', example: 'P00123' }, description: 'Optional; not used by the implementation', optional: true },
+      recommend_id: { type: 'array', items: { type: 'number', example: 1 }, description: 'Required; not empty' },
+      mem_code: { type: 'string', example: 'M00123', description: 'Optional; overridden by JWT mem_code if present', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'List of recommended products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/recommend-products')
   async getRecommendProducts(
@@ -2298,6 +3035,17 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Set promotion status for all products under a tier' })
+  @ApiBody({
+    schema: objectSchema({
+      tier_id: { type: 'number', example: 1, description: 'Required' },
+      status: { type: 'boolean', example: true, description: 'Required' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Promotion status updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/set-all-product')
   async setAllProductPromotion(
@@ -2309,6 +3057,17 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check the promotion tier applicable to a product for a member' })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Tier/promotion info' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/check-product-promotion')
   async checkProductPromotion(
@@ -2320,6 +3079,11 @@ export class AppController {
     );
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all image-debug records (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of image-debug records' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/image-bug/all-imagedebug')
   async getAllImagedebug(@Req() req: Request & { user: JwtPayload }) {
@@ -2330,12 +3094,23 @@ export class AppController {
     return await this.imagedebugService.getAllImagedebug();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get promotion tier list for all products' })
+  @ApiResponse({ status: 200, description: 'Tier list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/tier-list-all-product')
   async getPromotionTierList() {
     return await this.promotionService.getTierAllProduct();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get reward products for a promotion tier' })
+  @ApiParam({ name: 'tier_id', description: 'Tier id', example: 1 })
+  @ApiResponse({ status: 200, description: 'List of reward products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/tier-list-all-product-reward/:tier_id')
   async getPromotionTierListReward(
@@ -2349,6 +3124,19 @@ export class AppController {
     );
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload a banner/contract-log image' })
+  @ApiBody({
+    schema: objectSchema({
+      file: { type: 'string', format: 'binary', description: 'Required; image file' },
+      name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed', optional: true },
+      type: { type: 'string', enum: ['wang', 'attestor', 'creditor', 'banner'], example: 'banner', description: 'Optional', optional: true },
+      bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'File uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/create-log-banner')
   @UseInterceptors(FileInterceptor('file'))
@@ -2378,6 +3166,21 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get contract-log banner(s) by id or all' })
+  @ApiBody({
+    schema: objectSchema({
+      bannerId: {
+        oneOf: [{ type: 'number' }, { type: 'string', enum: ['all'] }],
+        example: 'all',
+        description: 'Optional; banner id, or "all" to get every banner',
+        optional: true,
+      },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Banner(s) found' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/banner')
   async getContractLogBanner(
@@ -2387,6 +3190,17 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get dropdown data for contract-log forms (e.g. attestor/creditor lists)' })
+  @ApiBody({
+    schema: objectSchema({
+      group: { type: 'string', example: 'attestor', description: 'Required; not empty' },
+      type: { type: 'string', example: 'attestor', description: 'Required; not empty' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Dropdown data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/dropdown')
   async selectDataDropdown(
@@ -2400,6 +3214,27 @@ export class AppController {
     return { type: data.type, data: result.data };
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a contract-log banner record' })
+  @ApiBody({
+    schema: objectSchema({
+      selectedWang: { type: 'number', example: 1, description: 'Optional', optional: true },
+      selectedAttestor: { type: 'number', example: 1, description: 'Optional', optional: true },
+      selectedAttestor2: { type: 'number', example: 2, description: 'Optional', optional: true },
+      selectedCreditor: { type: 'number', example: 1, description: 'Optional', optional: true },
+      bannerId: { type: 'number', example: 1, description: 'Optional', optional: true },
+      bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed', optional: true },
+      signingDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
+      creditorCode: { type: 'string', example: 'C00123', description: 'Optional; empty string allowed', optional: true },
+      startDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
+      endDate: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
+      paymentDue: { type: 'string', format: 'date-time', example: '2026-07-23T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
+      address: { type: 'string', example: '99/1 ถนนสุขุมวิท', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Banner record created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/create-banner')
   async createContractLogBanner(
@@ -2425,6 +3260,16 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search creditors by keyword for contract-log forms' })
+  @ApiBody({
+    schema: objectSchema({
+      keyword: { type: 'string', example: 'บริษัท วังเภสัช', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'List of matching creditors' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/search-creditor')
   async getDataCreditor(
@@ -2433,6 +3278,20 @@ export class AppController {
     return await this.productsService.getDataCreditor(keyword);
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a contract-log creditor/banner image and info' })
+  @ApiBody({
+    schema: objectSchema({
+      contractId: { type: 'number', example: 1, description: 'Required' },
+      name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed', optional: true },
+      type: { type: 'string', enum: ['creditor', 'banner'], example: 'creditor', description: 'Optional', optional: true },
+      bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed', optional: true },
+      file: { type: 'string', format: 'binary', description: 'Optional; image file', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Contract log updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/update-creditor-person')
   @UseInterceptors(FileInterceptor('file'))
@@ -2458,6 +3317,18 @@ export class AppController {
     });
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload a signed contract file' })
+  @ApiBody({
+    schema: objectSchema({
+      contractId: { type: 'number', example: 1, description: 'Required' },
+      name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed', optional: true },
+      file: { type: 'string', format: 'binary', description: 'Required; signed contract file' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Signed contract uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/upload-signed-contract')
   @UseInterceptors(FileInterceptor('file'))
@@ -2473,6 +3344,21 @@ export class AppController {
     });
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get contract-log company-day record(s) by id or all' })
+  @ApiBody({
+    schema: objectSchema({
+      companyDayId: {
+        oneOf: [{ type: 'number' }, { type: 'string', enum: ['all'] }],
+        example: 'all',
+        description: 'Optional; company-day record id, or "all" to get every record',
+        optional: true,
+      },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Company-day record(s)' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/contract-details')
   async getContractCompanyDays(
@@ -2484,6 +3370,17 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update reward redemption limit for a product' })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      limit: { type: 'number', example: 50, description: 'Required' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Limit updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/limit-update')
   async updatePromotionLimit(
@@ -2495,12 +3392,31 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Reset reward redemption count for a product' })
+  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Limit count reset' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/reset-limit-count')
   async resetLimitReward(@Body() data: { pro_code: string }) {
     return await this.promotionService.resetCountLimit(data.pro_code);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Set a replacement product for a discontinued product' })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      replace_pro_code: { type: 'string', example: 'P00456', description: 'Required; not empty' },
+      note: { type: 'string', example: 'สินค้าหมดสายผลิต', description: 'Optional; empty string allowed', optional: true },
+      date_end: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Replacement product set' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/replace/replace-product')
   async ReplaceProduct(
@@ -2521,6 +3437,36 @@ export class AppController {
     );
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a contract-log company-day record' })
+  @ApiBody({
+    schema: objectSchema({
+      selectedWang: { type: 'number', example: 1, description: 'Optional', optional: true },
+      selectedAttestor: { type: 'number', example: 1, description: 'Optional', optional: true },
+      selectedAttestor2: { type: 'number', example: 2, description: 'Optional', optional: true },
+      selectedCreditor: { type: 'number', example: 1, description: 'Optional', optional: true },
+      bannerId: { type: 'number', example: 1, description: 'Optional', optional: true },
+      bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed', optional: true },
+      signingDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
+      creditorCode: { type: 'string', example: 'C00123', description: 'Optional; empty string allowed', optional: true },
+      startDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
+      endDate: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
+      address: { type: 'string', example: '99/1 ถนนสุขุมวิท', description: 'Optional; empty string allowed', optional: true },
+      reportDueDate: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
+      finalPaymentAmount: { type: 'number', example: 5000, description: 'Optional', optional: true },
+      totalSupportValue: { type: 'number', example: 10000, description: 'Optional', optional: true },
+      supportDeliveryDate: { type: 'string', format: 'date-time', example: '2026-07-01T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
+      numberOfInstallments: { type: 'number', example: 3, description: 'Optional', optional: true },
+      installmentIntervalDays: { type: 'number', example: 30, description: 'Optional', optional: true },
+      firstInstallmentAmount: { type: 'number', example: 3000, description: 'Optional', optional: true },
+      firstPaymentCondition: { type: 'string', example: 'ชำระทันทีหลังเซ็นสัญญา', description: 'Optional; empty string allowed', optional: true },
+      finalInstallmentAmount: { type: 'number', example: 2000, description: 'Optional', optional: true },
+      productsToOrder: { type: 'string', example: 'P00123, P00456', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Company-day record created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/create-company-day')
   async createContractCompanyDay(
@@ -2553,6 +3499,19 @@ export class AppController {
     return await this.contractLogService.createContractLogCompanyDay(data);
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a contract-log company-day record (creditor image)' })
+  @ApiBody({
+    schema: objectSchema({
+      contractId: { type: 'number', example: 1, description: 'Required' },
+      name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed', optional: true },
+      type: { type: 'string', enum: ['creditor'], example: 'creditor', description: 'Optional', optional: true },
+      file: { type: 'string', format: 'binary', description: 'Optional; image file', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Company-day record updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/update-company-day')
   @UseInterceptors(FileInterceptor('file'))
@@ -2579,6 +3538,17 @@ export class AppController {
     });
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload a signed company-day contract file' })
+  @ApiBody({
+    schema: objectSchema({
+      contractId: { type: 'number', example: 1, description: 'Required' },
+      file: { type: 'string', format: 'binary', description: 'Required; signed contract file' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Signed contract uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/upload-signed-company-day')
   @UseInterceptors(FileInterceptor('file'))
@@ -2594,18 +3564,40 @@ export class AppController {
     });
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get the replacement product info for a product' })
+  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Replacement product info' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/replace/get-product')
   async GetProductAndReplace(@Body() data: { pro_code: string }) {
     return await this.recommendService.GetProductAndReplace(data.pro_code);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Clear the replacement product for a product' })
+  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Replacement product cleared' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/replace/replace-product-null')
   async UpdateProductAndReplaceNull(@Body() data: { pro_code: string }) {
     return await this.recommendService.RemoveReplaceProduct(data.pro_code);
   }
 
+  @ApiTags('Policy Document')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Find policy document categories (optionally by name)' })
+  @ApiBody({
+    schema: objectSchema({
+      name: { type: 'string', example: 'นโยบายความเป็นส่วนตัว', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'List of policy categories' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/policy/option-catagory')
   async findOptionCatagoryPolicy(@Body('name') name?: string) {
@@ -2613,6 +3605,18 @@ export class AppController {
     return await this.policyDocService.findOptionCatagoryPolicy(name);
   }
 
+  @ApiTags('Policy Document')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Save a new policy document version' })
+  @ApiBody({
+    schema: objectSchema({
+      content: { type: 'string', example: '<p>เนื้อหานโยบาย</p>', description: 'Required; not empty' },
+      category: { type: 'number', example: 1, description: 'Required' },
+      type: { type: 'number', example: 1, description: 'Required' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Policy document saved' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/policy/upload-policy')
   async savePolicyDoc(
@@ -2628,6 +3632,11 @@ export class AppController {
     return await this.policyDocService.savePolicyDoc(content, category, type);
   }
 
+  @ApiTags('Policy Document')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check and get the correct (latest unsigned) policy for current member' })
+  @ApiResponse({ status: 200, description: 'Applicable policy document' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/policy/check-policy')
   async ensureUserHasPolicyMember(@Req() req: Request & { user: JwtPayload }) {
@@ -2635,6 +3644,12 @@ export class AppController {
     return await this.policyDocService.checkAndGetCorrectPolicy(mem_code);
   }
 
+  @ApiTags('Policy Document')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Agree to a policy document for current member' })
+  @ApiBody({ schema: objectSchema({ policyID: { type: 'number', example: 1, description: 'Required' } }) })
+  @ApiResponse({ status: 201, description: 'Agreement recorded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/policy/agree')
   async agreeToPolicyDoc(
@@ -2647,6 +3662,11 @@ export class AppController {
     return await this.policyDocService.agreePolicyDoc(mem_code, body.policyID);
   }
 
+  @ApiTags('Policy Document')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all policy documents' })
+  @ApiResponse({ status: 200, description: 'List of policy documents' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/policy/all-policies')
   async getAllPolicies(): Promise<
@@ -2663,6 +3683,11 @@ export class AppController {
     return await this.policyDocService.getAllPolicies();
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all campaigns' })
+  @ApiResponse({ status: 200, description: 'List of campaigns' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns')
   async getAllCampaigns() {
@@ -2681,6 +3706,17 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a campaign' })
+  @ApiBody({
+    schema: objectSchema({
+      name: { type: 'string', example: 'แคมเปญสิ้นปี 2026', description: 'Required; not empty' },
+      description: { type: 'string', example: 'แคมเปญลดราคาสิ้นปี', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Campaign created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns')
   async createCampaign(@Body() body: { name: string; description?: string }) {
@@ -2698,6 +3734,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a campaign' })
+  @ApiParam({ name: 'id', description: 'Campaign id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Campaign deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/campaigns/:id')
   async deleteCampaign(@Param('id') id: string) {
@@ -2718,6 +3760,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get tracking data for a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Campaign data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns/:campaignId/data')
   async getCampaignData(@Param('campaignId') campaignId: string) {
@@ -2735,6 +3783,20 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a data row in a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiBody({
+    schema: objectSchema({
+      set_number: { type: 'number', example: 1, description: 'Required' },
+      condition: { type: 'string', example: 'ซื้อครบ 1000 บาท', description: 'Optional; empty string allowed', optional: true },
+      target: { type: 'string', example: 'P00123', description: 'Optional; empty string allowed', optional: true },
+      con_percent: { type: 'string', example: '10', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Row created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/data')
   async createRow(
@@ -2758,6 +3820,26 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a campaign data row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiBody({
+    schema: objectSchema({
+      target: { type: 'string', example: 'P00123', description: 'Optional; empty string allowed', optional: true },
+      con_percent: { type: 'string', example: '10', description: 'Optional; empty string allowed', optional: true },
+      condition: { type: 'string', example: 'ซื้อครบ 1000 บาท', description: 'Optional; empty string allowed', optional: true },
+      set_number: { type: 'number', example: 1, description: 'Optional', optional: true },
+      price_per_set: { type: 'string', example: '500.00', description: 'Optional; empty string allowed', optional: true },
+      number_of_sets: { type: 'number', example: 2, description: 'Optional', optional: true },
+      unit_price: { type: 'number', example: 250, description: 'Optional', optional: true },
+      quantity: { type: 'number', example: 2, description: 'Optional', optional: true },
+      discounted_price: { type: 'number', example: 450, description: 'Optional', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 200, description: 'Row updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/campaigns/:campaignId/data/:rowId')
   async updateRow(
@@ -2788,6 +3870,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a campaign data row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Row deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/campaigns/:campaignId/data/:rowId')
   async deleteRow(
@@ -2805,6 +3894,19 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a reward column for a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiBody({
+    schema: objectSchema({
+      name: { type: 'string', example: 'ของแถม', description: 'Required; not empty' },
+      unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed', optional: true },
+      value_per_unit: { type: 'string', example: '10.00', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Reward column created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/columns')
   async createRewardColumn(
@@ -2826,6 +3928,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a reward column from a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'columnId', description: 'Reward column id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Reward column deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/campaigns/:campaignId/columns/:columnId')
   async deleteRewardColumn(
@@ -2851,6 +3960,11 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all products available to add to campaigns' })
+  @ApiResponse({ status: 200, description: 'List of products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns/products')
   async getProducts() {
@@ -2869,6 +3983,14 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a product to a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Product added to row' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/data/:rowId/products')
   async addProductToRow(
@@ -2899,6 +4021,14 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a product from a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Product removed from row' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/data/:rowId/products-delete')
   async removeProductFromRow(
@@ -2932,6 +4062,22 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a promo reward value to a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiBody({
+    schema: objectSchema({
+      reward_column_id: { type: 'string', example: '1', description: 'Required; not empty' },
+      quantity: { type: 'string', example: '2', description: 'Optional; empty string allowed', optional: true },
+      unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed', optional: true },
+      price: { type: 'string', example: '10.00', description: 'Optional; empty string allowed', optional: true },
+      value: { type: 'string', example: '20.00', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Promo reward added' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/data/:rowId/rewards')
   async addPromoReward(
@@ -2961,6 +4107,22 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a promo reward value in a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiParam({ name: 'rewardId', description: 'Reward id', example: '1' })
+  @ApiBody({
+    schema: objectSchema({
+      quantity: { type: 'string', example: '2', description: 'Optional; empty string allowed', optional: true },
+      unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed', optional: true },
+      price: { type: 'string', example: '10.00', description: 'Optional; empty string allowed', optional: true },
+      value: { type: 'string', example: '20.00', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 200, description: 'Promo reward updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/campaigns/:campaignId/data/:rowId/rewards/:rewardId')
   async updatePromoReward(
@@ -2997,6 +4159,14 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a promo reward from a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiParam({ name: 'rewardId', description: 'Reward id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Promo reward deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/campaigns/:campaignId/data/:rowId/rewards/:rewardId')
   async deletePromoReward(
@@ -3022,6 +4192,18 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a reward column image/product link' })
+  @ApiBody({
+    schema: objectSchema({
+      reward_id: { type: 'string', example: '1', description: 'Required; not empty' },
+      url: { type: 'string', example: 'https://example.com/image.png', description: 'Required; not empty' },
+      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Reward column updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/update-collumn-reward')
   async updateRewardColumn(
@@ -3045,6 +4227,17 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload an image for a campaign reward' })
+  @ApiBody({
+    schema: objectSchema({
+      file: { type: 'string', format: 'binary', description: 'Required; image file' },
+      reward_id: { type: 'string', example: '1', description: 'Required; not empty' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Image uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/upload-reward-image')
   @UseInterceptors(FileInterceptor('file'))
@@ -3066,6 +4259,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload a generic campaign image' })
+  @ApiBody({ schema: objectSchema({ file: { type: 'string', format: 'binary', description: 'Required; image file' } }) })
+  @ApiResponse({ status: 201, description: 'Image uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/upload-image')
   @UseInterceptors(FileInterceptor('file'))
@@ -3081,6 +4280,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get purchase products listed in a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiResponse({ status: 200, description: 'List of purchase products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns/:campaignId/purchase-products')
   async getPurchaseProducts(@Param('campaignId') campaignId: string) {
@@ -3095,6 +4300,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a purchase product entry for a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiBody({ schema: objectSchema({ name: { type: 'string', example: 'แชมพูสมุนไพร', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Purchase product created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/purchase-products')
   async createPurchaseProduct(
@@ -3115,6 +4327,19 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a purchase product entry' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'productId', description: 'Purchase product id', example: '1' })
+  @ApiBody({
+    schema: objectSchema({
+      name: { type: 'string', example: 'แชมพูสมุนไพร', description: 'Optional; empty string allowed', optional: true },
+      img_url: { type: 'string', example: 'https://example.com/image.png', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 200, description: 'Purchase product updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Patch('/campaigns/:campaignId/purchase-products/:productId')
   async updatePurchaseProduct(
@@ -3137,6 +4362,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a purchase product entry' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'productId', description: 'Purchase product id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Purchase product deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/campaigns/:campaignId/purchase-products/:productId')
   async deletePurchaseProduct(
@@ -3154,6 +4386,14 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload an image for a purchase product' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'productId', description: 'Purchase product id', example: '1' })
+  @ApiBody({ schema: objectSchema({ file: { type: 'string', format: 'binary', description: 'Required; image file' } }) })
+  @ApiResponse({ status: 201, description: 'Image uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/purchase-products/:productId/upload-image')
   @UseInterceptors(FileInterceptor('file'))
@@ -3180,6 +4420,25 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiOperation({ summary: 'Generate a campaign poster image via AI' })
+  @ApiBody({
+    schema: objectSchema({
+      prompt: { type: 'string', example: 'โปสเตอร์โปรโมชั่นสินค้าฤดูร้อน', description: 'Required; not empty' },
+      aspectRatio: { type: 'string', example: '1:1', description: 'Required; not empty' },
+      imageItems: {
+        ...arraySchema({
+          url: { type: 'string', example: 'https://example.com/image.png', description: 'Required; not empty' },
+          name: { type: 'string', example: 'แชมพูสมุนไพร', description: 'Required; not empty' },
+          quantity: { type: 'number', example: 1, description: 'Required' },
+          unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed', optional: true },
+        }),
+        optional: true,
+      },
+      session_cookies: { type: 'string', example: '', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Poster generation request id' })
   // @UseGuards(JwtAuthGuard)
   @Post('/campaigns/generate-poster')
   async generatePoster(
@@ -3204,6 +4463,15 @@ export class AppController {
     );
   }
 
+  @ApiTags('Campaigns')
+  @ApiOperation({ summary: 'Poll for AI poster generation result by request id' })
+  @ApiParam({ name: 'requestId', description: 'Poster generation request id', example: 'req_00123' })
+  @ApiBody({
+    schema: objectSchema({
+      session_cookies: { type: 'string', example: '', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Generation result' })
   @Post('/campaigns/get-response-id/:requestId')
   async getResponseId(
     @Param('requestId') requestId: string,
@@ -3215,6 +4483,12 @@ export class AppController {
     );
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get reward columns for a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiResponse({ status: 200, description: 'List of reward columns' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns/:campaignId/columns')
   async getRewardColumns(@Param('campaignId') campaignId: string) {
@@ -3222,6 +4496,14 @@ export class AppController {
     return { success: true, data: columns };
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update value-per-unit for a reward column' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'columnId', description: 'Reward column id', example: '1' })
+  @ApiBody({ schema: objectSchema({ value_per_unit: { type: 'number', example: 10, description: 'Required' } }) })
+  @ApiResponse({ status: 200, description: 'Value per unit updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Patch('/campaigns/:campaignId/columns/:columnId')
   async updateRewardColumnValuePerUnit(
@@ -3237,6 +4519,14 @@ export class AppController {
     return { success: true };
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Save a generated poster image to a campaign row history' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiBody({ schema: objectSchema({ img_url: { type: 'string', example: 'https://example.com/poster.png', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Poster history saved' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/data/:rowId/poster-history')
   async savePosterHistory(
@@ -3257,6 +4547,28 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a banner from a poster history image and link it' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiParam({ name: 'historyId', description: 'Poster history id', example: '1' })
+  @ApiBody({
+    schema: objectSchema({
+      img_url: { type: 'string', example: 'https://example.com/poster.png', description: 'Required; not empty' },
+      banner_name: { type: 'string', example: 'โปสเตอร์โปรโมชั่นฤดูร้อน', description: 'Optional; empty string allowed', optional: true },
+      banner_location: {
+        type: 'string',
+        enum: ['store_carousel', 'landing_hero', 'popup', 'sidebar'],
+        example: 'store_carousel',
+        description: 'Required; not empty',
+      },
+      date_start: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Required; ISO datetime' },
+      date_end: { type: 'string', format: 'date-time', example: '2026-07-23T00:00:00.000Z', description: 'Required; ISO datetime' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Banner created and linked' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post(
     '/campaigns/:campaignId/data/:rowId/poster-history/:historyId/banner-links',
@@ -3295,6 +4607,15 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a banner link from poster history (keeps the banner image file)' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiParam({ name: 'historyId', description: 'Poster history id', example: '1' })
+  @ApiParam({ name: 'linkId', description: 'Banner link id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Banner link removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete(
     '/campaigns/:campaignId/data/:rowId/poster-history/:historyId/banner-links/:linkId',
@@ -3314,6 +4635,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get poster history for a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiResponse({ status: 200, description: 'List of poster history items' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns/:campaignId/data/:rowId/poster-history')
   async getPosterHistory(@Param('rowId') rowId: string) {
@@ -3328,6 +4656,10 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiOperation({ summary: 'Proxy-download an ideogram.ai generated image (avoids CORS)' })
+  @ApiQuery({ name: 'url', description: 'Must start with https://ideogram.ai/', example: 'https://ideogram.ai/api/images/example.png' })
+  @ApiResponse({ status: 200, description: 'Image binary stream' })
   @Get('/campaigns/proxy-image')
   async proxyImage(@Query('url') url: string, @Res() res: Response) {
     if (!url || !url.startsWith('https://ideogram.ai/')) {
@@ -3349,6 +4681,11 @@ export class AppController {
     res.send(Buffer.from(response.data));
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search banner-eligible products (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/products-banner')
   async searchProductsBanner(@Req() req: Request & { user: JwtPayload }) {
@@ -3359,6 +4696,11 @@ export class AppController {
     return await this.productsService.searchProductsBanner();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all creditors (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of creditors' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/get-creditor')
   async getCreditors(@Req() req: Request & { user: JwtPayload }) {
@@ -3369,6 +4711,10 @@ export class AppController {
     return await this.productsService.getCreditors();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get delivery tracking location for an order' })
+  @ApiParam({ name: 'sh_running', description: 'Shopping head running number', example: 'SO00123' })
+  @ApiResponse({ status: 200, description: 'Order tracking location' })
   @Get('/ecom/track-order/:sh_running')
   async trackOrder(@Param('sh_running') sh_running: string) {
     try {
@@ -3387,6 +4733,12 @@ export class AppController {
   // ========== Product Return APIs ==========
 
   // Customer: Get eligible orders for return
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get orders eligible for return for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of eligible orders' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/returns/eligible-orders/:mem_code')
   async getEligibleOrders(@Param('mem_code') mem_code: string) {
@@ -3407,6 +4759,12 @@ export class AppController {
   }
 
   // Customer: Get order items for return selection
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get order items available for return selection' })
+  @ApiParam({ name: 'soh_running', description: 'Shopping order head running number', example: 'SO00123' })
+  @ApiResponse({ status: 200, description: 'List of order items' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/returns/order-items/:soh_running')
   async getOrderItemsForReturn(
@@ -3433,6 +4791,39 @@ export class AppController {
   }
 
   // Customer: Create return request
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a product return request (customer-initiated)' })
+  @ApiBody({
+    schema: objectSchema({
+      soh_id: { type: 'number', example: 12345, description: 'Required' },
+      mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+      reason: {
+        type: 'string',
+        enum: ['damaged', 'expired', 'wrong_item', 'disaster', 'other'],
+        example: 'damaged',
+        description: 'Required; not empty',
+      },
+      reason_detail: { type: 'string', example: 'สินค้าชำรุดตอนเปิดกล่อง', description: 'Optional; empty string allowed', optional: true },
+      resolution_type: {
+        type: 'string',
+        enum: ['refund', 'replacement'],
+        example: 'refund',
+        description: 'Required; not empty',
+      },
+      items: arraySchema({
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        qty: { type: 'number', example: 2, description: 'Required' },
+        unit: { type: 'string', example: 'กล่อง', description: 'Required; not empty' },
+        price_per_unit: { type: 'number', example: 150, description: 'Required' },
+        item_reason: { type: 'string', example: 'สินค้าชำรุด', description: 'Optional; empty string allowed', optional: true },
+        expiry_date: { type: 'string', example: '2026-12-31', description: 'Optional; format YYYY-MM-DD', optional: true },
+      }),
+      notes: { type: 'string', example: '', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Return request created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/returns/create')
   async createReturn(
@@ -3474,6 +4865,18 @@ export class AppController {
   }
 
   // Customer: Upload evidence images
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload evidence images for a return request (up to 5 files)' })
+  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiBody({
+    schema: objectSchema({
+      files: { type: 'array', items: { type: 'string', format: 'binary' }, description: 'Optional; up to 5 image files', optional: true },
+      description: { type: 'string', example: '', description: 'Optional; empty string allowed', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Images uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/returns/:return_id/images')
   @UseInterceptors(FileFieldsInterceptor([{ name: 'files', maxCount: 5 }]))
@@ -3503,6 +4906,12 @@ export class AppController {
   }
 
   // Customer: Submit return request
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Submit a draft return request for review' })
+  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiResponse({ status: 201, description: 'Return request submitted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/returns/:return_id/submit')
   async submitReturn(
@@ -3529,6 +4938,15 @@ export class AppController {
   }
 
   // Customer: Get my returns
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get return requests for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiQuery({ name: 'status', required: false, type: String, example: 'pending' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
+  @ApiResponse({ status: 200, description: 'List of return requests' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/returns/my-returns/:mem_code')
   async getMyReturns(
@@ -3558,6 +4976,12 @@ export class AppController {
   }
 
   // Customer: Get return detail
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get detail of a return request' })
+  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Return request detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/returns/:return_id')
   async getReturnDetail(@Param('return_id') return_id: string) {
@@ -3580,6 +5004,12 @@ export class AppController {
   }
 
   // Customer: Delete draft return
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a draft (unsubmitted) return request' })
+  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Draft return deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/returns/:return_id')
   async deleteDraftReturn(
@@ -3662,6 +5092,14 @@ export class AppController {
   // }
 
   // Get user behavior (for personalization)
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get tracked behavior events for a member (for personalization)' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'User behavior data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/tracking/user/:mem_code')
   async getUserBehavior(
@@ -3690,6 +5128,14 @@ export class AppController {
   }
 
   // Admin: Get product analytics
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get product view/interaction analytics (requires permission)' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'Product analytics data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/product/:pro_code')
   async getProductAnalytics(
@@ -3723,6 +5169,13 @@ export class AppController {
   }
 
   // Admin: Get search analytics
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get search behavior analytics (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'Search analytics data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/searches')
   async getSearchAnalytics(
@@ -3754,6 +5207,13 @@ export class AppController {
   }
 
   // Admin: Get dashboard stats
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get behavior tracking dashboard stats (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'Dashboard stats' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/dashboard')
   async getTrackingDashboard(
@@ -3785,6 +5245,13 @@ export class AppController {
   }
 
   // Admin: Get daily trend
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get daily behavior trend (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'Daily trend data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/daily-trend')
   async getDailyTrend(
@@ -3816,6 +5283,14 @@ export class AppController {
   }
 
   // Admin: Get top products
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get top viewed/purchased products (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '10' })
+  @ApiResponse({ status: 200, description: 'List of top products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/top-products')
   async getTopProducts(
@@ -3849,6 +5324,12 @@ export class AppController {
   }
 
   // Admin: Get recent activity feed
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get recent customer activity feed (requires permission)' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '50' })
+  @ApiResponse({ status: 200, description: 'Recent activity feed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/recent-activity')
   async getRecentActivity(
@@ -3878,6 +5359,12 @@ export class AppController {
   }
 
   // Admin: Get user journeys
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get user navigation journeys (requires permission)' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiResponse({ status: 200, description: 'List of user journeys' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/user-journeys')
   async getUserJourneys(
@@ -3907,6 +5394,14 @@ export class AppController {
   }
 
   // Admin: Get zero result searches
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get search queries that returned zero results (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '30' })
+  @ApiResponse({ status: 200, description: 'List of zero-result searches' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/zero-result-searches')
   async getZeroResultSearches(
@@ -3940,6 +5435,13 @@ export class AppController {
   }
 
   // Admin: Get stock alerts based on demand
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get demand-based stock alerts (requires permission)' })
+  @ApiQuery({ name: 'days', required: false, type: String, example: '7' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiResponse({ status: 200, description: 'List of stock alerts' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/stock-alerts')
   async getStockAlerts(
@@ -3971,6 +5473,13 @@ export class AppController {
   }
 
   // Admin: Get cart conversion analytics
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get cart-to-purchase conversion analytics (requires permission)' })
+  @ApiQuery({ name: 'days', required: false, type: String, example: '30' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiResponse({ status: 200, description: 'Cart conversion analytics' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/cart-analytics')
   async getCartConversionAnalytics(
@@ -4002,6 +5511,12 @@ export class AppController {
   }
 
   // Admin: Get customer segments
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get customer segmentation analysis (requires permission)' })
+  @ApiQuery({ name: 'days', required: false, type: String, example: '90' })
+  @ApiResponse({ status: 200, description: 'Customer segments' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/customer-segments')
   async getCustomerSegments(
@@ -4031,6 +5546,12 @@ export class AppController {
   }
 
   // Admin: Get retention analysis
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get customer retention analysis (requires permission)' })
+  @ApiQuery({ name: 'weeks', required: false, type: String, example: '8' })
+  @ApiResponse({ status: 200, description: 'Retention analysis' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/retention')
   async getRetentionAnalysis(
@@ -4060,6 +5581,12 @@ export class AppController {
   }
 
   // Admin: Get repeat purchase patterns
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get repeat purchase patterns (requires permission)' })
+  @ApiQuery({ name: 'days', required: false, type: String, example: '180' })
+  @ApiResponse({ status: 200, description: 'Repeat purchase patterns' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/repeat-purchases')
   async getRepeatPurchasePatterns(
@@ -4089,6 +5616,13 @@ export class AppController {
   }
 
   // Admin: Get purchase interval box plot data
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get purchase interval box-plot data (requires permission)' })
+  @ApiQuery({ name: 'days', required: false, type: String, example: '180' })
+  @ApiQuery({ name: 'group_by', required: false, type: String, example: 'overall', description: 'one of: overall, product, segment, month' })
+  @ApiResponse({ status: 200, description: 'Box-plot data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/purchase-intervals-boxplot')
   async getPurchaseIntervalBoxPlot(
@@ -4120,6 +5654,13 @@ export class AppController {
   }
 
   // Admin: Get user journey sankey
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get user journey sankey diagram data (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: true, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: true, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'Sankey diagram data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/user-journey-sankey')
   async getUserJourneySankey(
@@ -4137,6 +5678,18 @@ export class AppController {
     );
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Change a member\'s role/permission (Admin only)' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiBody({
+    schema: objectSchema({
+      newRole: { type: 'string', enum: ['User', 'Admin', 'Sales'], example: 'Sales', description: 'Required; not empty' },
+      permission: { type: 'boolean', example: true, description: 'Optional; defaults to false', optional: true },
+    }),
+  })
+  @ApiResponse({ status: 200, description: 'Role changed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/change-role/:mem_code')
   async changeUserRole(
@@ -4163,6 +5716,11 @@ export class AppController {
     );
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all staff users (Admin only)' })
+  @ApiResponse({ status: 200, description: 'List of staff users' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/user/staff-list')
   async getStaffUsers(@Req() req: Request & { user: JwtPayload }) {
@@ -4174,6 +5732,12 @@ export class AppController {
     return await this.usersService.getStaffUsers();
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Look up a member for role management (Admin only)' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'Member info for role management' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/user/lookup/:mem_code')
   async lookupUserForRoleManage(
@@ -4186,6 +5750,12 @@ export class AppController {
     return await this.usersService.findUserForRoleManageByMemCode(mem_code);
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search members for role management (Admin only)' })
+  @ApiQuery({ name: 'q', required: false, type: String, example: 'สมชาย' })
+  @ApiResponse({ status: 200, description: 'List of matching members' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/user/search')
   async searchUsersForRoleManage(
@@ -4198,6 +5768,21 @@ export class AppController {
     return await this.usersService.searchUsersForRoleManage(query ?? '');
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update enabled feature flags for a member (Admin only)' })
+  @ApiBody({
+    schema: objectSchema({
+      mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+      features: {
+        type: 'array',
+        items: { type: 'string', example: 'happy_hour' },
+        description: 'Required; list of feature flag keys',
+      },
+    }),
+  })
+  @ApiResponse({ status: 200, description: 'Features updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/admin/user/update-features')
   async updateUserFeatures(
@@ -4218,6 +5803,13 @@ export class AppController {
     );
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get paginated admin role-change action logs (Admin only)' })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 20 })
+  @ApiResponse({ status: 200, description: 'Paginated admin action logs' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/user/role-logs')
   async getAdminActionLogs(
@@ -4231,12 +5823,27 @@ export class AppController {
     return await this.usersService.getAdminActionLogs(page, limit);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get RT (return) order notifications from the last 3 days' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of RT notifications' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/get-notification-rt/:mem_code')
   async getRTNotifications(@Param('mem_code') mem_code: string) {
     return await this.notifyRtService.getRTOrdersInTheLast3Days(mem_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Update RT (return) notification read status' })
+  @ApiBody({
+    schema: objectSchema({
+      soh_running: { type: 'string', example: 'SO00123', description: 'Required; not empty' },
+      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'RT notification status updated' })
   @Post('/ecom/update-notification-rt')
   async updateRTNotification(
     @Body() data: { soh_running: string; pro_code: string },
@@ -4245,6 +5852,12 @@ export class AppController {
     return await this.notifyRtService.updateRTStatus(data);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Register a push notification token for current member' })
+  @ApiBody({ schema: objectSchema({ token: { type: 'string', example: 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Token registered' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/qc/add-token-for-notification')
   async addTokenForNotification(
@@ -4258,6 +5871,12 @@ export class AppController {
     });
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a push notification token for current member' })
+  @ApiBody({ schema: objectSchema({ token: { type: 'string', example: 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Token removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/qc/remove-token-for-notification')
   async removeTokenForNotification(
@@ -4271,6 +5890,17 @@ export class AppController {
     });
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload a banner image for a hotdeal' })
+  @ApiBody({
+    schema: objectSchema({
+      id: { type: 'number', example: 1, description: 'Required' },
+      file: { type: 'string', format: 'binary', description: 'Required; image file' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Banner uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/admin/hotdeal/upload-banner')
   @UseInterceptors(FileInterceptor('file'))
@@ -4281,18 +5911,36 @@ export class AppController {
     return await this.hotdealService.uploadBannerHotdeal(file, body.id);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all hotdeals with their banners' })
+  @ApiResponse({ status: 200, description: 'List of hotdeals with banners' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/hotdeal/get-banner')
   async getHotdealBanner() {
     return await this.hotdealService.getAllHotdealsWithBanners();
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a hotdeal banner' })
+  @ApiParam({ name: 'id', description: 'Hotdeal banner id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Banner deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/admin/hotdeal/delete-banner/:id')
   async deleteHotdealBanner(@Param('id') id: number) {
     return await this.hotdealService.deleteBannerHotdeal(id);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get paginated list of products with a replacement set' })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 10 })
+  @ApiResponse({ status: 200, description: 'Paginated replacement products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/replace-product')
   async getReplacementProduct(
@@ -4302,6 +5950,17 @@ export class AppController {
     return await this.recommendService.getAllReplaceProducts(page, limit);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload/update the poster image for a promotion tier' })
+  @ApiBody({
+    schema: objectSchema({
+      tier_id: { type: 'string', example: '1', description: 'Required; not empty' },
+      file: { type: 'string', format: 'binary', description: 'Required; image file' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Tier poster updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('ecom/promotion/update-tier-poster')
   @UseInterceptors(FileInterceptor('file'))
@@ -4312,6 +5971,15 @@ export class AppController {
     return this.promotionService.updateTierPoster(Number(tier_id), file);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiOperation({ summary: 'Check/recalculate tier-turn-back reward price for an order item' })
+  @ApiBody({
+    schema: objectSchema({
+      sh_running: { type: 'string', example: 'SO00123', description: 'Required; not empty' },
+      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Tier price result' })
   @Post('/ecom/get-tier-price')
   async getTierPrice(@Body() body: { sh_running: string; pro_code: string }) {
     return await this.shoppingOrderService.checkOrderTurnBackReward(
@@ -4320,6 +5988,13 @@ export class AppController {
     );
   }
 
+  @ApiTags('Happy Hour')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check and adjust happy-hour reward for an order (requires permission)' })
+  @ApiBody({ schema: objectSchema({ sh_running: { type: 'string', example: 'SO00123', description: 'Required; not empty' } }) })
+  @ApiResponse({ status: 201, description: 'Happy-hour reward adjusted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/check-happy-hour-reward')
   async checkHappyHourReward(
@@ -4334,6 +6009,12 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get hotdeal detail by product code for current member' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Hotdeal detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/hotdeal/:pro_code')
   async getHotdealByProCode(
@@ -4344,6 +6025,21 @@ export class AppController {
     return await this.hotdealService.getHotdealFromproCode(pro_code, mem_code);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add hotdeal freebie products to cart for current member' })
+  @ApiBody({
+    schema: objectSchema({
+      freebies: arraySchema({
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        unit: { type: 'string', example: 'กล่อง', description: 'Required; not empty' },
+        amount: { type: 'number', example: 1, description: 'Required' },
+        pro_code1: { type: 'string', example: 'P00100', description: 'Required; not empty; the qualifying product code' },
+      }),
+    }),
+  })
+  @ApiResponse({ status: 201, description: 'Freebies added to cart' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/hotdeal/add-other-product')
   async createHotdeal(
@@ -4370,6 +6066,11 @@ export class AppController {
     return results;
   }
 
+  @ApiTags('Products')
+  @ApiOperation({ summary: 'Get product image by product code' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Product image data' })
+  @ApiResponse({ status: 404, description: 'Product not found' })
   @Get('/ecom/get-product-image/:pro_code')
   async getProductImage(@Param('pro_code') pro_code: string) {
     this.logger.log('Fetching product image for pro_code:', pro_code);
@@ -4397,12 +6098,23 @@ export class AppController {
     }
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Manually trigger the company-day promotion cart re-check' })
+  @ApiResponse({ status: 200, description: 'Check triggered' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/trigger/check-promotion-company-day')
   async triggerCheckPromotionCompanyDay() {
     await this.shoppingCartService.callCheckCartPromotion();
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Autocomplete product search against the external product source' })
+  @ApiQuery({ name: 'search', description: 'Search keyword', example: 'แชมพู' })
+  @ApiResponse({ status: 200, description: 'List of matching products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-search-autocomplete')
   async productSearchAutoComplete(@Query('search') search: string) {
@@ -4416,6 +6128,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search Lotus gift card products (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of Lotus card products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/products/lotus-cards')
   async searchLotusCards(@Req() req: Request & { user: JwtPayload }) {
@@ -4427,6 +6145,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search products by name for admin (requires permission)' })
+  @ApiQuery({ name: 'keyword', required: false, type: String, example: 'แชมพู' })
+  @ApiResponse({ status: 200, description: 'List of matching products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   @UseGuards(JwtAuthGuard)
   @Get('ecom/admin/products/search')
   async productSearchProductName(

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -51,56 +51,58 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { HotdealService } from './hotdeal/hotdeal.service';
 import { PromotionService } from './promotion/promotion.service';
 import type { PromotionEntityWithTransformedData } from './promotion/promotion.service';
-import { UpdateUserDataDto } from 'src/users/dto/update-user-data.dto';
-import { UpdateBannerDto } from 'src/banner/dto/update-banner.dto';
-import { UploadBannerDto } from 'src/banner/dto/upload-banner.dto';
-import { CreateBannerFromUrlDto } from 'src/banner/dto/create-banner-from-url.dto';
-import { UploadImageUserDto } from 'src/users/dto/upload-image-user.dto';
-import { UpdateFlagDto } from 'src/feature-flags/dto/update-flag.dto';
-import { UploadPoItemDto } from 'src/products/dto/upload-po-item.dto';
-import { UploadProductFlashSaleItemDto } from 'src/products/dto/upload-product-flashsale-item.dto';
-import { UploadProductL16Dto } from 'src/products/dto/upload-product-l16.dto';
-import { GetFlashSaleDto } from 'src/products/dto/get-flashsale.dto';
-import { AddToFavoriteDto } from 'src/favorite/dto/add-to-favorite.dto';
-import { DeleteFavoriteDto } from 'src/favorite/dto/delete-favorite.dto';
-import { SigninDto } from 'src/auth/dto/signin.dto';
-import { SearchProductsDto } from 'src/products/dto/search-products.dto';
-import { SearchCategoryProductsDto } from 'src/products/dto/search-category-products.dto';
-import { ProductForYouDto } from 'src/products/dto/product-for-you.dto';
-import { SubmitOrderDto } from 'src/shopping-order/dto/submit-order.dto';
-import { GetProductDetailDto } from 'src/products/dto/get-product-detail.dto';
-import { AddProductCartDto } from 'src/shopping-cart/dto/add-product-cart.dto';
-import { TrackCompanyDayViewDto } from 'src/company-day-analytic/dto/track-company-day-view.dto';
-import { CheckProductCartAllDto } from 'src/shopping-cart/dto/check-product-cart-all.dto';
-import { DeleteProductCartDto } from 'src/shopping-cart/dto/delete-product-cart.dto';
-import { CheckProductCartDto } from 'src/shopping-cart/dto/check-product-cart.dto';
-import { AddPromotionDto } from 'src/promotion/dto/add-promotion.dto';
-import { UpdatePromoPosterDto } from 'src/promotion/dto/update-promo-poster.dto';
-import { AddTierDto } from 'src/promotion/dto/add-tier.dto';
-import { UpdatePromotionStatusDto } from 'src/promotion/dto/update-promotion-status.dto';
-import { DeleteTierDto } from 'src/promotion/dto/delete-tier.dto';
-import { DeletePromotionDto } from 'src/promotion/dto/delete-promotion.dto';
-import { DuplicatePromotionDto } from 'src/promotion/dto/duplicate-promotion.dto';
-import { AddPromotionConditionDto } from 'src/promotion/dto/add-promotion-condition.dto';
-import { DeletePromotionConditionDto } from 'src/promotion/dto/delete-promotion-condition.dto';
-import { AddPromotionRewardDto } from 'src/promotion/dto/add-promotion-reward.dto';
-import { GetProductByCreditorDto } from 'src/promotion/dto/get-product-by-creditor.dto';
-import { DeletePromotionRewardDto } from 'src/promotion/dto/delete-promotion-reward.dto';
-import { UpdatePromotionDto } from 'src/promotion/dto/update-promotion.dto';
-import { EditPromotionRewardDto } from 'src/promotion/dto/edit-promotion-reward.dto';
-import { GetProductTierDto } from 'src/promotion/dto/get-product-tier.dto';
-import { AddCreditorDto } from 'src/products/dto/add-creditor.dto';
-import { EditTierDto } from 'src/promotion/dto/edit-tier.dto';
-import { ImportWangdayDto } from 'src/wangday/dto/import-wangday.dto';
-import { SaveHotdealDto } from 'src/hotdeal/dto/save-hotdeal.dto';
-import { DeleteHotdealDto } from 'src/hotdeal/dto/delete-hotdeal.dto';
-import { CheckHotdealMatchDto } from 'src/hotdeal/dto/check-hotdeal-match.dto';
-import { UseCodeForCheckRewardDto } from 'src/promotion/dto/use-code-for-check-reward.dto';
-import { GenerateCodePromotionDto } from 'src/promotion/dto/generate-code-promotion.dto';
-import { UpdateProductFromBackOfficeDto, UpdateStockFromBackOfficeDto } from 'src/products/dto/back-office.dto';
-import { UpdateCustomerDataDto, RefreshTokenDto } from 'src/auth/dto/auth.dto';
-import { AddLotItemDto } from 'src/lot/dto/add-lots.dto';
 import {
+  UpdateUserDataDto,
+  UpdateBannerDto,
+  UploadBannerDto,
+  CreateBannerFromUrlDto,
+  UploadImageUserDto,
+  UpdateFlagDto,
+  UploadPoItemDto,
+  UploadProductFlashSaleItemDto,
+  UploadProductL16Dto,
+  GetFlashSaleDto,
+  AddToFavoriteDto,
+  DeleteFavoriteDto,
+  SigninDto,
+  SearchProductsDto,
+  SearchCategoryProductsDto,
+  ProductForYouDto,
+  SubmitOrderDto,
+  GetProductDetailDto,
+  AddProductCartDto,
+  TrackCompanyDayViewDto,
+  CheckProductCartAllDto,
+  DeleteProductCartDto,
+  CheckProductCartDto,
+  AddPromotionDto,
+  UpdatePromoPosterDto,
+  AddTierDto,
+  UpdatePromotionStatusDto,
+  DeleteTierDto,
+  DeletePromotionDto,
+  DuplicatePromotionDto,
+  AddPromotionConditionDto,
+  DeletePromotionConditionDto,
+  AddPromotionRewardDto,
+  GetProductByCreditorDto,
+  DeletePromotionRewardDto,
+  UpdatePromotionDto,
+  EditPromotionRewardDto,
+  GetProductTierDto,
+  AddCreditorDto,
+  EditTierDto,
+  ImportWangdayDto,
+  SaveHotdealDto,
+  DeleteHotdealDto,
+  CheckHotdealMatchDto,
+  UseCodeForCheckRewardDto,
+  GenerateCodePromotionDto,
+  UpdateProductFromBackOfficeDto,
+  UpdateStockFromBackOfficeDto,
+  UpdateCustomerDataDto,
+  RefreshTokenDto,
+  AddLotItemDto,
   AddFlashsaleDto,
   AddProductToFlashsaleDto,
   DeleteProductFlashsaleDto,
@@ -109,27 +111,28 @@ import {
   ChangeStatusFlashsaleDto,
   DeleteFlashsaleDto,
   EditFlashsaleDto,
-} from 'src/flashsale/dto/flashsale.dto';
-import { UploadLogFileDto } from 'src/backend/dto/upload-log-file.dto';
-import {
+  UploadLogFileDto,
   AddInvisibleTopicDto,
   AddInvisibleProductDto,
   DeleteInvisibleProductDto,
   DeleteInvisibleTopicDto,
-} from 'src/invisible-product/dto/invisible-product.dto';
-import { CreateAddressBodyDto } from 'src/edit-address/dto/create-address.dto';
-import { SaveModalContentDto } from 'src/modalmain/dto/save-modal-content.dto';
-import { AddProductFreeDto, DeleteProductFreeDto, EditProductFreeDto } from 'src/fix-free/dto/fix-free.dto';
-import { CreateSessionDto, LogoutSessionDto, MemCodeDto } from 'src/sessions/dto/sessions.dto';
-import {
+  CreateAddressBodyDto,
+  SaveModalContentDto,
+  AddProductFreeDto,
+  DeleteProductFreeDto,
+  EditProductFreeDto,
+  CreateSessionDto,
+  LogoutSessionDto,
+  MemCodeDto,
   RequestOtpDto,
   ValidateOtpDto,
   ChangePasswordDto,
   ResetPasswordDto,
-} from 'src/change-password/dto/change-password.dto';
-import { NewArrivalItemDto } from 'src/new-arrivals/dto/new-arrival-item.dto';
-import { ImportDataInvoiceDto, ImportDataRtDto } from 'src/debtor/dto/debtor.dto';
-import { UpdateKeysearchDto } from 'src/product-keyword/dto/update-keysearch.dto';
+  NewArrivalItemDto,
+  ImportDataInvoiceDto,
+  ImportDataRtDto,
+  UpdateKeysearchDto,
+} from 'src/common/dto-index';
 import { objectSchema, arraySchema } from 'src/common/swagger-helpers';
 import { BackendService } from './backend/backend.service';
 import { DebtorService } from './debtor/debtor.service';
@@ -242,7 +245,11 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiOperation({ summary: 'Send order data to old system' })
-  @ApiParam({ name: 'soh_running', description: 'Order running number', example: 'SO-67010001' })
+  @ApiParam({
+    name: 'soh_running',
+    description: 'Order running number',
+    example: 'SO-67010001',
+  })
   @ApiResponse({ status: 200, description: 'Data sent to old system' })
   @Get('/ecom/get-data/:soh_running')
   async apiForOldSystem(@Param('soh_running') soh_running: string) {
@@ -254,7 +261,8 @@ export class AppController {
   @ApiQuery({
     name: 'location',
     required: false,
-    description: 'Banner placement location. Omit to get banners for all locations.',
+    description:
+      'Banner placement location. Omit to get banners for all locations.',
     enum: ['store_carousel', 'landing_hero', 'popup', 'sidebar'],
     example: 'landing_hero',
   })
@@ -284,7 +292,8 @@ export class AppController {
   @ApiOperation({ summary: 'Update a banner by id' })
   @ApiParam({ name: 'id', description: 'Banner id', example: '12' })
   @ApiBody({
-    description: 'Partial banner fields to update — any subset of BannerEntity columns; omitted fields are left unchanged.',
+    description:
+      'Partial banner fields to update — any subset of BannerEntity columns; omitted fields are left unchanged.',
     type: UpdateBannerDto,
   })
   @ApiResponse({ status: 200, description: 'Banner updated' })
@@ -380,7 +389,11 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiOperation({ summary: 'Get a feature flag status' })
-  @ApiParam({ name: 'flag', description: 'Feature flag name', example: 'new_checkout' })
+  @ApiParam({
+    name: 'flag',
+    description: 'Feature flag name',
+    example: 'new_checkout',
+  })
   @ApiResponse({ status: 200, description: 'Feature flag status' })
   @Get('/ecom/feature-flag/:flag')
   async checkFlag(@Param('flag') flag: string) {
@@ -505,8 +518,17 @@ export class AppController {
   @ApiTags('Product Search')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get favorite product list' })
-  @ApiParam({ name: 'mem_code', description: 'Member code (unused, taken from JWT)', example: 'M00123' })
-  @ApiQuery({ name: 'sort_by', required: false, description: 'Optional sort order key; omit for default order', example: 'name' })
+  @ApiParam({
+    name: 'mem_code',
+    description: 'Member code (unused, taken from JWT)',
+    example: 'M00123',
+  })
+  @ApiQuery({
+    name: 'sort_by',
+    required: false,
+    description: 'Optional sort order key; omit for default order',
+    example: 'name',
+  })
   @ApiResponse({ status: 200, description: 'Favorite list' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -738,7 +760,11 @@ export class AppController {
   @ApiTags('Product Search')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'List point-redeemable products' })
-  @ApiParam({ name: 'sortBy', description: 'Sort order key, e.g. "name" or "point"', example: 'name' })
+  @ApiParam({
+    name: 'sortBy',
+    description: 'Sort order key, e.g. "name" or "point"',
+    example: 'name',
+  })
   @ApiResponse({ status: 200, description: 'Product coin list' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -945,7 +971,11 @@ export class AppController {
   @ApiTags('Cart & Checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get cart snapshot with summary' })
-  @ApiParam({ name: 'mem_code', description: 'Member code (unused, taken from JWT)', example: 'M00123' })
+  @ApiParam({
+    name: 'mem_code',
+    description: 'Member code (unused, taken from JWT)',
+    example: 'M00123',
+  })
   @ApiResponse({ status: 200, description: 'Cart snapshot' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -978,7 +1008,11 @@ export class AppController {
   @ApiTags('Cart & Checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Soft delete a cart item' })
-  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiParam({
+    name: 'pro_code',
+    description: 'Product code',
+    example: 'P00123',
+  })
   @ApiResponse({ status: 200, description: 'Cart item soft deleted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -996,7 +1030,11 @@ export class AppController {
   @ApiTags('Cart & Checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get a single product for cart' })
-  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiParam({
+    name: 'pro_code',
+    description: 'Product code',
+    example: 'P00123',
+  })
   @ApiResponse({ status: 200, description: 'Product detail' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1053,7 +1091,11 @@ export class AppController {
   @ApiTags('Cart & Checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get a single order by running number' })
-  @ApiParam({ name: 'soh_runing', description: 'Order running number', example: 'SO-67010001' })
+  @ApiParam({
+    name: 'soh_runing',
+    description: 'Order running number',
+    example: 'SO-67010001',
+  })
   @ApiResponse({ status: 200, description: 'Order detail' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1512,7 +1554,11 @@ export class AppController {
 
   @ApiTags('Hotdeal & Flash Sale')
   @ApiOperation({ summary: 'Search main products for hotdeal' })
-  @ApiParam({ name: 'keyword', description: 'Search keyword', example: 'paracetamol' })
+  @ApiParam({
+    name: 'keyword',
+    description: 'Search keyword',
+    example: 'paracetamol',
+  })
   @ApiResponse({ status: 201, description: 'Matched products' })
   @Post('/ecom/admin/hotdeal/search-product-main/:keyword')
   async searchProductMain(@Param('keyword') keyword: string) {
@@ -1569,7 +1615,13 @@ export class AppController {
   @ApiOperation({ summary: 'Get hotdeals (simple list) for current member' })
   @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
   @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
-  @ApiQuery({ name: 'special_deal', required: false, type: String, description: '"true" or "false"', example: 'false' })
+  @ApiQuery({
+    name: 'special_deal',
+    required: false,
+    type: String,
+    description: '"true" or "false"',
+    example: 'false',
+  })
   @ApiResponse({ status: 200, description: 'List of hotdeals' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1595,7 +1647,9 @@ export class AppController {
 
   @ApiTags('Hotdeal & Flash Sale')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get product-pro deals (simple list) for current member' })
+  @ApiOperation({
+    summary: 'Get product-pro deals (simple list) for current member',
+  })
   @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
   @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
   @ApiResponse({ status: 200, description: 'List of product-pro deals' })
@@ -1617,7 +1671,9 @@ export class AppController {
 
   @ApiTags('Hotdeal & Flash Sale')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get "buy more get 1" deals (simple list) for current member' })
+  @ApiOperation({
+    summary: 'Get "buy more get 1" deals (simple list) for current member',
+  })
   @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
   @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
   @ApiResponse({ status: 200, description: 'List of buy-more-get-1 deals' })
@@ -1685,7 +1741,9 @@ export class AppController {
 
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Generate a promo code for a member (requires permission)' })
+  @ApiOperation({
+    summary: 'Generate a promo code for a member (requires permission)',
+  })
   @ApiBody({ type: GenerateCodePromotionDto })
   @ApiResponse({ status: 201, description: 'Promo code generated' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -1704,7 +1762,11 @@ export class AppController {
 
   @ApiTags('Hotdeal & Flash Sale')
   @ApiOperation({ summary: 'Get hotdeal/freebie detail by product code' })
-  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiParam({
+    name: 'pro_code',
+    description: 'Product code',
+    example: 'P00123',
+  })
   @ApiResponse({ status: 200, description: 'Hotdeal detail' })
   @Get('/ecom/hotdeal/get-hotdeal-from-code/:pro_code')
   async getHotdealFromCode(@Param('pro_code') pro_code: string) {
@@ -1712,7 +1774,9 @@ export class AppController {
   }
 
   @ApiTags('Misc / Admin Tools')
-  @ApiOperation({ summary: 'Bulk update products from back office import file' })
+  @ApiOperation({
+    summary: 'Bulk update products from back office import file',
+  })
   @ApiBody({ type: UpdateProductFromBackOfficeDto })
   @ApiResponse({ status: 201, description: 'Products updated' })
   @Post('/ecom/admin/update-product-from-back-office')
@@ -1780,7 +1844,11 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiOperation({ summary: 'Get file log entries by feature' })
-  @ApiParam({ name: 'feature', description: 'Feature name', example: 'wangday-import' })
+  @ApiParam({
+    name: 'feature',
+    description: 'Feature name',
+    example: 'wangday-import',
+  })
   @ApiResponse({ status: 200, description: 'File log entries' })
   @Get('/ecom/fileLog/:feature')
   async getFileLog(@Param('feature') feature: string) {
@@ -1816,7 +1884,9 @@ export class AppController {
 
   @ApiTags('Products')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get all searchable product keywords for current member' })
+  @ApiOperation({
+    summary: 'Get all searchable product keywords for current member',
+  })
   @ApiResponse({ status: 200, description: 'List of product keywords' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1888,7 +1958,11 @@ export class AppController {
   @ApiTags('Hotdeal & Flash Sale')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get products in a daily flash sale' })
-  @ApiParam({ name: 'promotion_id', description: 'Flash sale promotion id', example: '3' })
+  @ApiParam({
+    name: 'promotion_id',
+    description: 'Flash sale promotion id',
+    example: '3',
+  })
   @ApiResponse({ status: 200, description: 'List of products in flash sale' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1919,9 +1993,7 @@ export class AppController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/edit-product')
-  async editProductInDailyFlashSale(
-    @Body() data: EditProductInFlashsaleDto,
-  ) {
+  async editProductInDailyFlashSale(@Body() data: EditProductInFlashsaleDto) {
     return await this.flashsaleService.editProductInFlashSale(data);
   }
 
@@ -1953,9 +2025,7 @@ export class AppController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/change-status')
-  async changeStatusDailyFlashsale(
-    @Body() data: ChangeStatusFlashsaleDto,
-  ) {
+  async changeStatusDailyFlashsale(@Body() data: ChangeStatusFlashsaleDto) {
     return await this.flashsaleService.changeStatus({
       promotion_id: data.id,
       is_active: data.is_active,
@@ -1991,7 +2061,11 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiOperation({ summary: 'Get the log file for a feature' })
-  @ApiParam({ name: 'feature', description: 'Feature name', example: 'wangday-import' })
+  @ApiParam({
+    name: 'feature',
+    description: 'Feature name',
+    example: 'wangday-import',
+  })
   @ApiResponse({ status: 200, description: 'Log file content' })
   @Get('/ecom/get-upload-log-file/:feature')
   async getUploadLogFile(@Param('feature') feature: string) {
@@ -2041,7 +2115,11 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiOperation({ summary: 'Get invisible products by creditor code' })
-  @ApiParam({ name: 'creditor_code', description: 'Creditor code', example: 'C00123' })
+  @ApiParam({
+    name: 'creditor_code',
+    description: 'Creditor code',
+    example: 'C00123',
+  })
   @ApiResponse({ status: 200, description: 'List of products' })
   @Get('/ecom/invisible/product/creditor/:creditor_code')
   async getInvisibleProductByCreditor(
@@ -2052,7 +2130,11 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiOperation({ summary: 'Get invisible products by invisible topic id' })
-  @ApiParam({ name: 'invisible_id', description: 'Invisible topic id', example: 1 })
+  @ApiParam({
+    name: 'invisible_id',
+    description: 'Invisible topic id',
+    example: 1,
+  })
   @ApiResponse({ status: 200, description: 'List of products' })
   @Get('/ecom/invisible/product/creditor/list/:invisible_id')
   async getInvisibleProductByInvisibleID(
@@ -2184,7 +2266,9 @@ export class AppController {
 
   @ApiTags('Products')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Add a product to the "fix free" point-redeemable list' })
+  @ApiOperation({
+    summary: 'Add a product to the "fix free" point-redeemable list',
+  })
   @ApiBody({ type: AddProductFreeDto })
   @ApiResponse({ status: 201, description: 'Product added' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -2262,7 +2346,11 @@ export class AppController {
   @ApiTags('Session')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get an active session by token' })
-  @ApiParam({ name: 'session_token', description: 'Session token', example: 'a1b2c3d4e5' })
+  @ApiParam({
+    name: 'session_token',
+    description: 'Session token',
+    example: 'a1b2c3d4e5',
+  })
   @ApiResponse({ status: 200, description: 'Active session' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2286,7 +2374,11 @@ export class AppController {
   @ApiTags('Session')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update last activity timestamp of a session' })
-  @ApiParam({ name: 'session_token', description: 'Session token', example: 'a1b2c3d4e5' })
+  @ApiParam({
+    name: 'session_token',
+    description: 'Session token',
+    example: 'a1b2c3d4e5',
+  })
   @ApiResponse({ status: 200, description: 'Session activity updated' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2326,7 +2418,10 @@ export class AppController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Logout recently active sessions of a member' })
   @ApiBody({ type: MemCodeDto })
-  @ApiResponse({ status: 201, description: 'Recently active sessions logged out' })
+  @ApiResponse({
+    status: 201,
+    description: 'Recently active sessions logged out',
+  })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/session/logout-recent')
@@ -2338,7 +2433,11 @@ export class AppController {
   @ApiTags('Session')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Validate whether a session token is still active' })
-  @ApiParam({ name: 'session_token', description: 'Session token', example: 'a1b2c3d4e5' })
+  @ApiParam({
+    name: 'session_token',
+    description: 'Session token',
+    example: 'a1b2c3d4e5',
+  })
   @ApiResponse({ status: 200, description: 'Validation result' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2362,7 +2461,9 @@ export class AppController {
   }
 
   @ApiTags('Password')
-  @ApiOperation({ summary: 'Check whether a member has an email on file for password reset' })
+  @ApiOperation({
+    summary: 'Check whether a member has an email on file for password reset',
+  })
   @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
   @ApiResponse({ status: 200, description: 'Email check result' })
   @Get('/ecom/password/check-email/:mem_code')
@@ -2468,8 +2569,14 @@ export class AppController {
 
   @ApiTags('Products')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get up to 30 new-arrival products for current member' })
-  @ApiParam({ name: 'mem_code', description: 'Member code (unused, taken from JWT)', example: 'M00123' })
+  @ApiOperation({
+    summary: 'Get up to 30 new-arrival products for current member',
+  })
+  @ApiParam({
+    name: 'mem_code',
+    description: 'Member code (unused, taken from JWT)',
+    example: 'M00123',
+  })
   @ApiResponse({ status: 200, description: 'List of new-arrival products' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2484,7 +2591,11 @@ export class AppController {
 
   @ApiTags('Hotdeal & Flash Sale')
   @ApiOperation({ summary: 'Find a hotdeal by product code' })
-  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiParam({
+    name: 'pro_code',
+    description: 'Product code',
+    example: 'P00123',
+  })
   @ApiResponse({ status: 200, description: 'Hotdeal detail' })
   @Get('/ecom/hotdeal/find/:pro_code')
   find(@Param('pro_code') pro_code: string): Promise<any> {
@@ -2493,7 +2604,9 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get wangday data grouped by product (requires permission)' })
+  @ApiOperation({
+    summary: 'Get wangday data grouped by product (requires permission)',
+  })
   @ApiResponse({ status: 200, description: 'Wangday data by product' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2514,7 +2627,9 @@ export class AppController {
 
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get all company-day promotions (requires permission)' })
+  @ApiOperation({
+    summary: 'Get all company-day promotions (requires permission)',
+  })
   @ApiResponse({ status: 200, description: 'List of promotions' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2579,7 +2694,9 @@ export class AppController {
   }
   @ApiTags('Products')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get all "fix free" products (requires permission)' })
+  @ApiOperation({
+    summary: 'Get all "fix free" products (requires permission)',
+  })
   @ApiResponse({ status: 200, description: 'List of free products' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2596,7 +2713,9 @@ export class AppController {
 
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get all promotional products (requires permission)' })
+  @ApiOperation({
+    summary: 'Get all promotional products (requires permission)',
+  })
   @ApiResponse({ status: 200, description: 'List of promotional products' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2657,8 +2776,14 @@ export class AppController {
 
   @ApiTags('Debtor / Reduction')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Find a reduction invoice by invoice id for current member' })
-  @ApiParam({ name: 'invoice', description: 'Invoice number', example: 'INV00123' })
+  @ApiOperation({
+    summary: 'Find a reduction invoice by invoice id for current member',
+  })
+  @ApiParam({
+    name: 'invoice',
+    description: 'Invoice number',
+    example: 'INV00123',
+  })
   @ApiResponse({ status: 200, description: 'Debtor/invoice record' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2679,8 +2804,14 @@ export class AppController {
 
   @ApiTags('Debtor / Reduction')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Find a reduction RT (return) record by id for current member' })
-  @ApiParam({ name: 'rt', description: 'RT (return) number', example: 'RT00123' })
+  @ApiOperation({
+    summary: 'Find a reduction RT (return) record by id for current member',
+  })
+  @ApiParam({
+    name: 'rt',
+    description: 'RT (return) number',
+    example: 'RT00123',
+  })
   @ApiResponse({ status: 200, description: 'Reduction RT record' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2707,16 +2838,18 @@ export class AppController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/keysearch/update-product-keysearch')
-  async updateKeysearch(
-    @Body() data: UpdateKeysearchDto,
-  ) {
+  async updateKeysearch(@Body() data: UpdateKeysearchDto) {
     await this.productKeySearch.updateKeyword(data);
   }
 
   @ApiTags('Products')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get keysearch info for one product' })
-  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiParam({
+    name: 'pro_code',
+    description: 'Product code',
+    example: 'P00123',
+  })
   @ApiResponse({ status: 200, description: 'Keysearch info' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2727,7 +2860,9 @@ export class AppController {
 
   @ApiTags('Users')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Check/refresh latest purchase date for current member' })
+  @ApiOperation({
+    summary: 'Check/refresh latest purchase date for current member',
+  })
   @ApiResponse({ status: 200, description: 'Check result' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2757,15 +2892,53 @@ export class AppController {
   @ApiOperation({ summary: 'Create or update an employee record' })
   @ApiBody({
     schema: objectSchema({
-      emp_code: { type: 'string', example: 'E00123', description: 'Required; not empty' },
+      emp_code: {
+        type: 'string',
+        example: 'E00123',
+        description: 'Required; not empty',
+      },
       data: objectSchema({
-        emp_code: { type: 'string', example: 'E00123', description: 'Required; not empty' },
-        emp_nickname: { type: 'string', example: 'นัท', description: 'Optional; empty string allowed', optional: true },
-        emp_firstname: { type: 'string', example: 'สมชาย', description: 'Optional; empty string allowed', optional: true },
-        emp_lastname: { type: 'string', example: 'ใจดี', description: 'Optional; empty string allowed', optional: true },
-        emp_mobile: { type: 'string', example: '0812345678', description: 'Optional; empty string allowed', optional: true },
-        emp_email: { type: 'string', example: 'somchai@example.com', description: 'Optional; empty string allowed', optional: true },
-        emp_ID_line: { type: 'string', example: 'somchai_line', description: 'Optional; empty string allowed', optional: true },
+        emp_code: {
+          type: 'string',
+          example: 'E00123',
+          description: 'Required; not empty',
+        },
+        emp_nickname: {
+          type: 'string',
+          example: 'นัท',
+          description: 'Optional; empty string allowed',
+          optional: true,
+        },
+        emp_firstname: {
+          type: 'string',
+          example: 'สมชาย',
+          description: 'Optional; empty string allowed',
+          optional: true,
+        },
+        emp_lastname: {
+          type: 'string',
+          example: 'ใจดี',
+          description: 'Optional; empty string allowed',
+          optional: true,
+        },
+        emp_mobile: {
+          type: 'string',
+          example: '0812345678',
+          description: 'Optional; empty string allowed',
+          optional: true,
+        },
+        emp_email: {
+          type: 'string',
+          example: 'somchai@example.com',
+          description: 'Optional; empty string allowed',
+          optional: true,
+        },
+        emp_ID_line: {
+          type: 'string',
+          example: 'somchai_line',
+          description: 'Optional; empty string allowed',
+          optional: true,
+        },
       }),
     }),
   })
@@ -2808,7 +2981,11 @@ export class AppController {
   @ApiOperation({ summary: 'Bulk update daily sale amount for products' })
   @ApiBody({
     schema: arraySchema({
-      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
       amount: { type: 'number', example: 25, description: 'Required' },
     }),
   })
@@ -2824,12 +3001,27 @@ export class AppController {
 
   @ApiTags('Users')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Update or clear VIP tag for a member (requires permission)' })
+  @ApiOperation({
+    summary: 'Update or clear VIP tag for a member (requires permission)',
+  })
   @ApiBody({
     schema: objectSchema({
-      mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
-      message: { type: 'string', example: 'อนุมัติ VIP แล้ว', description: 'Required; not empty' },
-      tagVIP: { type: 'string', example: 'VIP', description: 'Optional; empty string/omit clears the tag', optional: true },
+      mem_code: {
+        type: 'string',
+        example: 'M00123',
+        description: 'Required; not empty',
+      },
+      message: {
+        type: 'string',
+        example: 'อนุมัติ VIP แล้ว',
+        description: 'Required; not empty',
+      },
+      tagVIP: {
+        type: 'string',
+        example: 'VIP',
+        description: 'Optional; empty string/omit clears the tag',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 200, description: 'VIP tag updated' })
@@ -2909,7 +3101,15 @@ export class AppController {
   @ApiTags('Recommend')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Insert a recommend tag' })
-  @ApiBody({ schema: objectSchema({ tag: { type: 'string', example: 'สินค้าขายดี', description: 'Required; not empty' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      tag: {
+        type: 'string',
+        example: 'สินค้าขายดี',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Tag inserted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2936,7 +3136,11 @@ export class AppController {
   @ApiBody({
     schema: objectSchema({
       tag_id: { type: 'number', example: 1, description: 'Required' },
-      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Tag attached to product' })
@@ -2955,7 +3159,11 @@ export class AppController {
   @ApiOperation({ summary: 'Update display rank for a recommended product' })
   @ApiBody({
     schema: objectSchema({
-      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
       rank: { type: 'number', example: 1, description: 'Required' },
     }),
   })
@@ -2971,7 +3179,15 @@ export class AppController {
   @ApiTags('Recommend')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Remove all recommend tags from a product' })
-  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Tags removed' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2983,7 +3199,15 @@ export class AppController {
   @ApiTags('Recommend')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete display rank for a recommended product' })
-  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Rank deleted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -2995,7 +3219,11 @@ export class AppController {
   @ApiTags('Recommend')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete a recommend tag' })
-  @ApiBody({ schema: objectSchema({ tag_id: { type: 'number', example: 1, description: 'Required' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      tag_id: { type: 'number', example: 1, description: 'Required' },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Tag deleted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -3006,12 +3234,28 @@ export class AppController {
 
   @ApiTags('Recommend')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get recommended products by recommend ids for current member' })
+  @ApiOperation({
+    summary: 'Get recommended products by recommend ids for current member',
+  })
   @ApiBody({
     schema: objectSchema({
-      pro_code: { type: 'array', items: { type: 'string', example: 'P00123' }, description: 'Optional; not used by the implementation', optional: true },
-      recommend_id: { type: 'array', items: { type: 'number', example: 1 }, description: 'Required; not empty' },
-      mem_code: { type: 'string', example: 'M00123', description: 'Optional; overridden by JWT mem_code if present', optional: true },
+      pro_code: {
+        type: 'array',
+        items: { type: 'string', example: 'P00123' },
+        description: 'Optional; not used by the implementation',
+        optional: true,
+      },
+      recommend_id: {
+        type: 'array',
+        items: { type: 'number', example: 1 },
+        description: 'Required; not empty',
+      },
+      mem_code: {
+        type: 'string',
+        example: 'M00123',
+        description: 'Optional; overridden by JWT mem_code if present',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'List of recommended products' })
@@ -3037,7 +3281,9 @@ export class AppController {
 
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Set promotion status for all products under a tier' })
+  @ApiOperation({
+    summary: 'Set promotion status for all products under a tier',
+  })
   @ApiBody({
     schema: objectSchema({
       tier_id: { type: 'number', example: 1, description: 'Required' },
@@ -3059,11 +3305,21 @@ export class AppController {
 
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Check the promotion tier applicable to a product for a member' })
+  @ApiOperation({
+    summary: 'Check the promotion tier applicable to a product for a member',
+  })
   @ApiBody({
     schema: objectSchema({
-      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
-      mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
+      mem_code: {
+        type: 'string',
+        example: 'M00123',
+        description: 'Required; not empty',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Tier/promotion info' })
@@ -3081,7 +3337,9 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get all image-debug records (requires permission)' })
+  @ApiOperation({
+    summary: 'Get all image-debug records (requires permission)',
+  })
   @ApiResponse({ status: 200, description: 'List of image-debug records' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -3129,10 +3387,30 @@ export class AppController {
   @ApiOperation({ summary: 'Upload a banner/contract-log image' })
   @ApiBody({
     schema: objectSchema({
-      file: { type: 'string', format: 'binary', description: 'Required; image file' },
-      name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed', optional: true },
-      type: { type: 'string', enum: ['wang', 'attestor', 'creditor', 'banner'], example: 'banner', description: 'Optional', optional: true },
-      bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed', optional: true },
+      file: {
+        type: 'string',
+        format: 'binary',
+        description: 'Required; image file',
+      },
+      name: {
+        type: 'string',
+        example: 'สมชาย ใจดี',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      type: {
+        type: 'string',
+        enum: ['wang', 'attestor', 'creditor', 'banner'],
+        example: 'banner',
+        description: 'Optional',
+        optional: true,
+      },
+      bannerName: {
+        type: 'string',
+        example: 'แบนเนอร์โปรโมชั่น',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'File uploaded' })
@@ -3192,11 +3470,22 @@ export class AppController {
 
   @ApiTags('Contract Log')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get dropdown data for contract-log forms (e.g. attestor/creditor lists)' })
+  @ApiOperation({
+    summary:
+      'Get dropdown data for contract-log forms (e.g. attestor/creditor lists)',
+  })
   @ApiBody({
     schema: objectSchema({
-      group: { type: 'string', example: 'attestor', description: 'Required; not empty' },
-      type: { type: 'string', example: 'attestor', description: 'Required; not empty' },
+      group: {
+        type: 'string',
+        example: 'attestor',
+        description: 'Required; not empty',
+      },
+      type: {
+        type: 'string',
+        example: 'attestor',
+        description: 'Required; not empty',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Dropdown data' })
@@ -3219,18 +3508,82 @@ export class AppController {
   @ApiOperation({ summary: 'Create a contract-log banner record' })
   @ApiBody({
     schema: objectSchema({
-      selectedWang: { type: 'number', example: 1, description: 'Optional', optional: true },
-      selectedAttestor: { type: 'number', example: 1, description: 'Optional', optional: true },
-      selectedAttestor2: { type: 'number', example: 2, description: 'Optional', optional: true },
-      selectedCreditor: { type: 'number', example: 1, description: 'Optional', optional: true },
-      bannerId: { type: 'number', example: 1, description: 'Optional', optional: true },
-      bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed', optional: true },
-      signingDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
-      creditorCode: { type: 'string', example: 'C00123', description: 'Optional; empty string allowed', optional: true },
-      startDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
-      endDate: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
-      paymentDue: { type: 'string', format: 'date-time', example: '2026-07-23T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
-      address: { type: 'string', example: '99/1 ถนนสุขุมวิท', description: 'Optional; empty string allowed', optional: true },
+      selectedWang: {
+        type: 'number',
+        example: 1,
+        description: 'Optional',
+        optional: true,
+      },
+      selectedAttestor: {
+        type: 'number',
+        example: 1,
+        description: 'Optional',
+        optional: true,
+      },
+      selectedAttestor2: {
+        type: 'number',
+        example: 2,
+        description: 'Optional',
+        optional: true,
+      },
+      selectedCreditor: {
+        type: 'number',
+        example: 1,
+        description: 'Optional',
+        optional: true,
+      },
+      bannerId: {
+        type: 'number',
+        example: 1,
+        description: 'Optional',
+        optional: true,
+      },
+      bannerName: {
+        type: 'string',
+        example: 'แบนเนอร์โปรโมชั่น',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      signingDate: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-06-23T00:00:00.000Z',
+        description: 'Optional; ISO datetime',
+        optional: true,
+      },
+      creditorCode: {
+        type: 'string',
+        example: 'C00123',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      startDate: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-06-23T00:00:00.000Z',
+        description: 'Optional; ISO datetime',
+        optional: true,
+      },
+      endDate: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-12-31T00:00:00.000Z',
+        description: 'Optional; ISO datetime',
+        optional: true,
+      },
+      paymentDue: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-07-23T00:00:00.000Z',
+        description: 'Optional; ISO datetime',
+        optional: true,
+      },
+      address: {
+        type: 'string',
+        example: '99/1 ถนนสุขุมวิท',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Banner record created' })
@@ -3262,10 +3615,17 @@ export class AppController {
 
   @ApiTags('Contract Log')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Search creditors by keyword for contract-log forms' })
+  @ApiOperation({
+    summary: 'Search creditors by keyword for contract-log forms',
+  })
   @ApiBody({
     schema: objectSchema({
-      keyword: { type: 'string', example: 'บริษัท วังเภสัช', description: 'Optional; empty string allowed', optional: true },
+      keyword: {
+        type: 'string',
+        example: 'บริษัท วังเภสัช',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'List of matching creditors' })
@@ -3280,14 +3640,37 @@ export class AppController {
 
   @ApiTags('Contract Log')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Update a contract-log creditor/banner image and info' })
+  @ApiOperation({
+    summary: 'Update a contract-log creditor/banner image and info',
+  })
   @ApiBody({
     schema: objectSchema({
       contractId: { type: 'number', example: 1, description: 'Required' },
-      name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed', optional: true },
-      type: { type: 'string', enum: ['creditor', 'banner'], example: 'creditor', description: 'Optional', optional: true },
-      bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed', optional: true },
-      file: { type: 'string', format: 'binary', description: 'Optional; image file', optional: true },
+      name: {
+        type: 'string',
+        example: 'สมชาย ใจดี',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      type: {
+        type: 'string',
+        enum: ['creditor', 'banner'],
+        example: 'creditor',
+        description: 'Optional',
+        optional: true,
+      },
+      bannerName: {
+        type: 'string',
+        example: 'แบนเนอร์โปรโมชั่น',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      file: {
+        type: 'string',
+        format: 'binary',
+        description: 'Optional; image file',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Contract log updated' })
@@ -3323,8 +3706,17 @@ export class AppController {
   @ApiBody({
     schema: objectSchema({
       contractId: { type: 'number', example: 1, description: 'Required' },
-      name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed', optional: true },
-      file: { type: 'string', format: 'binary', description: 'Required; signed contract file' },
+      name: {
+        type: 'string',
+        example: 'สมชาย ใจดี',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      file: {
+        type: 'string',
+        format: 'binary',
+        description: 'Required; signed contract file',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Signed contract uploaded' })
@@ -3346,13 +3738,16 @@ export class AppController {
 
   @ApiTags('Contract Log')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get contract-log company-day record(s) by id or all' })
+  @ApiOperation({
+    summary: 'Get contract-log company-day record(s) by id or all',
+  })
   @ApiBody({
     schema: objectSchema({
       companyDayId: {
         oneOf: [{ type: 'number' }, { type: 'string', enum: ['all'] }],
         example: 'all',
-        description: 'Optional; company-day record id, or "all" to get every record',
+        description:
+          'Optional; company-day record id, or "all" to get every record',
         optional: true,
       },
     }),
@@ -3375,7 +3770,11 @@ export class AppController {
   @ApiOperation({ summary: 'Update reward redemption limit for a product' })
   @ApiBody({
     schema: objectSchema({
-      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
       limit: { type: 'number', example: 50, description: 'Required' },
     }),
   })
@@ -3395,7 +3794,15 @@ export class AppController {
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Reset reward redemption count for a product' })
-  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Limit count reset' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -3406,13 +3813,34 @@ export class AppController {
 
   @ApiTags('Products')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Set a replacement product for a discontinued product' })
+  @ApiOperation({
+    summary: 'Set a replacement product for a discontinued product',
+  })
   @ApiBody({
     schema: objectSchema({
-      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
-      replace_pro_code: { type: 'string', example: 'P00456', description: 'Required; not empty' },
-      note: { type: 'string', example: 'สินค้าหมดสายผลิต', description: 'Optional; empty string allowed', optional: true },
-      date_end: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
+      replace_pro_code: {
+        type: 'string',
+        example: 'P00456',
+        description: 'Required; not empty',
+      },
+      note: {
+        type: 'string',
+        example: 'สินค้าหมดสายผลิต',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      date_end: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-12-31T00:00:00.000Z',
+        description: 'Optional; ISO datetime',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Replacement product set' })
@@ -3442,27 +3870,137 @@ export class AppController {
   @ApiOperation({ summary: 'Create a contract-log company-day record' })
   @ApiBody({
     schema: objectSchema({
-      selectedWang: { type: 'number', example: 1, description: 'Optional', optional: true },
-      selectedAttestor: { type: 'number', example: 1, description: 'Optional', optional: true },
-      selectedAttestor2: { type: 'number', example: 2, description: 'Optional', optional: true },
-      selectedCreditor: { type: 'number', example: 1, description: 'Optional', optional: true },
-      bannerId: { type: 'number', example: 1, description: 'Optional', optional: true },
-      bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed', optional: true },
-      signingDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
-      creditorCode: { type: 'string', example: 'C00123', description: 'Optional; empty string allowed', optional: true },
-      startDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
-      endDate: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
-      address: { type: 'string', example: '99/1 ถนนสุขุมวิท', description: 'Optional; empty string allowed', optional: true },
-      reportDueDate: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
-      finalPaymentAmount: { type: 'number', example: 5000, description: 'Optional', optional: true },
-      totalSupportValue: { type: 'number', example: 10000, description: 'Optional', optional: true },
-      supportDeliveryDate: { type: 'string', format: 'date-time', example: '2026-07-01T00:00:00.000Z', description: 'Optional; ISO datetime', optional: true },
-      numberOfInstallments: { type: 'number', example: 3, description: 'Optional', optional: true },
-      installmentIntervalDays: { type: 'number', example: 30, description: 'Optional', optional: true },
-      firstInstallmentAmount: { type: 'number', example: 3000, description: 'Optional', optional: true },
-      firstPaymentCondition: { type: 'string', example: 'ชำระทันทีหลังเซ็นสัญญา', description: 'Optional; empty string allowed', optional: true },
-      finalInstallmentAmount: { type: 'number', example: 2000, description: 'Optional', optional: true },
-      productsToOrder: { type: 'string', example: 'P00123, P00456', description: 'Optional; empty string allowed', optional: true },
+      selectedWang: {
+        type: 'number',
+        example: 1,
+        description: 'Optional',
+        optional: true,
+      },
+      selectedAttestor: {
+        type: 'number',
+        example: 1,
+        description: 'Optional',
+        optional: true,
+      },
+      selectedAttestor2: {
+        type: 'number',
+        example: 2,
+        description: 'Optional',
+        optional: true,
+      },
+      selectedCreditor: {
+        type: 'number',
+        example: 1,
+        description: 'Optional',
+        optional: true,
+      },
+      bannerId: {
+        type: 'number',
+        example: 1,
+        description: 'Optional',
+        optional: true,
+      },
+      bannerName: {
+        type: 'string',
+        example: 'แบนเนอร์โปรโมชั่น',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      signingDate: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-06-23T00:00:00.000Z',
+        description: 'Optional; ISO datetime',
+        optional: true,
+      },
+      creditorCode: {
+        type: 'string',
+        example: 'C00123',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      startDate: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-06-23T00:00:00.000Z',
+        description: 'Optional; ISO datetime',
+        optional: true,
+      },
+      endDate: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-12-31T00:00:00.000Z',
+        description: 'Optional; ISO datetime',
+        optional: true,
+      },
+      address: {
+        type: 'string',
+        example: '99/1 ถนนสุขุมวิท',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      reportDueDate: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-12-31T00:00:00.000Z',
+        description: 'Optional; ISO datetime',
+        optional: true,
+      },
+      finalPaymentAmount: {
+        type: 'number',
+        example: 5000,
+        description: 'Optional',
+        optional: true,
+      },
+      totalSupportValue: {
+        type: 'number',
+        example: 10000,
+        description: 'Optional',
+        optional: true,
+      },
+      supportDeliveryDate: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-07-01T00:00:00.000Z',
+        description: 'Optional; ISO datetime',
+        optional: true,
+      },
+      numberOfInstallments: {
+        type: 'number',
+        example: 3,
+        description: 'Optional',
+        optional: true,
+      },
+      installmentIntervalDays: {
+        type: 'number',
+        example: 30,
+        description: 'Optional',
+        optional: true,
+      },
+      firstInstallmentAmount: {
+        type: 'number',
+        example: 3000,
+        description: 'Optional',
+        optional: true,
+      },
+      firstPaymentCondition: {
+        type: 'string',
+        example: 'ชำระทันทีหลังเซ็นสัญญา',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      finalInstallmentAmount: {
+        type: 'number',
+        example: 2000,
+        description: 'Optional',
+        optional: true,
+      },
+      productsToOrder: {
+        type: 'string',
+        example: 'P00123, P00456',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Company-day record created' })
@@ -3501,13 +4039,31 @@ export class AppController {
 
   @ApiTags('Contract Log')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Update a contract-log company-day record (creditor image)' })
+  @ApiOperation({
+    summary: 'Update a contract-log company-day record (creditor image)',
+  })
   @ApiBody({
     schema: objectSchema({
       contractId: { type: 'number', example: 1, description: 'Required' },
-      name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed', optional: true },
-      type: { type: 'string', enum: ['creditor'], example: 'creditor', description: 'Optional', optional: true },
-      file: { type: 'string', format: 'binary', description: 'Optional; image file', optional: true },
+      name: {
+        type: 'string',
+        example: 'สมชาย ใจดี',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      type: {
+        type: 'string',
+        enum: ['creditor'],
+        example: 'creditor',
+        description: 'Optional',
+        optional: true,
+      },
+      file: {
+        type: 'string',
+        format: 'binary',
+        description: 'Optional; image file',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Company-day record updated' })
@@ -3544,7 +4100,11 @@ export class AppController {
   @ApiBody({
     schema: objectSchema({
       contractId: { type: 'number', example: 1, description: 'Required' },
-      file: { type: 'string', format: 'binary', description: 'Required; signed contract file' },
+      file: {
+        type: 'string',
+        format: 'binary',
+        description: 'Required; signed contract file',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Signed contract uploaded' })
@@ -3567,7 +4127,15 @@ export class AppController {
   @ApiTags('Products')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get the replacement product info for a product' })
-  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Replacement product info' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -3579,7 +4147,15 @@ export class AppController {
   @ApiTags('Products')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Clear the replacement product for a product' })
-  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Replacement product cleared' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -3590,10 +4166,17 @@ export class AppController {
 
   @ApiTags('Policy Document')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Find policy document categories (optionally by name)' })
+  @ApiOperation({
+    summary: 'Find policy document categories (optionally by name)',
+  })
   @ApiBody({
     schema: objectSchema({
-      name: { type: 'string', example: 'นโยบายความเป็นส่วนตัว', description: 'Optional; empty string allowed', optional: true },
+      name: {
+        type: 'string',
+        example: 'นโยบายความเป็นส่วนตัว',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'List of policy categories' })
@@ -3610,7 +4193,11 @@ export class AppController {
   @ApiOperation({ summary: 'Save a new policy document version' })
   @ApiBody({
     schema: objectSchema({
-      content: { type: 'string', example: '<p>เนื้อหานโยบาย</p>', description: 'Required; not empty' },
+      content: {
+        type: 'string',
+        example: '<p>เนื้อหานโยบาย</p>',
+        description: 'Required; not empty',
+      },
       category: { type: 'number', example: 1, description: 'Required' },
       type: { type: 'number', example: 1, description: 'Required' },
     }),
@@ -3634,7 +4221,10 @@ export class AppController {
 
   @ApiTags('Policy Document')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Check and get the correct (latest unsigned) policy for current member' })
+  @ApiOperation({
+    summary:
+      'Check and get the correct (latest unsigned) policy for current member',
+  })
   @ApiResponse({ status: 200, description: 'Applicable policy document' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -3647,7 +4237,11 @@ export class AppController {
   @ApiTags('Policy Document')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Agree to a policy document for current member' })
-  @ApiBody({ schema: objectSchema({ policyID: { type: 'number', example: 1, description: 'Required' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      policyID: { type: 'number', example: 1, description: 'Required' },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Agreement recorded' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -3711,8 +4305,17 @@ export class AppController {
   @ApiOperation({ summary: 'Create a campaign' })
   @ApiBody({
     schema: objectSchema({
-      name: { type: 'string', example: 'แคมเปญสิ้นปี 2026', description: 'Required; not empty' },
-      description: { type: 'string', example: 'แคมเปญลดราคาสิ้นปี', description: 'Optional; empty string allowed', optional: true },
+      name: {
+        type: 'string',
+        example: 'แคมเปญสิ้นปี 2026',
+        description: 'Required; not empty',
+      },
+      description: {
+        type: 'string',
+        example: 'แคมเปญลดราคาสิ้นปี',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Campaign created' })
@@ -3790,9 +4393,24 @@ export class AppController {
   @ApiBody({
     schema: objectSchema({
       set_number: { type: 'number', example: 1, description: 'Required' },
-      condition: { type: 'string', example: 'ซื้อครบ 1000 บาท', description: 'Optional; empty string allowed', optional: true },
-      target: { type: 'string', example: 'P00123', description: 'Optional; empty string allowed', optional: true },
-      con_percent: { type: 'string', example: '10', description: 'Optional; empty string allowed', optional: true },
+      condition: {
+        type: 'string',
+        example: 'ซื้อครบ 1000 บาท',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      target: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      con_percent: {
+        type: 'string',
+        example: '10',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Row created' })
@@ -3827,15 +4445,60 @@ export class AppController {
   @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
   @ApiBody({
     schema: objectSchema({
-      target: { type: 'string', example: 'P00123', description: 'Optional; empty string allowed', optional: true },
-      con_percent: { type: 'string', example: '10', description: 'Optional; empty string allowed', optional: true },
-      condition: { type: 'string', example: 'ซื้อครบ 1000 บาท', description: 'Optional; empty string allowed', optional: true },
-      set_number: { type: 'number', example: 1, description: 'Optional', optional: true },
-      price_per_set: { type: 'string', example: '500.00', description: 'Optional; empty string allowed', optional: true },
-      number_of_sets: { type: 'number', example: 2, description: 'Optional', optional: true },
-      unit_price: { type: 'number', example: 250, description: 'Optional', optional: true },
-      quantity: { type: 'number', example: 2, description: 'Optional', optional: true },
-      discounted_price: { type: 'number', example: 450, description: 'Optional', optional: true },
+      target: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      con_percent: {
+        type: 'string',
+        example: '10',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      condition: {
+        type: 'string',
+        example: 'ซื้อครบ 1000 บาท',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      set_number: {
+        type: 'number',
+        example: 1,
+        description: 'Optional',
+        optional: true,
+      },
+      price_per_set: {
+        type: 'string',
+        example: '500.00',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      number_of_sets: {
+        type: 'number',
+        example: 2,
+        description: 'Optional',
+        optional: true,
+      },
+      unit_price: {
+        type: 'number',
+        example: 250,
+        description: 'Optional',
+        optional: true,
+      },
+      quantity: {
+        type: 'number',
+        example: 2,
+        description: 'Optional',
+        optional: true,
+      },
+      discounted_price: {
+        type: 'number',
+        example: 450,
+        description: 'Optional',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 200, description: 'Row updated' })
@@ -3900,9 +4563,23 @@ export class AppController {
   @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
   @ApiBody({
     schema: objectSchema({
-      name: { type: 'string', example: 'ของแถม', description: 'Required; not empty' },
-      unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed', optional: true },
-      value_per_unit: { type: 'string', example: '10.00', description: 'Optional; empty string allowed', optional: true },
+      name: {
+        type: 'string',
+        example: 'ของแถม',
+        description: 'Required; not empty',
+      },
+      unit: {
+        type: 'string',
+        example: 'ชิ้น',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      value_per_unit: {
+        type: 'string',
+        example: '10.00',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Reward column created' })
@@ -3988,7 +4665,15 @@ export class AppController {
   @ApiOperation({ summary: 'Add a product to a campaign row' })
   @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
   @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
-  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Product added to row' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -4026,7 +4711,15 @@ export class AppController {
   @ApiOperation({ summary: 'Remove a product from a campaign row' })
   @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
   @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
-  @ApiBody({ schema: objectSchema({ pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Product removed from row' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -4069,11 +4762,35 @@ export class AppController {
   @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
   @ApiBody({
     schema: objectSchema({
-      reward_column_id: { type: 'string', example: '1', description: 'Required; not empty' },
-      quantity: { type: 'string', example: '2', description: 'Optional; empty string allowed', optional: true },
-      unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed', optional: true },
-      price: { type: 'string', example: '10.00', description: 'Optional; empty string allowed', optional: true },
-      value: { type: 'string', example: '20.00', description: 'Optional; empty string allowed', optional: true },
+      reward_column_id: {
+        type: 'string',
+        example: '1',
+        description: 'Required; not empty',
+      },
+      quantity: {
+        type: 'string',
+        example: '2',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      unit: {
+        type: 'string',
+        example: 'ชิ้น',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      price: {
+        type: 'string',
+        example: '10.00',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      value: {
+        type: 'string',
+        example: '20.00',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Promo reward added' })
@@ -4115,10 +4832,30 @@ export class AppController {
   @ApiParam({ name: 'rewardId', description: 'Reward id', example: '1' })
   @ApiBody({
     schema: objectSchema({
-      quantity: { type: 'string', example: '2', description: 'Optional; empty string allowed', optional: true },
-      unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed', optional: true },
-      price: { type: 'string', example: '10.00', description: 'Optional; empty string allowed', optional: true },
-      value: { type: 'string', example: '20.00', description: 'Optional; empty string allowed', optional: true },
+      quantity: {
+        type: 'string',
+        example: '2',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      unit: {
+        type: 'string',
+        example: 'ชิ้น',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      price: {
+        type: 'string',
+        example: '10.00',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      value: {
+        type: 'string',
+        example: '20.00',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 200, description: 'Promo reward updated' })
@@ -4197,9 +4934,21 @@ export class AppController {
   @ApiOperation({ summary: 'Update a reward column image/product link' })
   @ApiBody({
     schema: objectSchema({
-      reward_id: { type: 'string', example: '1', description: 'Required; not empty' },
-      url: { type: 'string', example: 'https://example.com/image.png', description: 'Required; not empty' },
-      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      reward_id: {
+        type: 'string',
+        example: '1',
+        description: 'Required; not empty',
+      },
+      url: {
+        type: 'string',
+        example: 'https://example.com/image.png',
+        description: 'Required; not empty',
+      },
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Reward column updated' })
@@ -4232,8 +4981,16 @@ export class AppController {
   @ApiOperation({ summary: 'Upload an image for a campaign reward' })
   @ApiBody({
     schema: objectSchema({
-      file: { type: 'string', format: 'binary', description: 'Required; image file' },
-      reward_id: { type: 'string', example: '1', description: 'Required; not empty' },
+      file: {
+        type: 'string',
+        format: 'binary',
+        description: 'Required; image file',
+      },
+      reward_id: {
+        type: 'string',
+        example: '1',
+        description: 'Required; not empty',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Image uploaded' })
@@ -4262,7 +5019,15 @@ export class AppController {
   @ApiTags('Campaigns')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Upload a generic campaign image' })
-  @ApiBody({ schema: objectSchema({ file: { type: 'string', format: 'binary', description: 'Required; image file' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      file: {
+        type: 'string',
+        format: 'binary',
+        description: 'Required; image file',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Image uploaded' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -4304,7 +5069,15 @@ export class AppController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Create a purchase product entry for a campaign' })
   @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
-  @ApiBody({ schema: objectSchema({ name: { type: 'string', example: 'แชมพูสมุนไพร', description: 'Required; not empty' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      name: {
+        type: 'string',
+        example: 'แชมพูสมุนไพร',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Purchase product created' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -4331,11 +5104,25 @@ export class AppController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update a purchase product entry' })
   @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
-  @ApiParam({ name: 'productId', description: 'Purchase product id', example: '1' })
+  @ApiParam({
+    name: 'productId',
+    description: 'Purchase product id',
+    example: '1',
+  })
   @ApiBody({
     schema: objectSchema({
-      name: { type: 'string', example: 'แชมพูสมุนไพร', description: 'Optional; empty string allowed', optional: true },
-      img_url: { type: 'string', example: 'https://example.com/image.png', description: 'Optional; empty string allowed', optional: true },
+      name: {
+        type: 'string',
+        example: 'แชมพูสมุนไพร',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
+      img_url: {
+        type: 'string',
+        example: 'https://example.com/image.png',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 200, description: 'Purchase product updated' })
@@ -4366,7 +5153,11 @@ export class AppController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete a purchase product entry' })
   @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
-  @ApiParam({ name: 'productId', description: 'Purchase product id', example: '1' })
+  @ApiParam({
+    name: 'productId',
+    description: 'Purchase product id',
+    example: '1',
+  })
   @ApiResponse({ status: 200, description: 'Purchase product deleted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -4390,8 +5181,20 @@ export class AppController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Upload an image for a purchase product' })
   @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
-  @ApiParam({ name: 'productId', description: 'Purchase product id', example: '1' })
-  @ApiBody({ schema: objectSchema({ file: { type: 'string', format: 'binary', description: 'Required; image file' } }) })
+  @ApiParam({
+    name: 'productId',
+    description: 'Purchase product id',
+    example: '1',
+  })
+  @ApiBody({
+    schema: objectSchema({
+      file: {
+        type: 'string',
+        format: 'binary',
+        description: 'Required; image file',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Image uploaded' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -4424,18 +5227,44 @@ export class AppController {
   @ApiOperation({ summary: 'Generate a campaign poster image via AI' })
   @ApiBody({
     schema: objectSchema({
-      prompt: { type: 'string', example: 'โปสเตอร์โปรโมชั่นสินค้าฤดูร้อน', description: 'Required; not empty' },
-      aspectRatio: { type: 'string', example: '1:1', description: 'Required; not empty' },
+      prompt: {
+        type: 'string',
+        example: 'โปสเตอร์โปรโมชั่นสินค้าฤดูร้อน',
+        description: 'Required; not empty',
+      },
+      aspectRatio: {
+        type: 'string',
+        example: '1:1',
+        description: 'Required; not empty',
+      },
       imageItems: {
         ...arraySchema({
-          url: { type: 'string', example: 'https://example.com/image.png', description: 'Required; not empty' },
-          name: { type: 'string', example: 'แชมพูสมุนไพร', description: 'Required; not empty' },
+          url: {
+            type: 'string',
+            example: 'https://example.com/image.png',
+            description: 'Required; not empty',
+          },
+          name: {
+            type: 'string',
+            example: 'แชมพูสมุนไพร',
+            description: 'Required; not empty',
+          },
           quantity: { type: 'number', example: 1, description: 'Required' },
-          unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed', optional: true },
+          unit: {
+            type: 'string',
+            example: 'ชิ้น',
+            description: 'Optional; empty string allowed',
+            optional: true,
+          },
         }),
         optional: true,
       },
-      session_cookies: { type: 'string', example: '', description: 'Optional; empty string allowed', optional: true },
+      session_cookies: {
+        type: 'string',
+        example: '',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Poster generation request id' })
@@ -4464,11 +5293,22 @@ export class AppController {
   }
 
   @ApiTags('Campaigns')
-  @ApiOperation({ summary: 'Poll for AI poster generation result by request id' })
-  @ApiParam({ name: 'requestId', description: 'Poster generation request id', example: 'req_00123' })
+  @ApiOperation({
+    summary: 'Poll for AI poster generation result by request id',
+  })
+  @ApiParam({
+    name: 'requestId',
+    description: 'Poster generation request id',
+    example: 'req_00123',
+  })
   @ApiBody({
     schema: objectSchema({
-      session_cookies: { type: 'string', example: '', description: 'Optional; empty string allowed', optional: true },
+      session_cookies: {
+        type: 'string',
+        example: '',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Generation result' })
@@ -4501,7 +5341,11 @@ export class AppController {
   @ApiOperation({ summary: 'Update value-per-unit for a reward column' })
   @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
   @ApiParam({ name: 'columnId', description: 'Reward column id', example: '1' })
-  @ApiBody({ schema: objectSchema({ value_per_unit: { type: 'number', example: 10, description: 'Required' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      value_per_unit: { type: 'number', example: 10, description: 'Required' },
+    }),
+  })
   @ApiResponse({ status: 200, description: 'Value per unit updated' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -4521,10 +5365,20 @@ export class AppController {
 
   @ApiTags('Campaigns')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Save a generated poster image to a campaign row history' })
+  @ApiOperation({
+    summary: 'Save a generated poster image to a campaign row history',
+  })
   @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
   @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
-  @ApiBody({ schema: objectSchema({ img_url: { type: 'string', example: 'https://example.com/poster.png', description: 'Required; not empty' } }) })
+  @ApiBody({
+    schema: objectSchema({
+      img_url: {
+        type: 'string',
+        example: 'https://example.com/poster.png',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Poster history saved' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -4549,22 +5403,47 @@ export class AppController {
 
   @ApiTags('Campaigns')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Create a banner from a poster history image and link it' })
+  @ApiOperation({
+    summary: 'Create a banner from a poster history image and link it',
+  })
   @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
   @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
-  @ApiParam({ name: 'historyId', description: 'Poster history id', example: '1' })
+  @ApiParam({
+    name: 'historyId',
+    description: 'Poster history id',
+    example: '1',
+  })
   @ApiBody({
     schema: objectSchema({
-      img_url: { type: 'string', example: 'https://example.com/poster.png', description: 'Required; not empty' },
-      banner_name: { type: 'string', example: 'โปสเตอร์โปรโมชั่นฤดูร้อน', description: 'Optional; empty string allowed', optional: true },
+      img_url: {
+        type: 'string',
+        example: 'https://example.com/poster.png',
+        description: 'Required; not empty',
+      },
+      banner_name: {
+        type: 'string',
+        example: 'โปสเตอร์โปรโมชั่นฤดูร้อน',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
       banner_location: {
         type: 'string',
         enum: ['store_carousel', 'landing_hero', 'popup', 'sidebar'],
         example: 'store_carousel',
         description: 'Required; not empty',
       },
-      date_start: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Required; ISO datetime' },
-      date_end: { type: 'string', format: 'date-time', example: '2026-07-23T00:00:00.000Z', description: 'Required; ISO datetime' },
+      date_start: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-06-23T00:00:00.000Z',
+        description: 'Required; ISO datetime',
+      },
+      date_end: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-07-23T00:00:00.000Z',
+        description: 'Required; ISO datetime',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Banner created and linked' })
@@ -4609,10 +5488,17 @@ export class AppController {
 
   @ApiTags('Campaigns')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Remove a banner link from poster history (keeps the banner image file)' })
+  @ApiOperation({
+    summary:
+      'Remove a banner link from poster history (keeps the banner image file)',
+  })
   @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
   @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
-  @ApiParam({ name: 'historyId', description: 'Poster history id', example: '1' })
+  @ApiParam({
+    name: 'historyId',
+    description: 'Poster history id',
+    example: '1',
+  })
   @ApiParam({ name: 'linkId', description: 'Banner link id', example: '1' })
   @ApiResponse({ status: 200, description: 'Banner link removed' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -4657,8 +5543,14 @@ export class AppController {
   }
 
   @ApiTags('Campaigns')
-  @ApiOperation({ summary: 'Proxy-download an ideogram.ai generated image (avoids CORS)' })
-  @ApiQuery({ name: 'url', description: 'Must start with https://ideogram.ai/', example: 'https://ideogram.ai/api/images/example.png' })
+  @ApiOperation({
+    summary: 'Proxy-download an ideogram.ai generated image (avoids CORS)',
+  })
+  @ApiQuery({
+    name: 'url',
+    description: 'Must start with https://ideogram.ai/',
+    example: 'https://ideogram.ai/api/images/example.png',
+  })
   @ApiResponse({ status: 200, description: 'Image binary stream' })
   @Get('/campaigns/proxy-image')
   async proxyImage(@Query('url') url: string, @Res() res: Response) {
@@ -4683,7 +5575,9 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Search banner-eligible products (requires permission)' })
+  @ApiOperation({
+    summary: 'Search banner-eligible products (requires permission)',
+  })
   @ApiResponse({ status: 200, description: 'List of products' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -4713,7 +5607,11 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiOperation({ summary: 'Get delivery tracking location for an order' })
-  @ApiParam({ name: 'sh_running', description: 'Shopping head running number', example: 'SO00123' })
+  @ApiParam({
+    name: 'sh_running',
+    description: 'Shopping head running number',
+    example: 'SO00123',
+  })
   @ApiResponse({ status: 200, description: 'Order tracking location' })
   @Get('/ecom/track-order/:sh_running')
   async trackOrder(@Param('sh_running') sh_running: string) {
@@ -4762,7 +5660,11 @@ export class AppController {
   @ApiTags('Product Returns')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get order items available for return selection' })
-  @ApiParam({ name: 'soh_running', description: 'Shopping order head running number', example: 'SO00123' })
+  @ApiParam({
+    name: 'soh_running',
+    description: 'Shopping order head running number',
+    example: 'SO00123',
+  })
   @ApiResponse({ status: 200, description: 'List of order items' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -4793,18 +5695,29 @@ export class AppController {
   // Customer: Create return request
   @ApiTags('Product Returns')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Create a product return request (customer-initiated)' })
+  @ApiOperation({
+    summary: 'Create a product return request (customer-initiated)',
+  })
   @ApiBody({
     schema: objectSchema({
       soh_id: { type: 'number', example: 12345, description: 'Required' },
-      mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+      mem_code: {
+        type: 'string',
+        example: 'M00123',
+        description: 'Required; not empty',
+      },
       reason: {
         type: 'string',
         enum: ['damaged', 'expired', 'wrong_item', 'disaster', 'other'],
         example: 'damaged',
         description: 'Required; not empty',
       },
-      reason_detail: { type: 'string', example: 'สินค้าชำรุดตอนเปิดกล่อง', description: 'Optional; empty string allowed', optional: true },
+      reason_detail: {
+        type: 'string',
+        example: 'สินค้าชำรุดตอนเปิดกล่อง',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
       resolution_type: {
         type: 'string',
         enum: ['refund', 'replacement'],
@@ -4812,14 +5725,41 @@ export class AppController {
         description: 'Required; not empty',
       },
       items: arraySchema({
-        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        pro_code: {
+          type: 'string',
+          example: 'P00123',
+          description: 'Required; not empty',
+        },
         qty: { type: 'number', example: 2, description: 'Required' },
-        unit: { type: 'string', example: 'กล่อง', description: 'Required; not empty' },
-        price_per_unit: { type: 'number', example: 150, description: 'Required' },
-        item_reason: { type: 'string', example: 'สินค้าชำรุด', description: 'Optional; empty string allowed', optional: true },
-        expiry_date: { type: 'string', example: '2026-12-31', description: 'Optional; format YYYY-MM-DD', optional: true },
+        unit: {
+          type: 'string',
+          example: 'กล่อง',
+          description: 'Required; not empty',
+        },
+        price_per_unit: {
+          type: 'number',
+          example: 150,
+          description: 'Required',
+        },
+        item_reason: {
+          type: 'string',
+          example: 'สินค้าชำรุด',
+          description: 'Optional; empty string allowed',
+          optional: true,
+        },
+        expiry_date: {
+          type: 'string',
+          example: '2026-12-31',
+          description: 'Optional; format YYYY-MM-DD',
+          optional: true,
+        },
       }),
-      notes: { type: 'string', example: '', description: 'Optional; empty string allowed', optional: true },
+      notes: {
+        type: 'string',
+        example: '',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Return request created' })
@@ -4867,12 +5807,28 @@ export class AppController {
   // Customer: Upload evidence images
   @ApiTags('Product Returns')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Upload evidence images for a return request (up to 5 files)' })
-  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiOperation({
+    summary: 'Upload evidence images for a return request (up to 5 files)',
+  })
+  @ApiParam({
+    name: 'return_id',
+    description: 'Return request id',
+    example: '1',
+  })
   @ApiBody({
     schema: objectSchema({
-      files: { type: 'array', items: { type: 'string', format: 'binary' }, description: 'Optional; up to 5 image files', optional: true },
-      description: { type: 'string', example: '', description: 'Optional; empty string allowed', optional: true },
+      files: {
+        type: 'array',
+        items: { type: 'string', format: 'binary' },
+        description: 'Optional; up to 5 image files',
+        optional: true,
+      },
+      description: {
+        type: 'string',
+        example: '',
+        description: 'Optional; empty string allowed',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Images uploaded' })
@@ -4909,7 +5865,11 @@ export class AppController {
   @ApiTags('Product Returns')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Submit a draft return request for review' })
-  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiParam({
+    name: 'return_id',
+    description: 'Return request id',
+    example: '1',
+  })
   @ApiResponse({ status: 201, description: 'Return request submitted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -4942,7 +5902,12 @@ export class AppController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get return requests for a member' })
   @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
-  @ApiQuery({ name: 'status', required: false, type: String, example: 'pending' })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    type: String,
+    example: 'pending',
+  })
   @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
   @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
   @ApiResponse({ status: 200, description: 'List of return requests' })
@@ -4979,7 +5944,11 @@ export class AppController {
   @ApiTags('Product Returns')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get detail of a return request' })
-  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiParam({
+    name: 'return_id',
+    description: 'Return request id',
+    example: '1',
+  })
   @ApiResponse({ status: 200, description: 'Return request detail' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -5007,7 +5976,11 @@ export class AppController {
   @ApiTags('Product Returns')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete a draft (unsubmitted) return request' })
-  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiParam({
+    name: 'return_id',
+    description: 'Return request id',
+    example: '1',
+  })
   @ApiResponse({ status: 200, description: 'Draft return deleted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -5094,10 +6067,22 @@ export class AppController {
   // Get user behavior (for personalization)
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get tracked behavior events for a member (for personalization)' })
+  @ApiOperation({
+    summary: 'Get tracked behavior events for a member (for personalization)',
+  })
   @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
-  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
-  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiQuery({
+    name: 'from_date',
+    required: false,
+    type: String,
+    example: '2026-06-01',
+  })
+  @ApiQuery({
+    name: 'to_date',
+    required: false,
+    type: String,
+    example: '2026-06-23',
+  })
   @ApiResponse({ status: 200, description: 'User behavior data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -5130,10 +6115,26 @@ export class AppController {
   // Admin: Get product analytics
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get product view/interaction analytics (requires permission)' })
-  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
-  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
-  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiOperation({
+    summary: 'Get product view/interaction analytics (requires permission)',
+  })
+  @ApiParam({
+    name: 'pro_code',
+    description: 'Product code',
+    example: 'P00123',
+  })
+  @ApiQuery({
+    name: 'from_date',
+    required: false,
+    type: String,
+    example: '2026-06-01',
+  })
+  @ApiQuery({
+    name: 'to_date',
+    required: false,
+    type: String,
+    example: '2026-06-23',
+  })
   @ApiResponse({ status: 200, description: 'Product analytics data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -5171,9 +6172,21 @@ export class AppController {
   // Admin: Get search analytics
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get search behavior analytics (requires permission)' })
-  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
-  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiOperation({
+    summary: 'Get search behavior analytics (requires permission)',
+  })
+  @ApiQuery({
+    name: 'from_date',
+    required: false,
+    type: String,
+    example: '2026-06-01',
+  })
+  @ApiQuery({
+    name: 'to_date',
+    required: false,
+    type: String,
+    example: '2026-06-23',
+  })
   @ApiResponse({ status: 200, description: 'Search analytics data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -5209,9 +6222,21 @@ export class AppController {
   // Admin: Get dashboard stats
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get behavior tracking dashboard stats (requires permission)' })
-  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
-  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiOperation({
+    summary: 'Get behavior tracking dashboard stats (requires permission)',
+  })
+  @ApiQuery({
+    name: 'from_date',
+    required: false,
+    type: String,
+    example: '2026-06-01',
+  })
+  @ApiQuery({
+    name: 'to_date',
+    required: false,
+    type: String,
+    example: '2026-06-23',
+  })
   @ApiResponse({ status: 200, description: 'Dashboard stats' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -5248,8 +6273,18 @@ export class AppController {
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get daily behavior trend (requires permission)' })
-  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
-  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiQuery({
+    name: 'from_date',
+    required: false,
+    type: String,
+    example: '2026-06-01',
+  })
+  @ApiQuery({
+    name: 'to_date',
+    required: false,
+    type: String,
+    example: '2026-06-23',
+  })
   @ApiResponse({ status: 200, description: 'Daily trend data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -5285,9 +6320,21 @@ export class AppController {
   // Admin: Get top products
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get top viewed/purchased products (requires permission)' })
-  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
-  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiOperation({
+    summary: 'Get top viewed/purchased products (requires permission)',
+  })
+  @ApiQuery({
+    name: 'from_date',
+    required: false,
+    type: String,
+    example: '2026-06-01',
+  })
+  @ApiQuery({
+    name: 'to_date',
+    required: false,
+    type: String,
+    example: '2026-06-23',
+  })
   @ApiQuery({ name: 'limit', required: false, type: String, example: '10' })
   @ApiResponse({ status: 200, description: 'List of top products' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -5326,7 +6373,9 @@ export class AppController {
   // Admin: Get recent activity feed
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get recent customer activity feed (requires permission)' })
+  @ApiOperation({
+    summary: 'Get recent customer activity feed (requires permission)',
+  })
   @ApiQuery({ name: 'limit', required: false, type: String, example: '50' })
   @ApiResponse({ status: 200, description: 'Recent activity feed' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -5361,7 +6410,9 @@ export class AppController {
   // Admin: Get user journeys
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get user navigation journeys (requires permission)' })
+  @ApiOperation({
+    summary: 'Get user navigation journeys (requires permission)',
+  })
   @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
   @ApiResponse({ status: 200, description: 'List of user journeys' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -5396,9 +6447,22 @@ export class AppController {
   // Admin: Get zero result searches
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get search queries that returned zero results (requires permission)' })
-  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
-  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiOperation({
+    summary:
+      'Get search queries that returned zero results (requires permission)',
+  })
+  @ApiQuery({
+    name: 'from_date',
+    required: false,
+    type: String,
+    example: '2026-06-01',
+  })
+  @ApiQuery({
+    name: 'to_date',
+    required: false,
+    type: String,
+    example: '2026-06-23',
+  })
   @ApiQuery({ name: 'limit', required: false, type: String, example: '30' })
   @ApiResponse({ status: 200, description: 'List of zero-result searches' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -5437,7 +6501,9 @@ export class AppController {
   // Admin: Get stock alerts based on demand
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get demand-based stock alerts (requires permission)' })
+  @ApiOperation({
+    summary: 'Get demand-based stock alerts (requires permission)',
+  })
   @ApiQuery({ name: 'days', required: false, type: String, example: '7' })
   @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
   @ApiResponse({ status: 200, description: 'List of stock alerts' })
@@ -5475,7 +6541,9 @@ export class AppController {
   // Admin: Get cart conversion analytics
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get cart-to-purchase conversion analytics (requires permission)' })
+  @ApiOperation({
+    summary: 'Get cart-to-purchase conversion analytics (requires permission)',
+  })
   @ApiQuery({ name: 'days', required: false, type: String, example: '30' })
   @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
   @ApiResponse({ status: 200, description: 'Cart conversion analytics' })
@@ -5513,7 +6581,9 @@ export class AppController {
   // Admin: Get customer segments
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get customer segmentation analysis (requires permission)' })
+  @ApiOperation({
+    summary: 'Get customer segmentation analysis (requires permission)',
+  })
   @ApiQuery({ name: 'days', required: false, type: String, example: '90' })
   @ApiResponse({ status: 200, description: 'Customer segments' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -5548,7 +6618,9 @@ export class AppController {
   // Admin: Get retention analysis
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get customer retention analysis (requires permission)' })
+  @ApiOperation({
+    summary: 'Get customer retention analysis (requires permission)',
+  })
   @ApiQuery({ name: 'weeks', required: false, type: String, example: '8' })
   @ApiResponse({ status: 200, description: 'Retention analysis' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -5583,7 +6655,9 @@ export class AppController {
   // Admin: Get repeat purchase patterns
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get repeat purchase patterns (requires permission)' })
+  @ApiOperation({
+    summary: 'Get repeat purchase patterns (requires permission)',
+  })
   @ApiQuery({ name: 'days', required: false, type: String, example: '180' })
   @ApiResponse({ status: 200, description: 'Repeat purchase patterns' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -5618,9 +6692,17 @@ export class AppController {
   // Admin: Get purchase interval box plot data
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get purchase interval box-plot data (requires permission)' })
+  @ApiOperation({
+    summary: 'Get purchase interval box-plot data (requires permission)',
+  })
   @ApiQuery({ name: 'days', required: false, type: String, example: '180' })
-  @ApiQuery({ name: 'group_by', required: false, type: String, example: 'overall', description: 'one of: overall, product, segment, month' })
+  @ApiQuery({
+    name: 'group_by',
+    required: false,
+    type: String,
+    example: 'overall',
+    description: 'one of: overall, product, segment, month',
+  })
   @ApiResponse({ status: 200, description: 'Box-plot data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -5656,9 +6738,21 @@ export class AppController {
   // Admin: Get user journey sankey
   @ApiTags('Behavior Tracking')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get user journey sankey diagram data (requires permission)' })
-  @ApiQuery({ name: 'from_date', required: true, type: String, example: '2026-06-01' })
-  @ApiQuery({ name: 'to_date', required: true, type: String, example: '2026-06-23' })
+  @ApiOperation({
+    summary: 'Get user journey sankey diagram data (requires permission)',
+  })
+  @ApiQuery({
+    name: 'from_date',
+    required: true,
+    type: String,
+    example: '2026-06-01',
+  })
+  @ApiQuery({
+    name: 'to_date',
+    required: true,
+    type: String,
+    example: '2026-06-23',
+  })
   @ApiResponse({ status: 200, description: 'Sankey diagram data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -5680,12 +6774,22 @@ export class AppController {
 
   @ApiTags('Users')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Change a member\'s role/permission (Admin only)' })
+  @ApiOperation({ summary: "Change a member's role/permission (Admin only)" })
   @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
   @ApiBody({
     schema: objectSchema({
-      newRole: { type: 'string', enum: ['User', 'Admin', 'Sales'], example: 'Sales', description: 'Required; not empty' },
-      permission: { type: 'boolean', example: true, description: 'Optional; defaults to false', optional: true },
+      newRole: {
+        type: 'string',
+        enum: ['User', 'Admin', 'Sales'],
+        example: 'Sales',
+        description: 'Required; not empty',
+      },
+      permission: {
+        type: 'boolean',
+        example: true,
+        description: 'Optional; defaults to false',
+        optional: true,
+      },
     }),
   })
   @ApiResponse({ status: 200, description: 'Role changed' })
@@ -5734,7 +6838,9 @@ export class AppController {
 
   @ApiTags('Users')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Look up a member for role management (Admin only)' })
+  @ApiOperation({
+    summary: 'Look up a member for role management (Admin only)',
+  })
   @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
   @ApiResponse({ status: 200, description: 'Member info for role management' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -5770,10 +6876,16 @@ export class AppController {
 
   @ApiTags('Users')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Update enabled feature flags for a member (Admin only)' })
+  @ApiOperation({
+    summary: 'Update enabled feature flags for a member (Admin only)',
+  })
   @ApiBody({
     schema: objectSchema({
-      mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+      mem_code: {
+        type: 'string',
+        example: 'M00123',
+        description: 'Required; not empty',
+      },
       features: {
         type: 'array',
         items: { type: 'string', example: 'happy_hour' },
@@ -5805,7 +6917,9 @@ export class AppController {
 
   @ApiTags('Users')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get paginated admin role-change action logs (Admin only)' })
+  @ApiOperation({
+    summary: 'Get paginated admin role-change action logs (Admin only)',
+  })
   @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
   @ApiQuery({ name: 'limit', required: false, type: Number, example: 20 })
   @ApiResponse({ status: 200, description: 'Paginated admin action logs' })
@@ -5825,7 +6939,9 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get RT (return) order notifications from the last 3 days' })
+  @ApiOperation({
+    summary: 'Get RT (return) order notifications from the last 3 days',
+  })
   @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
   @ApiResponse({ status: 200, description: 'List of RT notifications' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -5839,8 +6955,16 @@ export class AppController {
   @ApiOperation({ summary: 'Update RT (return) notification read status' })
   @ApiBody({
     schema: objectSchema({
-      soh_running: { type: 'string', example: 'SO00123', description: 'Required; not empty' },
-      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      soh_running: {
+        type: 'string',
+        example: 'SO00123',
+        description: 'Required; not empty',
+      },
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'RT notification status updated' })
@@ -5854,8 +6978,18 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Register a push notification token for current member' })
-  @ApiBody({ schema: objectSchema({ token: { type: 'string', example: 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]', description: 'Required; not empty' } }) })
+  @ApiOperation({
+    summary: 'Register a push notification token for current member',
+  })
+  @ApiBody({
+    schema: objectSchema({
+      token: {
+        type: 'string',
+        example: 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Token registered' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -5873,8 +7007,18 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Remove a push notification token for current member' })
-  @ApiBody({ schema: objectSchema({ token: { type: 'string', example: 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]', description: 'Required; not empty' } }) })
+  @ApiOperation({
+    summary: 'Remove a push notification token for current member',
+  })
+  @ApiBody({
+    schema: objectSchema({
+      token: {
+        type: 'string',
+        example: 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Token removed' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -5896,7 +7040,11 @@ export class AppController {
   @ApiBody({
     schema: objectSchema({
       id: { type: 'number', example: 1, description: 'Required' },
-      file: { type: 'string', format: 'binary', description: 'Required; image file' },
+      file: {
+        type: 'string',
+        format: 'binary',
+        description: 'Required; image file',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Banner uploaded' })
@@ -5936,7 +7084,9 @@ export class AppController {
 
   @ApiTags('Products')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get paginated list of products with a replacement set' })
+  @ApiOperation({
+    summary: 'Get paginated list of products with a replacement set',
+  })
   @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
   @ApiQuery({ name: 'limit', required: false, type: Number, example: 10 })
   @ApiResponse({ status: 200, description: 'Paginated replacement products' })
@@ -5952,11 +7102,21 @@ export class AppController {
 
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Upload/update the poster image for a promotion tier' })
+  @ApiOperation({
+    summary: 'Upload/update the poster image for a promotion tier',
+  })
   @ApiBody({
     schema: objectSchema({
-      tier_id: { type: 'string', example: '1', description: 'Required; not empty' },
-      file: { type: 'string', format: 'binary', description: 'Required; image file' },
+      tier_id: {
+        type: 'string',
+        example: '1',
+        description: 'Required; not empty',
+      },
+      file: {
+        type: 'string',
+        format: 'binary',
+        description: 'Required; image file',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Tier poster updated' })
@@ -5972,11 +7132,21 @@ export class AppController {
   }
 
   @ApiTags('Promotion & Tier')
-  @ApiOperation({ summary: 'Check/recalculate tier-turn-back reward price for an order item' })
+  @ApiOperation({
+    summary: 'Check/recalculate tier-turn-back reward price for an order item',
+  })
   @ApiBody({
     schema: objectSchema({
-      sh_running: { type: 'string', example: 'SO00123', description: 'Required; not empty' },
-      pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      sh_running: {
+        type: 'string',
+        example: 'SO00123',
+        description: 'Required; not empty',
+      },
+      pro_code: {
+        type: 'string',
+        example: 'P00123',
+        description: 'Required; not empty',
+      },
     }),
   })
   @ApiResponse({ status: 201, description: 'Tier price result' })
@@ -5990,8 +7160,19 @@ export class AppController {
 
   @ApiTags('Happy Hour')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Check and adjust happy-hour reward for an order (requires permission)' })
-  @ApiBody({ schema: objectSchema({ sh_running: { type: 'string', example: 'SO00123', description: 'Required; not empty' } }) })
+  @ApiOperation({
+    summary:
+      'Check and adjust happy-hour reward for an order (requires permission)',
+  })
+  @ApiBody({
+    schema: objectSchema({
+      sh_running: {
+        type: 'string',
+        example: 'SO00123',
+        description: 'Required; not empty',
+      },
+    }),
+  })
   @ApiResponse({ status: 201, description: 'Happy-hour reward adjusted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
@@ -6011,8 +7192,14 @@ export class AppController {
 
   @ApiTags('Hotdeal & Flash Sale')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get hotdeal detail by product code for current member' })
-  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiOperation({
+    summary: 'Get hotdeal detail by product code for current member',
+  })
+  @ApiParam({
+    name: 'pro_code',
+    description: 'Product code',
+    example: 'P00123',
+  })
   @ApiResponse({ status: 200, description: 'Hotdeal detail' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -6027,14 +7214,28 @@ export class AppController {
 
   @ApiTags('Hotdeal & Flash Sale')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Add hotdeal freebie products to cart for current member' })
+  @ApiOperation({
+    summary: 'Add hotdeal freebie products to cart for current member',
+  })
   @ApiBody({
     schema: objectSchema({
       freebies: arraySchema({
-        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
-        unit: { type: 'string', example: 'กล่อง', description: 'Required; not empty' },
+        pro_code: {
+          type: 'string',
+          example: 'P00123',
+          description: 'Required; not empty',
+        },
+        unit: {
+          type: 'string',
+          example: 'กล่อง',
+          description: 'Required; not empty',
+        },
         amount: { type: 'number', example: 1, description: 'Required' },
-        pro_code1: { type: 'string', example: 'P00100', description: 'Required; not empty; the qualifying product code' },
+        pro_code1: {
+          type: 'string',
+          example: 'P00100',
+          description: 'Required; not empty; the qualifying product code',
+        },
       }),
     }),
   })
@@ -6068,7 +7269,11 @@ export class AppController {
 
   @ApiTags('Products')
   @ApiOperation({ summary: 'Get product image by product code' })
-  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiParam({
+    name: 'pro_code',
+    description: 'Product code',
+    example: 'P00123',
+  })
   @ApiResponse({ status: 200, description: 'Product image data' })
   @ApiResponse({ status: 404, description: 'Product not found' })
   @Get('/ecom/get-product-image/:pro_code')
@@ -6100,7 +7305,9 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Manually trigger the company-day promotion cart re-check' })
+  @ApiOperation({
+    summary: 'Manually trigger the company-day promotion cart re-check',
+  })
   @ApiResponse({ status: 200, description: 'Check triggered' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -6111,7 +7318,9 @@ export class AppController {
 
   @ApiTags('Products')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Autocomplete product search against the external product source' })
+  @ApiOperation({
+    summary: 'Autocomplete product search against the external product source',
+  })
   @ApiQuery({ name: 'search', description: 'Search keyword', example: 'แชมพู' })
   @ApiResponse({ status: 200, description: 'List of matching products' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -6130,7 +7339,9 @@ export class AppController {
 
   @ApiTags('Products')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Search Lotus gift card products (requires permission)' })
+  @ApiOperation({
+    summary: 'Search Lotus gift card products (requires permission)',
+  })
   @ApiResponse({ status: 200, description: 'List of Lotus card products' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
@@ -6147,8 +7358,15 @@ export class AppController {
 
   @ApiTags('Products')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Search products by name for admin (requires permission)' })
-  @ApiQuery({ name: 'keyword', required: false, type: String, example: 'แชมพู' })
+  @ApiOperation({
+    summary: 'Search products by name for admin (requires permission)',
+  })
+  @ApiQuery({
+    name: 'keyword',
+    required: false,
+    type: String,
+    example: 'แชมพู',
+  })
   @ApiResponse({ status: 200, description: 'List of matching products' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden' })

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -22,6 +22,15 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { Response } from 'express';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import axios from 'axios';
 import { AppService } from './app.service';
 import { AuthService, SigninResponse } from './auth/auth.service';
@@ -156,11 +165,19 @@ export class AppController {
     private readonly companyDayAnalyticService: CompanyDayAnalyticService,
   ) {}
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Send order data to old system' })
+  @ApiParam({ name: 'soh_running', description: 'Order running number' })
+  @ApiResponse({ status: 200, description: 'Data sent to old system' })
   @Get('/ecom/get-data/:soh_running')
   async apiForOldSystem(@Param('soh_running') soh_running: string) {
     return this.shoppingOrderService.sendDataToOldSystem(soh_running);
   }
 
+  @ApiTags('Banner & Contract Log')
+  @ApiOperation({ summary: 'Get banner image URLs by location' })
+  @ApiQuery({ name: 'location', required: false, description: 'Banner placement location' })
+  @ApiResponse({ status: 200, description: 'Banner image URLs' })
   @Get('/ecom/image-banner')
   async getImageUrl(
     @Query('location')
@@ -169,12 +186,25 @@ export class AppController {
     return this.bannerService.GetImageUrl(location);
   }
 
+  @ApiTags('Banner & Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a banner by id' })
+  @ApiParam({ name: 'id', description: 'Banner id' })
+  @ApiResponse({ status: 200, description: 'Banner deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/banner/:id')
   async deleteBanner(@Param('id') id: string) {
     return this.bannerService.deleteBannerById(Number(id));
   }
 
+  @ApiTags('Banner & Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a banner by id' })
+  @ApiParam({ name: 'id', description: 'Banner id' })
+  @ApiBody({ type: BannerEntity })
+  @ApiResponse({ status: 200, description: 'Banner updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Patch('/ecom/banner/:id')
   async updateBanner(
@@ -184,18 +214,48 @@ export class AppController {
     return this.bannerService.updateBanner(Number(id), data);
   }
 
+  @ApiTags('User & Employee Management')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get user data by member code' })
+  @ApiParam({ name: 'mem_code', description: 'Member code' })
+  @ApiResponse({ status: 200, description: 'User data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/user-data/:mem_code')
   async getUserData(@Param('mem_code') mem_code: string) {
     return this.authService.fetchUserData(mem_code);
   }
 
+  @ApiTags('User & Employee Management')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update user data' })
+  @ApiBody({ type: UserEntity })
+  @ApiResponse({ status: 201, description: 'User data updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/user-data/update')
   async updateUserData(@Body() data: UserEntity) {
     return this.authService.updateUserData(data);
   }
 
+  @ApiTags('Banner & Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload banner image with metadata' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary' },
+        date_start: { type: 'string', format: 'date-time' },
+        date_end: { type: 'string', format: 'date-time' },
+        banner_name: { type: 'string' },
+        banner_location: { type: 'string' },
+        link_url: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Banner uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/upload-file')
   @UseInterceptors(FileInterceptor('file'))
@@ -232,6 +292,23 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Banner & Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create banner from image URL' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        img_url: { type: 'string' },
+        banner_name: { type: 'string' },
+        banner_location: { type: 'string' },
+        date_start: { type: 'string', format: 'date-time' },
+        date_end: { type: 'string', format: 'date-time' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Banner created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/banner/from-url')
   async createBannerFromUrl(
@@ -253,6 +330,22 @@ export class AppController {
     return { success: true, data: banner };
   }
 
+  @ApiTags('User & Employee Management')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload user profile image' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary' },
+        mem_code: { type: 'string' },
+        type: { type: 'string' },
+        old_url: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'User image uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/user/upload-file')
   @UseInterceptors(FileInterceptor('file'))
@@ -268,23 +361,57 @@ export class AppController {
     );
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get a feature flag status' })
+  @ApiParam({ name: 'flag', description: 'Feature flag name' })
+  @ApiResponse({ status: 200, description: 'Feature flag status' })
   @Get('/ecom/feature-flag/:flag')
   async checkFlag(@Param('flag') flag: string) {
     return this.featureFlagsService.getFlag(flag);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all feature flags' })
+  @ApiResponse({ status: 200, description: 'All feature flags' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/feature-flags')
   async getAllFlags() {
     return this.featureFlagsService.getAllFlags();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a feature flag status' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { flag: { type: 'string' }, status: { type: 'boolean' } },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Feature flag updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/feature-flag/update-flag')
   async updateFlag(@Body() data: { flag: string; status: boolean }) {
     return this.featureFlagsService.updateFlag(data);
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload product PO data' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { pro_code: { type: 'string' }, month: { type: 'number' } },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'PO uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/products/insert-po')
   async uploadPO(
@@ -299,6 +426,23 @@ export class AppController {
     }
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload products for flash sale' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          productCode: { type: 'string' },
+          quantity: { type: 'number' },
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Flash sale products uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/products/upload-product-flashsale')
   async uploadProductFlashSale(
@@ -313,6 +457,20 @@ export class AppController {
     }
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload product L16-only status' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        data: { type: 'array', items: { type: 'object' } },
+        filename: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product L16 status uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/admin/product-l16/upload')
   async uploadProductL16Only(
@@ -331,6 +489,11 @@ export class AppController {
     }
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Export product L16 status' })
+  @ApiResponse({ status: 200, description: 'Product L16 status export' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/product-l16/export')
   async exportProductL16Status(@Req() req: Request & { user: JwtPayload }) {
@@ -342,6 +505,11 @@ export class AppController {
     }
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List flash sale product codes' })
+  @ApiResponse({ status: 200, description: 'Flash sale product codes' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/products/flashsale-procode')
   async listProcodeFlashSale(@Req() req: Request & { user: JwtPayload }) {
@@ -353,6 +521,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get favorite product list' })
+  @ApiParam({ name: 'mem_code', description: 'Member code' })
+  @ApiQuery({ name: 'sort_by', required: false, description: 'Sort order' })
+  @ApiResponse({ status: 200, description: 'Favorite list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/favorite/:mem_code')
   async getListFavorite(
@@ -367,6 +542,20 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get flash sale product list' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number' },
+        mem_code: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Flash sale list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/flashsale/get-list')
   async getDataFlashSale(
@@ -391,12 +580,41 @@ export class AppController {
     return func;
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add product to favorites' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        mem_code: { type: 'string' },
+        pro_code: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Added to favorites' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/favorite/add')
   async addToFavorite(@Body() data: { mem_code: string; pro_code: string }) {
     return await this.favoriteService.addToFavorite(data);
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a favorite product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        fav_id: { type: 'number' },
+        mem_code: { type: 'string' },
+        sort_by: { type: 'number' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Favorite deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/favorite/delete')
   async deleteFavorite(
@@ -410,6 +628,18 @@ export class AppController {
     });
   }
 
+  @ApiTags('Auth & Session')
+  @ApiOperation({ summary: 'User login' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        username: { type: 'string' },
+        password: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Login successful' })
   @Post('/ecom/login')
   async signin(
     @Body() data: { username: string; password: string },
@@ -422,6 +652,24 @@ export class AppController {
     });
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search products via Elasticsearch' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        keyword: { type: 'string' },
+        offset: { type: 'number' },
+        mem_code: { type: 'string' },
+        sort_by: { type: 'number' },
+        limit: { type: 'number' },
+        creditor_codes: { type: 'array', items: { type: 'string' } },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Search results' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/search-products')
   async searchProducts(
@@ -451,6 +699,24 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search products by category' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        keyword: { type: 'string' },
+        offset: { type: 'number' },
+        category: { type: 'number' },
+        mem_code: { type: 'string' },
+        sort_by: { type: 'number' },
+        limit: { type: 'number' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Category search results' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/category-products')
   async searchCategoryProducts(
@@ -473,6 +739,20 @@ export class AppController {
     });
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get recommended products for user' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        keyword: { type: 'string' },
+        pro_code: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Recommended products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-for-u')
   async productForYou(
@@ -487,6 +767,26 @@ export class AppController {
     });
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Submit a shopping order' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        emp_code: { type: 'string' },
+        mem_code: { type: 'string' },
+        total_price: { type: 'number' },
+        listFree: { type: 'array', items: { type: 'object' }, nullable: true },
+        priceOption: { type: 'string' },
+        paymentOptions: { type: 'string' },
+        shippingOptions: { type: 'string' },
+        addressed: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Order submitted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/submit-order')
   async submitOrder(
@@ -531,12 +831,32 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get cart item count' })
+  @ApiParam({ name: 'mem_code', description: 'Member code' })
+  @ApiResponse({ status: 200, description: 'Cart item count' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/cart/count/:mem_code')
   async CountCart(@Param('mem_code') mem_code: string) {
     return await this.shoppingCartService.getCartItemCount(mem_code);
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get product detail' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        pro_code: { type: 'string' },
+        mem_code: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-detail')
   async GetProductDetail(
@@ -557,6 +877,12 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Product Search')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List point-redeemable products' })
+  @ApiParam({ name: 'sortBy', description: 'Sort order' })
+  @ApiResponse({ status: 200, description: 'Product coin list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-coin/:sortBy')
   async productCoin(
@@ -592,6 +918,26 @@ export class AppController {
   //   }
   // }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add product to cart' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        mem_code: { type: 'string' },
+        pro_code: { type: 'string' },
+        pro_unit: { type: 'string' },
+        amount: { type: 'number' },
+        flashsale_end: { type: 'string' },
+        cartVersion: { type: 'string' },
+        clientVersion: { type: 'string' },
+        company_day_source: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product added to cart' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-add-cart')
   async addProductCart(
@@ -646,6 +992,22 @@ export class AppController {
     };
   }
 
+  @ApiTags('Tracking & Analytics')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Track company day promotion view' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        promo_id: { type: 'number' },
+        promo_name: { type: 'string' },
+        tier: { type: 'string' },
+        source: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'View tracked' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/company-day/view')
   trackCompanyDayView(
@@ -663,6 +1025,21 @@ export class AppController {
     return { success: true };
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check/uncheck all cart items' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        mem_code: { type: 'string' },
+        type: { type: 'string' },
+        clientVersion: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Cart items updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-check-all-cart')
   async checkProductCartAll(
@@ -695,6 +1072,21 @@ export class AppController {
     };
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete product from cart' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        mem_code: { type: 'string' },
+        pro_code: { type: 'string' },
+        clientVersion: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product removed from cart' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-delete-cart')
   async deleteProductCart(
@@ -726,6 +1118,22 @@ export class AppController {
     };
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check/uncheck a single cart item' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        mem_code: { type: 'string' },
+        pro_code: { type: 'string' },
+        type: { type: 'string' },
+        clientVersion: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Cart item updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-check-cart')
   async checkProductCart(
@@ -761,6 +1169,12 @@ export class AppController {
     };
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get cart snapshot with summary' })
+  @ApiParam({ name: 'mem_code', description: 'Member code' })
+  @ApiResponse({ status: 200, description: 'Cart snapshot' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-cart/:mem_code')
   async getProductCart(@Req() req: Request & { user: JwtPayload }) {
@@ -788,6 +1202,12 @@ export class AppController {
     };
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Soft delete a cart item' })
+  @ApiParam({ name: 'pro_code', description: 'Product code' })
+  @ApiResponse({ status: 200, description: 'Cart item soft deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/delete-cart-item/:pro_code')
   async softDeleteCartItem(
@@ -800,12 +1220,24 @@ export class AppController {
     );
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get a single product for cart' })
+  @ApiParam({ name: 'pro_code', description: 'Product code' })
+  @ApiResponse({ status: 200, description: 'Product detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-cart/get-one/:pro_code')
   async getProductCartOne(@Param('pro_code') pro_code: string) {
     return this.productsService.getProductOne(pro_code);
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get last 6 orders by member' })
+  @ApiParam({ name: 'memCode', description: 'Member code' })
+  @ApiResponse({ status: 200, description: 'Last 6 orders' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/last6/:memCode')
   async getLast6Orders(
@@ -822,6 +1254,12 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all orders by member' })
+  @ApiParam({ name: 'memCode', description: 'Member code' })
+  @ApiResponse({ status: 200, description: 'All member orders' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/all-order-member/:memCode')
   async AllOrderByMember(
@@ -839,6 +1277,12 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Cart & Checkout')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get a single order by running number' })
+  @ApiParam({ name: 'soh_runing', description: 'Order running number' })
+  @ApiResponse({ status: 200, description: 'Order detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/some-order/:soh_runing')
   async SomeOrderByMember(
@@ -854,6 +1298,24 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a promotion with poster' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary' },
+        promo_name: { type: 'string' },
+        creditor_code: { type: 'string' },
+        start_date: { type: 'string', format: 'date-time' },
+        end_date: { type: 'string', format: 'date-time' },
+        status: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Promotion created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/add')
   @UseInterceptors(FileInterceptor('file'))
@@ -876,6 +1338,20 @@ export class AppController {
     });
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update promotion poster image' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary' },
+        promo_id: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Poster updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/update-poster')
   @UseInterceptors(FileInterceptor('file'))
@@ -889,18 +1365,48 @@ export class AppController {
     });
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all promotions' })
+  @ApiResponse({ status: 200, description: 'Promotion list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/list')
   async getPromotions() {
     return this.promotionService.getAllPromotions();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get promotion detail by id' })
+  @ApiParam({ name: 'promo_id', description: 'Promotion id' })
+  @ApiResponse({ status: 200, description: 'Promotion detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/detail/:promo_id')
   async getPromotion(@Param('promo_id') promo_id: string) {
     return this.promotionService.getPromotionById(Number(promo_id));
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a tier to a promotion' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary' },
+        promo_id: { type: 'number' },
+        tier_name: { type: 'string' },
+        min_amount: { type: 'number' },
+        description: { type: 'string' },
+        detail: { type: 'string' },
+        is_unit_based: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Tier added' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/add-tier')
   @UseInterceptors(FileInterceptor('file'))
@@ -927,6 +1433,17 @@ export class AppController {
     });
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update promotion status' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { promo_id: { type: 'number' }, status: { type: 'boolean' } },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Status updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/update-status')
   async updatePromotionStatus(
@@ -935,24 +1452,60 @@ export class AppController {
     return this.promotionService.updateStatus(data.promo_id, data.status);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a tier' })
+  @ApiBody({
+    schema: { type: 'object', properties: { tier_id: { type: 'number' } } },
+  })
+  @ApiResponse({ status: 201, description: 'Tier deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/delete-tier')
   async deleteTier(@Body() data: { tier_id: number }) {
     return this.promotionService.deleteTier(data.tier_id);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a promotion' })
+  @ApiBody({
+    schema: { type: 'object', properties: { promo_id: { type: 'number' } } },
+  })
+  @ApiResponse({ status: 201, description: 'Promotion deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/delete')
   async deletePromotion(@Body() data: { promo_id: number }) {
     return this.promotionService.deletePromotion(data.promo_id);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List promotions available for duplicate' })
+  @ApiResponse({ status: 200, description: 'Promotions for duplicate' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/list-for-duplicate')
   async getPromotionsForDuplicate() {
     return this.promotionService.getPromotionsForDuplicate();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Duplicate a promotion' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        promo_id: { type: 'number' },
+        start_date: { type: 'string', format: 'date-time' },
+        end_date: { type: 'string', format: 'date-time' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Promotion duplicated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/duplicate')
   async duplicatePromotion(
@@ -961,6 +1514,20 @@ export class AppController {
     return this.promotionService.duplicatePromotion(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a promotion condition' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        tier_id: { type: 'number' },
+        product_gcode: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Condition created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/condition/add')
   async addPromotionCondition(
@@ -973,18 +1540,48 @@ export class AppController {
     return this.promotionService.createCondition(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a promotion condition' })
+  @ApiBody({
+    schema: { type: 'object', properties: { cond_id: { type: 'number' } } },
+  })
+  @ApiResponse({ status: 201, description: 'Condition deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/condition/delete')
   async deletePromotionCondition(@Body() data: { cond_id: number }) {
     return this.promotionService.deleteCondition(data.cond_id);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List conditions by tier' })
+  @ApiParam({ name: 'tier_id', description: 'Tier id' })
+  @ApiResponse({ status: 200, description: 'Conditions list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/condition/list/:tier_id')
   async listPromotionConditions(@Param('tier_id') tier_id: string) {
     return this.promotionService.getConditionsByTier(Number(tier_id));
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a promotion reward' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        tier_id: { type: 'number' },
+        product_gcode: { type: 'string' },
+        qty: { type: 'number' },
+        unit: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Reward created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/reward/add')
   async addPromotionReward(
@@ -999,6 +1596,12 @@ export class AppController {
     return this.promotionService.createReward(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List rewards by tier' })
+  @ApiParam({ name: 'tier_id', description: 'Tier id' })
+  @ApiResponse({ status: 200, description: 'Rewards list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/reward/list/:tier_id')
   async listPromotionRewards(
@@ -1012,48 +1615,108 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get products by creditor' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { creditor_code: { type: 'string' } },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Products by creditor' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/product/creditor')
   async getProductByCreditor(@Body() data: { creditor_code: string }) {
     return this.productsService.getProductByCreditor(data.creditor_code);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get products for promotion key search' })
+  @ApiResponse({ status: 200, description: 'Key search products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/product/keysearch')
   async getProductForKeySearch() {
     return this.productsService.getProductForKeySearch();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get flash sale products for key search' })
+  @ApiResponse({ status: 200, description: 'Flash sale key search products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/product/keysearch-flashsale')
   async getProductForKeySearchForFlashSale() {
     return this.productsService.getProductForKeySearchForFlashSale();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get recommend products for key search' })
+  @ApiResponse({ status: 200, description: 'Recommend key search products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/product/keysearch-recommend')
   async getProductForKeySearchForRecommend() {
     return this.productsService.getProductForKeySearchForRecommend();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiOperation({ summary: 'Get replace products for key search' })
+  @ApiResponse({ status: 200, description: 'Replace key search products' })
   // @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/product/keysearch-replace')
   async getProductForKeySearchForReplace() {
     return this.productsService.getProductForKeySearchForReplace();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get a tier by id' })
+  @ApiParam({ name: 'tier_id', description: 'Tier id' })
+  @ApiResponse({ status: 200, description: 'Tier detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/tiers/:tier_id')
   async getTierByID(@Param('tier_id') tier_id: number) {
     return this.promotionService.getTierOneById(tier_id);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a promotion reward' })
+  @ApiBody({
+    schema: { type: 'object', properties: { reward_id: { type: 'number' } } },
+  })
+  @ApiResponse({ status: 201, description: 'Reward deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/reward/delete')
   async deletePromotionReward(@Body() data: { reward_id: number }) {
     return this.promotionService.deleteReward(data.reward_id);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a promotion' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        promo_id: { type: 'number' },
+        promo_name: { type: 'string' },
+        start_date: { type: 'string', format: 'date-time' },
+        end_date: { type: 'string', format: 'date-time' },
+        status: { type: 'boolean' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Promotion updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/update/promotion')
   async updatePromotion(
@@ -1069,6 +1732,21 @@ export class AppController {
     return this.promotionService.updatePromotion(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Edit a promotion reward' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        reward_id: { type: 'number' },
+        qty: { type: 'number' },
+        unit: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Reward edited' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/update/edit-reward')
   async editReward(
@@ -1082,6 +1760,11 @@ export class AppController {
     return this.promotionService.editReward(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all tiers for customer' })
+  @ApiResponse({ status: 200, description: 'Tiers for customer' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/get-tier-for-customer')
   async getTierAll(@Req() req: Request & { user: JwtPayload }) {
@@ -1091,12 +1774,32 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all tier products' })
+  @ApiResponse({ status: 200, description: 'All tier products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/get-tier-products-all')
   async getTierProducts() {
     return this.promotionService.getAllTiersProduct();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get tier products for customer' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        tier_id: { type: 'number' },
+        mem_code: { type: 'string' },
+        sort_by: { type: 'number' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Tier products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/get-tier-product-for-customer')
   async getProductTier(
@@ -1105,6 +1808,18 @@ export class AppController {
     return this.promotionService.tierProducts(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiOperation({ summary: 'Add a creditor' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        creditor_code: { type: 'string' },
+        creditor_name: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Creditor added' })
   @Post('/ecom/promotion/creditor/add-creditor')
   async addCreditor(
     @Body() data: { creditor_code: string; creditor_name: string },
@@ -1112,6 +1827,21 @@ export class AppController {
     return this.productsService.addCreditor(data);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiOperation({ summary: 'Edit a tier' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        tier_id: { type: 'number' },
+        tier_name: { type: 'string' },
+        min_amount: { type: 'number' },
+        description: { type: 'string' },
+        detail: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Tier edited' })
   @Post('/ecom/promotion/edit-tier')
   async editTier(
     @Body()
@@ -1125,6 +1855,22 @@ export class AppController {
   ) {
     return await this.promotionService.updateTier(data);
   }
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Import wangday data from Excel' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        data: { type: 'array', items: { type: 'object' } },
+        isLastChunk: { type: 'boolean' },
+        isFirstChunk: { type: 'boolean' },
+        fileName: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Wangday data imported' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/wangday/import')
   async importWangday(
@@ -1184,16 +1930,28 @@ export class AppController {
     }
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get monthly wangday sum by code' })
+  @ApiParam({ name: 'wang_code', description: 'Wang code' })
+  @ApiResponse({ status: 200, description: 'Monthly wangday sum' })
   @Get('/ecom/wangday/monthly/:wang_code')
   async getWangdayMonthly(@Param('wang_code') wang_code: string) {
     const result = await this.wangdayService.getMonthlySumByWangCode(wang_code);
     return result;
   }
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get all wangday sum price by code' })
+  @ApiParam({ name: 'wang_code', description: 'Wang code' })
+  @ApiResponse({ status: 200, description: 'Wangday sum price' })
   @Get('/ecom/wangsumprice/:wang_code')
   async getWangSumPrice(@Param('wang_code') wang_code: string) {
     return this.wangdayService.getAllWangSumPrice(wang_code);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiOperation({ summary: 'Search main products for hotdeal' })
+  @ApiParam({ name: 'keyword', description: 'Search keyword' })
+  @ApiResponse({ status: 201, description: 'Matched products' })
   @Post('/ecom/admin/hotdeal/search-product-main/:keyword')
   async searchProductMain(@Param('keyword') keyword: string) {
     const result = await this.hotdealService.searchProduct(keyword);

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -30,6 +30,7 @@ import {
   ApiQuery,
   ApiBody,
   ApiResponse,
+  ApiConsumes,
 } from '@nestjs/swagger';
 import axios from 'axios';
 import { AppService } from './app.service';
@@ -331,6 +332,7 @@ export class AppController {
   @ApiTags('Banner & Contract Log')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Upload banner image with metadata' })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({ type: UploadBannerDto })
   @ApiResponse({ status: 201, description: 'Banner uploaded' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -369,6 +371,7 @@ export class AppController {
   @ApiTags('User & Employee Management')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Upload user profile image' })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({ type: UploadImageUserDto })
   @ApiResponse({ status: 201, description: 'User image uploaded' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -1116,6 +1119,7 @@ export class AppController {
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Add a promotion with poster' })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({ type: AddPromotionDto })
   @ApiResponse({ status: 201, description: 'Promotion created' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -1137,6 +1141,7 @@ export class AppController {
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update promotion poster image' })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({ type: UpdatePromoPosterDto })
   @ApiResponse({ status: 201, description: 'Poster updated' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -1179,6 +1184,7 @@ export class AppController {
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Add a tier to a promotion' })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({ type: AddTierDto })
   @ApiResponse({ status: 201, description: 'Tier added' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -3385,6 +3391,7 @@ export class AppController {
   @ApiTags('Contract Log')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Upload a banner/contract-log image' })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: objectSchema({
       file: {
@@ -3643,6 +3650,7 @@ export class AppController {
   @ApiOperation({
     summary: 'Update a contract-log creditor/banner image and info',
   })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: objectSchema({
       contractId: { type: 'number', example: 1, description: 'Required' },
@@ -3703,6 +3711,7 @@ export class AppController {
   @ApiTags('Contract Log')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Upload a signed contract file' })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: objectSchema({
       contractId: { type: 'number', example: 1, description: 'Required' },
@@ -4042,6 +4051,7 @@ export class AppController {
   @ApiOperation({
     summary: 'Update a contract-log company-day record (creditor image)',
   })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: objectSchema({
       contractId: { type: 'number', example: 1, description: 'Required' },
@@ -4097,6 +4107,7 @@ export class AppController {
   @ApiTags('Contract Log')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Upload a signed company-day contract file' })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: objectSchema({
       contractId: { type: 'number', example: 1, description: 'Required' },
@@ -4979,6 +4990,7 @@ export class AppController {
   @ApiTags('Campaigns')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Upload an image for a campaign reward' })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: objectSchema({
       file: {
@@ -5019,6 +5031,7 @@ export class AppController {
   @ApiTags('Campaigns')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Upload a generic campaign image' })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: objectSchema({
       file: {
@@ -5186,6 +5199,7 @@ export class AppController {
     description: 'Purchase product id',
     example: '1',
   })
+  @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: objectSchema({
       file: {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -167,7 +167,7 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiOperation({ summary: 'Send order data to old system' })
-  @ApiParam({ name: 'soh_running', description: 'Order running number' })
+  @ApiParam({ name: 'soh_running', description: 'Order running number', example: 'SO-67010001' })
   @ApiResponse({ status: 200, description: 'Data sent to old system' })
   @Get('/ecom/get-data/:soh_running')
   async apiForOldSystem(@Param('soh_running') soh_running: string) {
@@ -176,7 +176,13 @@ export class AppController {
 
   @ApiTags('Banner & Contract Log')
   @ApiOperation({ summary: 'Get banner image URLs by location' })
-  @ApiQuery({ name: 'location', required: false, description: 'Banner placement location' })
+  @ApiQuery({
+    name: 'location',
+    required: false,
+    description: 'Banner placement location. Omit to get banners for all locations.',
+    enum: ['store_carousel', 'landing_hero', 'popup', 'sidebar'],
+    example: 'landing_hero',
+  })
   @ApiResponse({ status: 200, description: 'Banner image URLs' })
   @Get('/ecom/image-banner')
   async getImageUrl(
@@ -189,7 +195,7 @@ export class AppController {
   @ApiTags('Banner & Contract Log')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete a banner by id' })
-  @ApiParam({ name: 'id', description: 'Banner id' })
+  @ApiParam({ name: 'id', description: 'Banner id', example: '12' })
   @ApiResponse({ status: 200, description: 'Banner deleted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -201,8 +207,11 @@ export class AppController {
   @ApiTags('Banner & Contract Log')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update a banner by id' })
-  @ApiParam({ name: 'id', description: 'Banner id' })
-  @ApiBody({ type: BannerEntity })
+  @ApiParam({ name: 'id', description: 'Banner id', example: '12' })
+  @ApiBody({
+    description: 'Partial banner fields to update — any subset of BannerEntity columns; omitted fields are left unchanged.',
+    type: BannerEntity,
+  })
   @ApiResponse({ status: 200, description: 'Banner updated' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -217,7 +226,7 @@ export class AppController {
   @ApiTags('User & Employee Management')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get user data by member code' })
-  @ApiParam({ name: 'mem_code', description: 'Member code' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
   @ApiResponse({ status: 200, description: 'User data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -229,7 +238,7 @@ export class AppController {
   @ApiTags('User & Employee Management')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update user data' })
-  @ApiBody({ type: UserEntity })
+  @ApiBody({ description: 'Full UserEntity payload (must include mem_code to identify the user)', type: UserEntity })
   @ApiResponse({ status: 201, description: 'User data updated' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -245,13 +254,39 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        file: { type: 'string', format: 'binary' },
-        date_start: { type: 'string', format: 'date-time' },
-        date_end: { type: 'string', format: 'date-time' },
-        banner_name: { type: 'string' },
-        banner_location: { type: 'string' },
-        link_url: { type: 'string' },
+        file: { type: 'string', format: 'binary', description: 'Banner image file (required)' },
+        date_start: { type: 'string', format: 'date-time', example: '2026-07-01T00:00:00Z', description: 'Required' },
+        date_end: { type: 'string', format: 'date-time', example: '2026-07-31T23:59:59Z', description: 'Required' },
+        banner_name: { type: 'string', example: 'Summer Sale', description: 'Optional; empty string allowed' },
+        banner_location: {
+          type: 'string',
+          enum: ['store_carousel', 'landing_hero', 'popup', 'sidebar'],
+          example: 'landing_hero',
+          description: 'Optional',
+        },
+        link_url: { type: 'string', example: 'https://wangpharma.com/promo', description: 'Optional; empty string allowed' },
+        display_type: {
+          type: 'string',
+          enum: ['image_only', 'text_only', 'image_with_text'],
+          example: 'image_with_text',
+          description: 'Optional',
+        },
+        title: { type: 'string', example: 'ลดราคาช่วงซัมเมอร์', description: 'Optional; empty string allowed' },
+        subtitle: { type: 'string', example: 'สูงสุด 50%', description: 'Optional; empty string allowed' },
+        description: { type: 'string', example: 'โปรโมชั่นพิเศษเฉพาะเดือนนี้', description: 'Optional; empty string allowed' },
+        cta_text: { type: 'string', example: 'ดูเพิ่มเติม', description: 'Optional; empty string allowed' },
+        cta_url: { type: 'string', example: 'https://wangpharma.com/promo', description: 'Optional; empty string allowed' },
+        cta_secondary_text: { type: 'string', example: 'ปิด', description: 'Optional; empty string allowed' },
+        cta_secondary_url: { type: 'string', example: '', description: 'Optional; empty string allowed' },
+        text_color: { type: 'string', enum: ['light', 'dark'], example: 'light', description: 'Optional' },
+        text_position: { type: 'string', enum: ['left', 'center', 'right'], example: 'center', description: 'Optional' },
+        bg_gradient: { type: 'string', example: 'linear-gradient(90deg,#000,#fff)', description: 'Optional; empty string allowed' },
+        is_drug: { type: 'boolean', example: false, description: 'Optional' },
+        advertise_code: { type: 'string', example: 'ADV001', description: 'Optional; empty string allowed' },
+        creditor: { type: 'string', example: 'C001', description: 'Optional; empty string allowed' },
+        product_list: { type: 'string', example: 'P00123,P00124', description: 'Optional comma-separated product codes; empty string allowed' },
       },
+      required: ['file', 'date_start', 'date_end'],
     },
   })
   @ApiResponse({ status: 201, description: 'Banner uploaded' })
@@ -299,12 +334,18 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        img_url: { type: 'string' },
-        banner_name: { type: 'string' },
-        banner_location: { type: 'string' },
-        date_start: { type: 'string', format: 'date-time' },
-        date_end: { type: 'string', format: 'date-time' },
+        img_url: { type: 'string', example: 'https://cdn.wangpharma.com/banners/abc.jpg', description: 'Required' },
+        banner_name: { type: 'string', example: 'Summer Sale', description: 'Optional; empty string allowed' },
+        banner_location: {
+          type: 'string',
+          enum: ['store_carousel', 'landing_hero', 'popup', 'sidebar'],
+          example: 'landing_hero',
+          description: 'Optional',
+        },
+        date_start: { type: 'string', format: 'date-time', example: '2026-07-01T00:00:00Z', description: 'Required' },
+        date_end: { type: 'string', format: 'date-time', example: '2026-07-31T23:59:59Z', description: 'Required' },
       },
+      required: ['img_url', 'date_start', 'date_end'],
     },
   })
   @ApiResponse({ status: 201, description: 'Banner created' })
@@ -337,11 +378,12 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        file: { type: 'string', format: 'binary' },
-        mem_code: { type: 'string' },
-        type: { type: 'string' },
-        old_url: { type: 'string' },
+        file: { type: 'string', format: 'binary', description: 'Required' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required' },
+        type: { type: 'string', example: 'profile', description: 'Required; image category/usage tag' },
+        old_url: { type: 'string', example: 'https://cdn.wangpharma.com/users/old.jpg', description: 'Required; pass empty string if there is no previous image to remove' },
       },
+      required: ['file', 'mem_code', 'type', 'old_url'],
     },
   })
   @ApiResponse({ status: 201, description: 'User image uploaded' })
@@ -363,7 +405,7 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiOperation({ summary: 'Get a feature flag status' })
-  @ApiParam({ name: 'flag', description: 'Feature flag name' })
+  @ApiParam({ name: 'flag', description: 'Feature flag name', example: 'new_checkout' })
   @ApiResponse({ status: 200, description: 'Feature flag status' })
   @Get('/ecom/feature-flag/:flag')
   async checkFlag(@Param('flag') flag: string) {
@@ -387,7 +429,11 @@ export class AppController {
   @ApiBody({
     schema: {
       type: 'object',
-      properties: { flag: { type: 'string' }, status: { type: 'boolean' } },
+      properties: {
+        flag: { type: 'string', example: 'new_checkout', description: 'Required' },
+        status: { type: 'boolean', example: true, description: 'Required' },
+      },
+      required: ['flag', 'status'],
     },
   })
   @ApiResponse({ status: 201, description: 'Feature flag updated' })
@@ -406,7 +452,11 @@ export class AppController {
       type: 'array',
       items: {
         type: 'object',
-        properties: { pro_code: { type: 'string' }, month: { type: 'number' } },
+        properties: {
+          pro_code: { type: 'string', example: 'P00123', description: 'Required; product code, not empty' },
+          month: { type: 'number', example: 6, description: 'Required; month number 1-12' },
+        },
+        required: ['pro_code', 'month'],
       },
     },
   })
@@ -435,9 +485,10 @@ export class AppController {
       items: {
         type: 'object',
         properties: {
-          productCode: { type: 'string' },
-          quantity: { type: 'number' },
+          productCode: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+          quantity: { type: 'number', example: 50, description: 'Required' },
         },
+        required: ['productCode', 'quantity'],
       },
     },
   })
@@ -464,9 +515,25 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        data: { type: 'array', items: { type: 'object' } },
-        filename: { type: 'string' },
+        data: {
+          type: 'array',
+          description: 'Required',
+          items: {
+            type: 'object',
+            properties: {
+              pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+              status: {
+                oneOf: [{ type: 'number' }, { type: 'string' }],
+                example: 1,
+                description: 'Required; 1 = L16-only, 0 = normal',
+              },
+            },
+            required: ['pro_code', 'status'],
+          },
+        },
+        filename: { type: 'string', example: 'l16-upload-2026-06.xlsx', description: 'Required; not empty' },
       },
+      required: ['data', 'filename'],
     },
   })
   @ApiResponse({ status: 201, description: 'Product L16 status uploaded' })
@@ -524,8 +591,8 @@ export class AppController {
   @ApiTags('Product Search')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get favorite product list' })
-  @ApiParam({ name: 'mem_code', description: 'Member code' })
-  @ApiQuery({ name: 'sort_by', required: false, description: 'Sort order' })
+  @ApiParam({ name: 'mem_code', description: 'Member code (unused, taken from JWT)', example: 'M00123' })
+  @ApiQuery({ name: 'sort_by', required: false, description: 'Optional sort order key; omit for default order', example: 'name' })
   @ApiResponse({ status: 200, description: 'Favorite list' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -549,9 +616,10 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        limit: { type: 'number' },
-        mem_code: { type: 'string' },
+        limit: { type: 'number', example: 20, description: 'Required' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Optional; overridden by JWT member code if present' },
       },
+      required: ['limit'],
     },
   })
   @ApiResponse({ status: 201, description: 'Flash sale list' })
@@ -587,9 +655,10 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        mem_code: { type: 'string' },
-        pro_code: { type: 'string' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
       },
+      required: ['mem_code', 'pro_code'],
     },
   })
   @ApiResponse({ status: 201, description: 'Added to favorites' })
@@ -607,10 +676,11 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        fav_id: { type: 'number' },
-        mem_code: { type: 'string' },
-        sort_by: { type: 'number' },
+        fav_id: { type: 'number', example: 101, description: 'Required' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required, but overridden by JWT member code' },
+        sort_by: { type: 'number', example: 1, description: 'Optional' },
       },
+      required: ['fav_id', 'mem_code'],
     },
   })
   @ApiResponse({ status: 201, description: 'Favorite deleted' })
@@ -634,9 +704,10 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        username: { type: 'string' },
-        password: { type: 'string' },
+        username: { type: 'string', example: 'pharmacy01', description: 'Required; not empty' },
+        password: { type: 'string', example: 'P@ssw0rd123', description: 'Required; not empty' },
       },
+      required: ['username', 'password'],
     },
   })
   @ApiResponse({ status: 201, description: 'Login successful' })
@@ -659,13 +730,19 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        keyword: { type: 'string' },
-        offset: { type: 'number' },
-        mem_code: { type: 'string' },
-        sort_by: { type: 'number' },
-        limit: { type: 'number' },
-        creditor_codes: { type: 'array', items: { type: 'string' } },
+        keyword: { type: 'string', example: 'paracetamol', description: 'Required; empty string returns unfiltered results' },
+        offset: { type: 'number', example: 0, description: 'Required' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required, but overridden by JWT member code' },
+        sort_by: { type: 'number', example: 1, description: 'Optional' },
+        limit: { type: 'number', example: 20, description: 'Required' },
+        creditor_codes: {
+          type: 'array',
+          items: { type: 'string' },
+          example: ['C001', 'C002'],
+          description: 'Optional filter by creditor codes',
+        },
       },
+      required: ['keyword', 'offset', 'mem_code', 'limit'],
     },
   })
   @ApiResponse({ status: 201, description: 'Search results' })
@@ -706,13 +783,14 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        keyword: { type: 'string' },
-        offset: { type: 'number' },
-        category: { type: 'number' },
-        mem_code: { type: 'string' },
-        sort_by: { type: 'number' },
-        limit: { type: 'number' },
+        keyword: { type: 'string', example: '', description: 'Required field; empty string allowed (returns whole category)' },
+        offset: { type: 'number', example: 0, description: 'Required' },
+        category: { type: 'number', example: 5, description: 'Required' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required, but overridden by JWT member code' },
+        sort_by: { type: 'number', example: 1, description: 'Optional' },
+        limit: { type: 'number', example: 20, description: 'Required' },
       },
+      required: ['keyword', 'offset', 'category', 'mem_code', 'limit'],
     },
   })
   @ApiResponse({ status: 201, description: 'Category search results' })
@@ -746,9 +824,10 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        keyword: { type: 'string' },
-        pro_code: { type: 'string' },
+        keyword: { type: 'string', example: '', description: 'Required; empty string allowed' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
       },
+      required: ['keyword', 'pro_code'],
     },
   })
   @ApiResponse({ status: 201, description: 'Recommended products' })
@@ -774,15 +853,38 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        emp_code: { type: 'string' },
-        mem_code: { type: 'string' },
-        total_price: { type: 'number' },
-        listFree: { type: 'array', items: { type: 'object' }, nullable: true },
-        priceOption: { type: 'string' },
-        paymentOptions: { type: 'string' },
-        shippingOptions: { type: 'string' },
-        addressed: { type: 'string' },
+        emp_code: { type: 'string', example: 'E001', description: 'Optional; empty string allowed' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required, but overridden by JWT member code' },
+        total_price: { type: 'number', example: 1500.5, description: 'Required' },
+        listFree: {
+          type: 'array',
+          nullable: true,
+          description: 'Required; pass null if no point-redeemed free items',
+          items: {
+            type: 'object',
+            properties: {
+              pro_code: { type: 'string', example: 'P00123' },
+              amount: { type: 'number', example: 1 },
+              pro_unit1: { type: 'string', example: 'กล่อง' },
+              pro_point: { type: 'number', example: 10 },
+              unit_enum: { type: 'string', enum: ['1', '2', '3'], example: '1' },
+            },
+          },
+        },
+        priceOption: { type: 'string', example: 'A', description: 'Required; not empty' },
+        paymentOptions: { type: 'string', example: 'cash', description: 'Required; not empty' },
+        shippingOptions: { type: 'string', example: 'standard', description: 'Required; not empty' },
+        addressed: { type: 'string', example: '123 ถ.สุขุมวิท กรุงเทพฯ', description: 'Required; not empty' },
       },
+      required: [
+        'mem_code',
+        'total_price',
+        'listFree',
+        'priceOption',
+        'paymentOptions',
+        'shippingOptions',
+        'addressed',
+      ],
     },
   })
   @ApiResponse({ status: 201, description: 'Order submitted' })
@@ -834,7 +936,7 @@ export class AppController {
   @ApiTags('Cart & Checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get cart item count' })
-  @ApiParam({ name: 'mem_code', description: 'Member code' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
   @ApiResponse({ status: 200, description: 'Cart item count' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -850,9 +952,10 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        pro_code: { type: 'string' },
-        mem_code: { type: 'string' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required, but overridden by JWT member code' },
       },
+      required: ['pro_code', 'mem_code'],
     },
   })
   @ApiResponse({ status: 201, description: 'Product detail' })
@@ -880,7 +983,7 @@ export class AppController {
   @ApiTags('Product Search')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'List point-redeemable products' })
-  @ApiParam({ name: 'sortBy', description: 'Sort order' })
+  @ApiParam({ name: 'sortBy', description: 'Sort order key, e.g. "name" or "point"', example: 'name' })
   @ApiResponse({ status: 200, description: 'Product coin list' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -925,15 +1028,16 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        mem_code: { type: 'string' },
-        pro_code: { type: 'string' },
-        pro_unit: { type: 'string' },
-        amount: { type: 'number' },
-        flashsale_end: { type: 'string' },
-        cartVersion: { type: 'string' },
-        clientVersion: { type: 'string' },
-        company_day_source: { type: 'string' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required, but overridden by JWT member code' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        pro_unit: { type: 'string', example: 'กล่อง', description: 'Required; not empty' },
+        amount: { type: 'number', example: 2, description: 'Required' },
+        flashsale_end: { type: 'string', example: '', description: 'Required; pass empty string if not a flash-sale item' },
+        cartVersion: { type: 'string', example: '1', description: 'Optional' },
+        clientVersion: { type: 'string', example: '1.0.0', description: 'Optional' },
+        company_day_source: { type: 'string', example: '', description: 'Optional; empty string allowed' },
       },
+      required: ['mem_code', 'pro_code', 'pro_unit', 'amount', 'flashsale_end'],
     },
   })
   @ApiResponse({ status: 201, description: 'Product added to cart' })
@@ -999,11 +1103,12 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        promo_id: { type: 'number' },
-        promo_name: { type: 'string' },
-        tier: { type: 'string' },
-        source: { type: 'string' },
+        promo_id: { type: 'number', example: 5, description: 'Required' },
+        promo_name: { type: 'string', example: 'Company Day มิถุนายน', description: 'Required; not empty' },
+        tier: { type: 'string', example: 'Gold', description: 'Required; not empty' },
+        source: { type: 'string', example: 'banner', description: 'Required; not empty' },
       },
+      required: ['promo_id', 'promo_name', 'tier', 'source'],
     },
   })
   @ApiResponse({ status: 201, description: 'View tracked' })
@@ -1032,10 +1137,11 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        mem_code: { type: 'string' },
-        type: { type: 'string' },
-        clientVersion: { type: 'string' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+        type: { type: 'string', enum: ['check', 'uncheck'], example: 'check', description: 'Required; not empty' },
+        clientVersion: { type: 'string', example: '1.0.0', description: 'Optional' },
       },
+      required: ['mem_code', 'type'],
     },
   })
   @ApiResponse({ status: 201, description: 'Cart items updated' })
@@ -1079,10 +1185,11 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        mem_code: { type: 'string' },
-        pro_code: { type: 'string' },
-        clientVersion: { type: 'string' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        clientVersion: { type: 'string', example: '1.0.0', description: 'Optional' },
       },
+      required: ['mem_code', 'pro_code'],
     },
   })
   @ApiResponse({ status: 201, description: 'Product removed from cart' })
@@ -1125,11 +1232,12 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        mem_code: { type: 'string' },
-        pro_code: { type: 'string' },
-        type: { type: 'string' },
-        clientVersion: { type: 'string' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        type: { type: 'string', enum: ['check', 'uncheck'], example: 'check', description: 'Required; not empty' },
+        clientVersion: { type: 'string', example: '1.0.0', description: 'Optional' },
       },
+      required: ['mem_code', 'pro_code', 'type'],
     },
   })
   @ApiResponse({ status: 201, description: 'Cart item updated' })
@@ -1172,7 +1280,7 @@ export class AppController {
   @ApiTags('Cart & Checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get cart snapshot with summary' })
-  @ApiParam({ name: 'mem_code', description: 'Member code' })
+  @ApiParam({ name: 'mem_code', description: 'Member code (unused, taken from JWT)', example: 'M00123' })
   @ApiResponse({ status: 200, description: 'Cart snapshot' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1205,7 +1313,7 @@ export class AppController {
   @ApiTags('Cart & Checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Soft delete a cart item' })
-  @ApiParam({ name: 'pro_code', description: 'Product code' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
   @ApiResponse({ status: 200, description: 'Cart item soft deleted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1223,7 +1331,7 @@ export class AppController {
   @ApiTags('Cart & Checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get a single product for cart' })
-  @ApiParam({ name: 'pro_code', description: 'Product code' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
   @ApiResponse({ status: 200, description: 'Product detail' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1235,7 +1343,7 @@ export class AppController {
   @ApiTags('Cart & Checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get last 6 orders by member' })
-  @ApiParam({ name: 'memCode', description: 'Member code' })
+  @ApiParam({ name: 'memCode', description: 'Member code', example: 'M00123' })
   @ApiResponse({ status: 200, description: 'Last 6 orders' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1257,7 +1365,7 @@ export class AppController {
   @ApiTags('Cart & Checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get all orders by member' })
-  @ApiParam({ name: 'memCode', description: 'Member code' })
+  @ApiParam({ name: 'memCode', description: 'Member code', example: 'M00123' })
   @ApiResponse({ status: 200, description: 'All member orders' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1280,7 +1388,7 @@ export class AppController {
   @ApiTags('Cart & Checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get a single order by running number' })
-  @ApiParam({ name: 'soh_runing', description: 'Order running number' })
+  @ApiParam({ name: 'soh_runing', description: 'Order running number', example: 'SO-67010001' })
   @ApiResponse({ status: 200, description: 'Order detail' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1305,13 +1413,14 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        file: { type: 'string', format: 'binary' },
-        promo_name: { type: 'string' },
-        creditor_code: { type: 'string' },
-        start_date: { type: 'string', format: 'date-time' },
-        end_date: { type: 'string', format: 'date-time' },
-        status: { type: 'string' },
+        file: { type: 'string', format: 'binary', description: 'Required; promotion poster image' },
+        promo_name: { type: 'string', example: 'โปรโมชั่นซัมเมอร์', description: 'Required; not empty' },
+        creditor_code: { type: 'string', example: 'C001', description: 'Optional; empty string treated as no creditor' },
+        start_date: { type: 'string', format: 'date-time', example: '2026-07-01T00:00:00Z', description: 'Required' },
+        end_date: { type: 'string', format: 'date-time', example: '2026-07-31T23:59:59Z', description: 'Required' },
+        status: { type: 'string', enum: ['true', 'false'], example: 'true', description: 'Required; string "true"/"false"' },
       },
+      required: ['file', 'promo_name', 'start_date', 'end_date', 'status'],
     },
   })
   @ApiResponse({ status: 201, description: 'Promotion created' })
@@ -1345,9 +1454,10 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        file: { type: 'string', format: 'binary' },
-        promo_id: { type: 'string' },
+        file: { type: 'string', format: 'binary', description: 'Required' },
+        promo_id: { type: 'string', example: '12', description: 'Required; not empty' },
       },
+      required: ['file', 'promo_id'],
     },
   })
   @ApiResponse({ status: 201, description: 'Poster updated' })
@@ -1379,7 +1489,7 @@ export class AppController {
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get promotion detail by id' })
-  @ApiParam({ name: 'promo_id', description: 'Promotion id' })
+  @ApiParam({ name: 'promo_id', description: 'Promotion id', example: '12' })
   @ApiResponse({ status: 200, description: 'Promotion detail' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1395,14 +1505,15 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        file: { type: 'string', format: 'binary' },
-        promo_id: { type: 'number' },
-        tier_name: { type: 'string' },
-        min_amount: { type: 'number' },
-        description: { type: 'string' },
-        detail: { type: 'string' },
-        is_unit_based: { type: 'string' },
+        file: { type: 'string', format: 'binary', description: 'Optional; tier poster image' },
+        promo_id: { type: 'number', example: 12, description: 'Required' },
+        tier_name: { type: 'string', example: 'Gold', description: 'Required; not empty' },
+        min_amount: { type: 'number', example: 1000, description: 'Required' },
+        description: { type: 'string', example: 'ซื้อครบ 1,000 บาท', description: 'Optional; empty string allowed' },
+        detail: { type: 'string', example: 'รับส่วนลด 10%', description: 'Optional; empty string allowed' },
+        is_unit_based: { type: 'string', enum: ['true', 'false'], example: 'false', description: 'Optional; string "true"/"false"' },
       },
+      required: ['promo_id', 'tier_name', 'min_amount'],
     },
   })
   @ApiResponse({ status: 201, description: 'Tier added' })
@@ -1439,7 +1550,11 @@ export class AppController {
   @ApiBody({
     schema: {
       type: 'object',
-      properties: { promo_id: { type: 'number' }, status: { type: 'boolean' } },
+      properties: {
+        promo_id: { type: 'number', example: 12, description: 'Required' },
+        status: { type: 'boolean', example: true, description: 'Required' },
+      },
+      required: ['promo_id', 'status'],
     },
   })
   @ApiResponse({ status: 201, description: 'Status updated' })
@@ -1456,7 +1571,11 @@ export class AppController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete a tier' })
   @ApiBody({
-    schema: { type: 'object', properties: { tier_id: { type: 'number' } } },
+    schema: {
+      type: 'object',
+      properties: { tier_id: { type: 'number', example: 5, description: 'Required' } },
+      required: ['tier_id'],
+    },
   })
   @ApiResponse({ status: 201, description: 'Tier deleted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -1470,7 +1589,11 @@ export class AppController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete a promotion' })
   @ApiBody({
-    schema: { type: 'object', properties: { promo_id: { type: 'number' } } },
+    schema: {
+      type: 'object',
+      properties: { promo_id: { type: 'number', example: 12, description: 'Required' } },
+      required: ['promo_id'],
+    },
   })
   @ApiResponse({ status: 201, description: 'Promotion deleted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -1498,10 +1621,11 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        promo_id: { type: 'number' },
-        start_date: { type: 'string', format: 'date-time' },
-        end_date: { type: 'string', format: 'date-time' },
+        promo_id: { type: 'number', example: 12, description: 'Required' },
+        start_date: { type: 'string', format: 'date-time', example: '2026-08-01T00:00:00Z', description: 'Required' },
+        end_date: { type: 'string', format: 'date-time', example: '2026-08-31T23:59:59Z', description: 'Required' },
       },
+      required: ['promo_id', 'start_date', 'end_date'],
     },
   })
   @ApiResponse({ status: 201, description: 'Promotion duplicated' })
@@ -1521,9 +1645,10 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        tier_id: { type: 'number' },
-        product_gcode: { type: 'string' },
+        tier_id: { type: 'number', example: 5, description: 'Required' },
+        product_gcode: { type: 'string', example: 'G001', description: 'Required; not empty' },
       },
+      required: ['tier_id', 'product_gcode'],
     },
   })
   @ApiResponse({ status: 201, description: 'Condition created' })
@@ -1544,7 +1669,11 @@ export class AppController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete a promotion condition' })
   @ApiBody({
-    schema: { type: 'object', properties: { cond_id: { type: 'number' } } },
+    schema: {
+      type: 'object',
+      properties: { cond_id: { type: 'number', example: 7, description: 'Required' } },
+      required: ['cond_id'],
+    },
   })
   @ApiResponse({ status: 201, description: 'Condition deleted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -1557,7 +1686,7 @@ export class AppController {
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'List conditions by tier' })
-  @ApiParam({ name: 'tier_id', description: 'Tier id' })
+  @ApiParam({ name: 'tier_id', description: 'Tier id', example: '5' })
   @ApiResponse({ status: 200, description: 'Conditions list' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1573,11 +1702,12 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        tier_id: { type: 'number' },
-        product_gcode: { type: 'string' },
-        qty: { type: 'number' },
-        unit: { type: 'string' },
+        tier_id: { type: 'number', example: 5, description: 'Required' },
+        product_gcode: { type: 'string', example: 'G001', description: 'Required; not empty' },
+        qty: { type: 'number', example: 1, description: 'Required' },
+        unit: { type: 'string', example: 'กล่อง', description: 'Required; not empty' },
       },
+      required: ['tier_id', 'product_gcode', 'qty', 'unit'],
     },
   })
   @ApiResponse({ status: 201, description: 'Reward created' })
@@ -1599,7 +1729,7 @@ export class AppController {
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'List rewards by tier' })
-  @ApiParam({ name: 'tier_id', description: 'Tier id' })
+  @ApiParam({ name: 'tier_id', description: 'Tier id', example: '5' })
   @ApiResponse({ status: 200, description: 'Rewards list' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1621,7 +1751,8 @@ export class AppController {
   @ApiBody({
     schema: {
       type: 'object',
-      properties: { creditor_code: { type: 'string' } },
+      properties: { creditor_code: { type: 'string', example: 'C001', description: 'Required; not empty' } },
+      required: ['creditor_code'],
     },
   })
   @ApiResponse({ status: 201, description: 'Products by creditor' })
@@ -1677,7 +1808,7 @@ export class AppController {
   @ApiTags('Promotion & Tier')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get a tier by id' })
-  @ApiParam({ name: 'tier_id', description: 'Tier id' })
+  @ApiParam({ name: 'tier_id', description: 'Tier id', example: '5' })
   @ApiResponse({ status: 200, description: 'Tier detail' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -1690,7 +1821,11 @@ export class AppController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete a promotion reward' })
   @ApiBody({
-    schema: { type: 'object', properties: { reward_id: { type: 'number' } } },
+    schema: {
+      type: 'object',
+      properties: { reward_id: { type: 'number', example: 9, description: 'Required' } },
+      required: ['reward_id'],
+    },
   })
   @ApiResponse({ status: 201, description: 'Reward deleted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -1707,12 +1842,13 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        promo_id: { type: 'number' },
-        promo_name: { type: 'string' },
-        start_date: { type: 'string', format: 'date-time' },
-        end_date: { type: 'string', format: 'date-time' },
-        status: { type: 'boolean' },
+        promo_id: { type: 'number', example: 12, description: 'Required' },
+        promo_name: { type: 'string', example: 'โปรโมชั่นซัมเมอร์', description: 'Optional; empty string allowed' },
+        start_date: { type: 'string', format: 'date-time', example: '2026-08-01T00:00:00Z', description: 'Optional' },
+        end_date: { type: 'string', format: 'date-time', example: '2026-08-31T23:59:59Z', description: 'Optional' },
+        status: { type: 'boolean', example: true, description: 'Optional' },
       },
+      required: ['promo_id'],
     },
   })
   @ApiResponse({ status: 201, description: 'Promotion updated' })
@@ -1739,10 +1875,11 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        reward_id: { type: 'number' },
-        qty: { type: 'number' },
-        unit: { type: 'string' },
+        reward_id: { type: 'number', example: 9, description: 'Required' },
+        qty: { type: 'number', example: 2, description: 'Required' },
+        unit: { type: 'string', example: 'กล่อง', description: 'Required; not empty' },
       },
+      required: ['reward_id', 'qty', 'unit'],
     },
   })
   @ApiResponse({ status: 201, description: 'Reward edited' })
@@ -1792,10 +1929,11 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        tier_id: { type: 'number' },
-        mem_code: { type: 'string' },
-        sort_by: { type: 'number' },
+        tier_id: { type: 'number', example: 5, description: 'Required' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+        sort_by: { type: 'number', example: 1, description: 'Optional' },
       },
+      required: ['tier_id', 'mem_code'],
     },
   })
   @ApiResponse({ status: 201, description: 'Tier products' })
@@ -1814,9 +1952,10 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        creditor_code: { type: 'string' },
-        creditor_name: { type: 'string' },
+        creditor_code: { type: 'string', example: 'C001', description: 'Required; not empty' },
+        creditor_name: { type: 'string', example: 'บริษัท ตัวอย่าง จำกัด', description: 'Required; not empty' },
       },
+      required: ['creditor_code', 'creditor_name'],
     },
   })
   @ApiResponse({ status: 201, description: 'Creditor added' })
@@ -1833,12 +1972,13 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        tier_id: { type: 'number' },
-        tier_name: { type: 'string' },
-        min_amount: { type: 'number' },
-        description: { type: 'string' },
-        detail: { type: 'string' },
+        tier_id: { type: 'number', example: 5, description: 'Required' },
+        tier_name: { type: 'string', example: 'Gold', description: 'Optional; empty string allowed' },
+        min_amount: { type: 'number', example: 1000, description: 'Optional' },
+        description: { type: 'string', example: 'ซื้อครบ 1,000 บาท', description: 'Optional; empty string allowed' },
+        detail: { type: 'string', example: 'รับส่วนลด 10%', description: 'Optional; empty string allowed' },
       },
+      required: ['tier_id'],
     },
   })
   @ApiResponse({ status: 201, description: 'Tier edited' })
@@ -1862,11 +2002,16 @@ export class AppController {
     schema: {
       type: 'object',
       properties: {
-        data: { type: 'array', items: { type: 'object' } },
-        isLastChunk: { type: 'boolean' },
-        isFirstChunk: { type: 'boolean' },
-        fileName: { type: 'string' },
+        data: {
+          type: 'array',
+          description: 'Required; rows from Excel with Thai column keys (วันที่, เลขที่ใบกำกับ, รหัสลูกค้า, ยอดเงินสุทธิ)',
+          items: { type: 'object' },
+        },
+        isLastChunk: { type: 'boolean', example: true, description: 'Required' },
+        isFirstChunk: { type: 'boolean', example: false, description: 'Required' },
+        fileName: { type: 'string', example: 'wangday-2026-06.xlsx', description: 'Required; not empty' },
       },
+      required: ['data', 'isLastChunk', 'isFirstChunk', 'fileName'],
     },
   })
   @ApiResponse({ status: 201, description: 'Wangday data imported' })
@@ -1932,7 +2077,7 @@ export class AppController {
 
   @ApiTags('Misc / Admin Tools')
   @ApiOperation({ summary: 'Get monthly wangday sum by code' })
-  @ApiParam({ name: 'wang_code', description: 'Wang code' })
+  @ApiParam({ name: 'wang_code', description: 'Wang code', example: 'W001' })
   @ApiResponse({ status: 200, description: 'Monthly wangday sum' })
   @Get('/ecom/wangday/monthly/:wang_code')
   async getWangdayMonthly(@Param('wang_code') wang_code: string) {
@@ -1941,7 +2086,7 @@ export class AppController {
   }
   @ApiTags('Misc / Admin Tools')
   @ApiOperation({ summary: 'Get all wangday sum price by code' })
-  @ApiParam({ name: 'wang_code', description: 'Wang code' })
+  @ApiParam({ name: 'wang_code', description: 'Wang code', example: 'W001' })
   @ApiResponse({ status: 200, description: 'Wangday sum price' })
   @Get('/ecom/wangsumprice/:wang_code')
   async getWangSumPrice(@Param('wang_code') wang_code: string) {
@@ -1950,7 +2095,7 @@ export class AppController {
 
   @ApiTags('Hotdeal & Flash Sale')
   @ApiOperation({ summary: 'Search main products for hotdeal' })
-  @ApiParam({ name: 'keyword', description: 'Search keyword' })
+  @ApiParam({ name: 'keyword', description: 'Search keyword', example: 'paracetamol' })
   @ApiResponse({ status: 201, description: 'Matched products' })
   @Post('/ecom/admin/hotdeal/search-product-main/:keyword')
   async searchProductMain(@Param('keyword') keyword: string) {
@@ -1964,6 +2109,23 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create or update a hotdeal' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        data: { type: 'object', description: 'Required; hotdeal input payload (pro_code, dates, discount, freebies, etc.)' },
+        id: { type: 'number', example: 5, description: 'Optional; omit to create, provide to update' },
+        order: { type: 'number', example: 1, description: 'Optional' },
+        special_deal: { type: 'boolean', example: false, description: 'Optional' },
+      },
+      required: ['data'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Hotdeal saved' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/admin/hotdeal/save-hotdeal')
   async saveHotdeal(
@@ -1984,17 +2146,43 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiOperation({ summary: 'Get all hotdeals with product names' })
+  @ApiResponse({ status: 200, description: 'List of hotdeals' })
   @Get('/ecom/admin/hotdeal/all-hotdeals')
   async getAllHotdeals() {
     return this.hotdealService.getAllHotdealsWithProductNames();
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a hotdeal' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 5, description: 'Required' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      },
+      required: ['id', 'pro_code'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Hotdeal deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/admin/hotdeal/delete')
   async deleteHotdeal(@Body() data: { id: number; pro_code: string }) {
     return this.hotdealService.deleteHotdeal(data.id, data.pro_code);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get hotdeals (simple list) for current member' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
+  @ApiQuery({ name: 'special_deal', required: false, type: String, description: '"true" or "false"', example: 'false' })
+  @ApiResponse({ status: 200, description: 'List of hotdeals' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/hotdeal/simple-list')
   async getAllHotdealsSimple(
@@ -2016,6 +2204,13 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get product-pro deals (simple list) for current member' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
+  @ApiResponse({ status: 200, description: 'List of product-pro deals' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-pro/simple-list')
   async getProductProSimpleList(
@@ -2031,6 +2226,13 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get "buy more get 1" deals (simple list) for current member' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
+  @ApiResponse({ status: 200, description: 'List of buy-more-get-1 deals' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/buy-more-get-1/simple-list')
   async getBuyMoreGetOneSimpleList(
@@ -2046,6 +2248,38 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiOperation({ summary: 'Check which cart items match active hotdeals' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        hotDeal: {
+          type: 'array',
+          description: 'Required',
+          items: {
+            type: 'object',
+            properties: {
+              pro_code: { type: 'string', example: 'P00123' },
+              shopping_cart: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    pro1_unit: { type: 'string', example: 'กล่อง' },
+                    pro1_amount: { type: 'string', example: '2' },
+                  },
+                },
+              },
+            },
+            required: ['pro_code', 'shopping_cart'],
+          },
+        },
+      },
+      required: ['hotDeal'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Matched hotdeals' })
   @Post('/ecom/hotdeal/check-hotdeal-match')
   async checkHotdealMatch(
     @Body()
@@ -2075,6 +2309,18 @@ export class AppController {
     }
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Apply a promo code and check reward in cart' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { code_text: { type: 'string', example: 'PROMO2026', description: 'Required; not empty' } },
+      required: ['code_text'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Reward checked' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/code/use')
   async useCodeForCheckReward(
@@ -2090,6 +2336,18 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Generate a promo code for a member (requires permission)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' } },
+      required: ['mem_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Promo code generated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/code/generate')
   async generateCodePromotion(
@@ -2103,11 +2361,32 @@ export class AppController {
     return this.promotionService.generateCodePromotion(data.mem_code);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiOperation({ summary: 'Get hotdeal/freebie detail by product code' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Hotdeal detail' })
   @Get('/ecom/hotdeal/get-hotdeal-from-code/:pro_code')
   async getHotdealFromCode(@Param('pro_code') pro_code: string) {
     return await this.hotdealService.getHotdealFromCode(pro_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Bulk update products from back office import file' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        group: {
+          type: 'array',
+          description: 'Required; rows of product fields to update (pro_code, pro_name, prices, ratios, units, supplier, stock fields)',
+          items: { type: 'object' },
+        },
+        filename: { type: 'string', example: 'back-office-2026-06.xlsx', description: 'Required; not empty' },
+      },
+      required: ['group', 'filename'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Products updated' })
   @Post('/ecom/admin/update-product-from-back-office')
   async updateProductFromBackOffice(
     @Body()
@@ -2142,6 +2421,36 @@ export class AppController {
     }
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Bulk upsert customer accounts' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+          mem_nameSite: { type: 'string', example: 'ร้านยาตัวอย่าง', description: 'Required; not empty' },
+          mem_username: { type: 'string', example: 'pharmacy01', description: 'Required; not empty' },
+          mem_password: { type: 'string', example: 'P@ssw0rd123', description: 'Required; not empty' },
+          mem_price: { type: 'string', example: 'A', description: 'Required; not empty' },
+          emp_saleoffice: { type: 'string', example: 'E001', description: 'Required; not empty' },
+          latest_purchase: { type: 'string', example: '2026-06-01', description: 'Required; not empty' },
+          emp_id_ref: { type: 'string', example: 'E001', description: 'Optional; empty string allowed' },
+        },
+        required: [
+          'mem_code',
+          'mem_nameSite',
+          'mem_username',
+          'mem_password',
+          'mem_price',
+          'emp_saleoffice',
+          'latest_purchase',
+        ],
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Customers upserted' })
   @Post('/ecom/update-customer-data')
   async updateCustomerData(
     @Body()
@@ -2159,11 +2468,38 @@ export class AppController {
     return this.authService.upsertUser(data);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get last shopping head running number' })
+  @ApiResponse({ status: 200, description: 'Last sh_running value' })
   @Get('/ecom/last-sh-running')
   async getLastShRunning() {
     return this.shoppingHeadService.getLastSHRunnning();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Bulk update stock from back office import file' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        group: {
+          type: 'array',
+          description: 'Required',
+          items: {
+            type: 'object',
+            properties: {
+              pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+              stock: { type: 'number', example: 100, description: 'Required' },
+            },
+            required: ['pro_code', 'stock'],
+          },
+        },
+        filename: { type: 'string', example: 'stock-2026-06.xlsx', description: 'Required; not empty' },
+      },
+      required: ['group', 'filename'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Stock updated' })
   @Post('/ecom/admin/update-stock-from-back-office')
   async updateStockFromBackOffice(
     @Body()
@@ -2179,12 +2515,21 @@ export class AppController {
       throw new Error('Error updating stock from back office');
     }
   }
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Reindex all products to Elasticsearch' })
+  @ApiResponse({ status: 201, description: 'Sync started/completed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/admin/sync-products-elastic')
   async syncProductsToElastic() {
     return this.productsService.syncAllProductsToElastic();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get file log entries by feature' })
+  @ApiParam({ name: 'feature', description: 'Feature name', example: 'wangday-import' })
+  @ApiResponse({ status: 200, description: 'File log entries' })
   @Get('/ecom/fileLog/:feature')
   async getFileLog(@Param('feature') feature: string) {
     const fileLogs = await this.backendService.getFeatured({
@@ -2193,18 +2538,35 @@ export class AppController {
     return fileLogs;
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all debtor records for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of debtor records' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/debtor/:mem_code')
   async getDebtor(@Param('mem_code') mem_code: string) {
     return await this.debtorService.getAllDebtors(mem_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get favorite product count for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'Favorite count' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/favorite/count/:mem_code')
   async getCountFavorite(@Param('mem_code') mem_code: string) {
     return await this.favoriteService.getCountFavorite(mem_code);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all searchable product keywords for current member' })
+  @ApiResponse({ status: 200, description: 'List of product keywords' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product/keysearch-all')
   async getKeySearch(@Req() req: Request & { user: JwtPayload }) {
@@ -2215,6 +2577,26 @@ export class AppController {
     );
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add product lot/expiry records' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          lot: { type: 'string', example: 'LOT2026A', description: 'Required; not empty' },
+          mfg: { type: 'string', example: '2026-01-01', description: 'Required; not empty' },
+          exp: { type: 'string', example: '2028-01-01', description: 'Required; not empty' },
+          pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        },
+        required: ['lot', 'mfg', 'exp', 'pro_code'],
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Lots added' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/lot/add-lots')
   async addLots(
@@ -2229,6 +2611,24 @@ export class AppController {
     return this.lotService.addLots(data);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a daily flash sale promotion' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        promotion_name: { type: 'string', example: 'Flash Sale วันศุกร์', description: 'Required; not empty' },
+        date: { type: 'string', example: '2026-07-03', description: 'Required; not empty' },
+        time_start: { type: 'string', example: '10:00', description: 'Required; not empty' },
+        time_end: { type: 'string', example: '14:00', description: 'Required; not empty' },
+        is_active: { type: 'boolean', example: true, description: 'Required' },
+      },
+      required: ['promotion_name', 'date', 'time_start', 'time_end', 'is_active'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Flash sale created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/add-flashsale')
   async addDailyFlashsale(
@@ -2244,6 +2644,22 @@ export class AppController {
     return await this.flashsaleService.addFlashSale(data);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a product to a daily flash sale' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        promotion_id: { type: 'number', example: 3, description: 'Required' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        limit: { type: 'number', example: 50, description: 'Required' },
+      },
+      required: ['promotion_id', 'pro_code', 'limit'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product added to flash sale' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/add-product')
   async addProductToDailyFlashsale(
@@ -2257,12 +2673,23 @@ export class AppController {
     return await this.flashsaleService.addProductToFlashSale(data);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all daily flash sale promotions' })
+  @ApiResponse({ status: 200, description: 'List of flash sales' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/daily-flashsale/list')
   async getAllDailyFlashsales() {
     return await this.flashsaleService.getAllFlashSales();
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get products in a daily flash sale' })
+  @ApiParam({ name: 'promotion_id', description: 'Flash sale promotion id', example: '3' })
+  @ApiResponse({ status: 200, description: 'List of products in flash sale' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/daily-flashsale/products/:promotion_id')
   async getProductsInDailyFlashsale(
@@ -2271,12 +2698,39 @@ export class AppController {
     return await this.flashsaleService.getProductsInFlashSale(promotion_id);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a product from a daily flash sale' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { id: { type: 'number', example: 10, description: 'Required' } },
+      required: ['id'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Product removed from flash sale' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/daily-flashsale/delete-product')
   async deleteProductDailyFlashsale(@Body('id') id: number) {
     return await this.flashsaleService.deleteProduct(id);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Edit a product in a daily flash sale' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 10, description: 'Required' },
+        limit: { type: 'number', example: 50, description: 'Required' },
+      },
+      required: ['id', 'limit'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product updated in flash sale' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/edit-product')
   async editProductInDailyFlashSale(
@@ -2285,6 +2739,20 @@ export class AppController {
     return await this.flashsaleService.editProductInFlashSale(data);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get active flash sale for current member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', example: 20, description: 'Optional; max items to return' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Optional; overridden by JWT mem_code if present' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Flash sale data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/get-flashsale')
   async getFlashsaleByDate(
@@ -2299,6 +2767,21 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Change active status of a daily flash sale' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 10, description: 'Required' },
+        is_active: { type: 'boolean', example: true, description: 'Required' },
+      },
+      required: ['id', 'is_active'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Status changed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/change-status')
   async changeStatusDailyFlashsale(
@@ -2310,12 +2793,39 @@ export class AppController {
     });
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a daily flash sale' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { id: { type: 'number', example: 3, description: 'Required' } },
+      required: ['id'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Flash sale deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/daily-flashsale/delete-flashsale')
   async deleteDailyFlashsale(@Body('id') id: number) {
     return await this.flashsaleService.deleteFlashSale(id);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upsert a file log entry' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        feature: { type: 'string', example: 'wangday-import', description: 'Required; not empty' },
+        filename: { type: 'string', example: 'import-2026-06-23.csv', description: 'Required; not empty' },
+      },
+      required: ['feature', 'filename'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'File log upserted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/upload-log-file')
   async uploadLogFile(@Body() data: { feature: string; filename: string }) {
@@ -2325,11 +2835,34 @@ export class AppController {
     });
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get the log file for a feature' })
+  @ApiParam({ name: 'feature', description: 'Feature name', example: 'wangday-import' })
+  @ApiResponse({ status: 200, description: 'Log file content' })
   @Get('/ecom/get-upload-log-file/:feature')
   async getUploadLogFile(@Param('feature') feature: string) {
     return await this.backendService.getLogfile(feature);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Edit a daily flash sale promotion' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        promotion_id: { type: 'number', example: 3, description: 'Required' },
+        promotion_name: { type: 'string', example: 'Flash Sale วันหยุด', description: 'Required; not empty' },
+        date: { type: 'string', example: '2026-06-23', description: 'Required; format YYYY-MM-DD' },
+        time_start: { type: 'string', example: '09:00', description: 'Required; format HH:mm' },
+        time_end: { type: 'string', example: '21:00', description: 'Required; format HH:mm' },
+        is_active: { type: 'boolean', example: true, description: 'Required' },
+      },
+      required: ['promotion_id', 'promotion_name', 'date', 'time_start', 'time_end', 'is_active'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Flash sale updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/daily-flashsale/edit-flashsale')
   async editDailyFlashsale(
@@ -2346,6 +2879,22 @@ export class AppController {
     return await this.flashsaleService.EditFlashSale(data);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add an invisible-product topic for a creditor' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        invisible_name: { type: 'string', example: 'ซ่อนสินค้าโปรโมชั่น', description: 'Required; not empty' },
+        date_end: { type: 'string', example: '2026-12-31', description: 'Required; format YYYY-MM-DD' },
+        creditor_code: { type: 'string', example: 'C00123', description: 'Required; not empty' },
+      },
+      required: ['invisible_name', 'date_end', 'creditor_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Topic added' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/invisible-product/add-invisible-topic')
   async addInvisibleTopic(
@@ -2359,12 +2908,21 @@ export class AppController {
     return await this.invisibleService.addInvisibleTopic(data);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all invisible-product topics' })
+  @ApiResponse({ status: 200, description: 'List of invisible-product topics' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/invisible-product/get-invisible-topic-all')
   async getInvisibleTopic() {
     return await this.invisibleService.handleGetInvisibleTopics();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get invisible products by creditor code' })
+  @ApiParam({ name: 'creditor_code', description: 'Creditor code', example: 'C00123' })
+  @ApiResponse({ status: 200, description: 'List of products' })
   @Get('/ecom/invisible/product/creditor/:creditor_code')
   async getInvisibleProductByCreditor(
     @Param('creditor_code') creditor_code: string,
@@ -2372,6 +2930,10 @@ export class AppController {
     return this.productsService.getProductByCreditor(creditor_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get invisible products by invisible topic id' })
+  @ApiParam({ name: 'invisible_id', description: 'Invisible topic id', example: 1 })
+  @ApiResponse({ status: 200, description: 'List of products' })
   @Get('/ecom/invisible/product/creditor/list/:invisible_id')
   async getInvisibleProductByInvisibleID(
     @Param('invisible_id') invisible_id: number,
@@ -2379,6 +2941,21 @@ export class AppController {
     return this.invisibleService.handleGetInvisibleProducts(invisible_id);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a product to an invisible-product topic' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        invisible_id: { type: 'number', example: 1, description: 'Required' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      },
+      required: ['invisible_id', 'pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product added to topic' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/invisible-product/add-product')
   async addInvisibleProduct(
@@ -2391,12 +2968,36 @@ export class AppController {
     return await this.invisibleService.updateProductInvisible(data);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a product from invisible-product topics' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } },
+      required: ['pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/invisible-product/delete-product')
   async deleteInvisibleProduct(@Body('pro_code') pro_code: string) {
     return await this.invisibleService.removeProductInvisible(pro_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete an invisible-product topic' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { invisible_id: { type: 'string', example: '1', description: 'Required; not empty' } },
+      required: ['invisible_id'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Topic deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/invisible-product/delete-topic')
   async deleteInvisibleTopic(@Body('invisible_id') invisible_id: string) {
@@ -2405,12 +3006,51 @@ export class AppController {
     );
   }
 
+  @ApiTags('Address')
+  @ApiOperation({ summary: 'Get an address by id' })
+  @ApiParam({ name: 'addressId', description: 'Address id', example: 5 })
+  @ApiResponse({ status: 201, description: 'Address detail' })
   // @UseGuards(JwtAuthGuard)
   @Post('/ecom/address/edit-address/:addressId')
   async editAddress(@Param('addressId') addressId: number) {
     return this.editAddressService.getAddressById(addressId);
   }
 
+  @ApiTags('Address')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new address for a member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', example: 'บ้าน', description: 'Optional; empty string allowed' },
+        fullName: { type: 'string', example: 'สมชาย ใจดี', description: 'Required; not empty' },
+        mem_address: { type: 'string', example: '99/1', description: 'Optional; empty string allowed' },
+        mem_village: { type: 'string', example: 'หมู่ 5', description: 'Optional; empty string allowed' },
+        mem_alley: { type: 'string', example: 'ซอย 1', description: 'Optional; empty string allowed' },
+        mem_road: { type: 'string', example: 'ถนนสุขุมวิท', description: 'Optional; empty string allowed' },
+        mem_province: { type: 'string', example: 'กรุงเทพมหานคร', description: 'Required; not empty' },
+        mem_amphur: { type: 'string', example: 'บางนา', description: 'Required; not empty' },
+        mem_tumbon: { type: 'string', example: 'บางนา', description: 'Required; not empty' },
+        mem_post: { type: 'string', example: '10260', description: 'Required; not empty' },
+        phoneNumber: { type: 'string', example: '0812345678', description: 'Required; not empty' },
+        Note: { type: 'string', example: 'ฝากไว้กับยาม', description: 'Optional; empty string allowed' },
+        defaults: { type: 'boolean', example: false, description: 'Optional; defaults to false' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+      },
+      required: [
+        'fullName',
+        'mem_province',
+        'mem_amphur',
+        'mem_tumbon',
+        'mem_post',
+        'phoneNumber',
+        'mem_code',
+      ],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Address created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/address/create-address')
   async createAddress(
@@ -2435,17 +3075,41 @@ export class AppController {
     return this.editAddressService.createAddress(addressData);
   }
 
+  @ApiTags('Address')
+  @ApiOperation({ summary: 'Update an existing address' })
+  @ApiParam({ name: 'id', description: 'Address id', example: 5 })
+  @ApiBody({ type: EditAddress })
+  @ApiResponse({ status: 200, description: 'Address updated' })
   // @UseGuards(JwtAuthGuard)
   @Put('/ecom/address/update-address/:id')
   async updateAddress(@Param('id') id: number, @Body() address: EditAddress) {
     return this.editAddressService.updateAddress(id, address);
   }
 
+  @ApiTags('Address')
+  @ApiOperation({ summary: 'Get all addresses for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of addresses' })
   @Get('/ecom/address/:mem_code')
   async getAddressByUser(@Param('mem_code') mem_code: string) {
     return await this.editAddressService.getAddressesByUser(mem_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Save modal/popup content' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 1, description: 'Required' },
+        title: { type: 'string', example: 'ประกาศปิดระบบ', description: 'Required; not empty' },
+        content: { type: 'string', example: '<p>เนื้อหา</p>', description: 'Optional; empty string allowed' },
+        show: { type: 'boolean', example: true, description: 'Required' },
+      },
+      required: ['id', 'title', 'show'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Modal content saved' })
   @Post('/ecom/admin/modal-content/save')
   async saveModalContent(
     @Body()
@@ -2459,11 +3123,19 @@ export class AppController {
     return this.modalContentService.saveModalContent(body);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get modal/popup content' })
+  @ApiResponse({ status: 200, description: 'Modal content' })
   @Get('/ecom/admin/modal-content/get')
   async getModalContent() {
     return this.modalContentService.getModalContent();
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all "fix free" (point-redeemable) products' })
+  @ApiResponse({ status: 200, description: 'List of free products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-free/all')
   async getAllProductFree() {
@@ -2474,18 +3146,60 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a product to the "fix free" point-redeemable list' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        pro_point: { type: 'number', example: 100, description: 'Required' },
+      },
+      required: ['pro_code', 'pro_point'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product added' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-free/add')
   async addProductFree(@Body() data: { pro_code: string; pro_point: number }) {
     return await this.fixFreeService.addProductFree(data);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a product from the "fix free" list' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } },
+      required: ['pro_code'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Product removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/product-free/delete')
   async deleteProductFree(@Body() data: { pro_code: string }) {
     return await this.fixFreeService.removeProductFree(data.pro_code);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Edit the point cost of a "fix free" product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        pro_point: { type: 'number', example: 150, description: 'Required' },
+      },
+      required: ['pro_code', 'pro_point'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product point updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product-free/edit')
   async editProductFree(@Body() data: { pro_code: string; pro_point: number }) {
@@ -2497,6 +3211,16 @@ export class AppController {
   //   return { ip };
   // }
 
+  @ApiTags('Auth')
+  @ApiOperation({ summary: 'Refresh an access token' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { token: { type: 'string', example: 'eyJhbGciOiJIUzI1NiIs...', description: 'Required; not empty; refresh token' } },
+      required: ['token'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'New access token issued' })
   @Post('/ecom/refresh_token')
   async refreshToken(@Body() body: { token: string }, @Req() req: Request) {
     return this.authService.refreshToken(
@@ -2506,6 +3230,23 @@ export class AppController {
   }
 
   // Session Management APIs
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a login session for current member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        session_token: { type: 'string', example: 'a1b2c3d4e5', description: 'Required; not empty' },
+        ip_address: { type: 'string', example: '203.0.113.10', description: 'Optional; empty string allowed' },
+        user_agent: { type: 'string', example: 'Mozilla/5.0', description: 'Optional; empty string allowed' },
+        device_type: { type: 'string', example: 'mobile', description: 'Optional; empty string allowed' },
+      },
+      required: ['session_token'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Session created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/session/create')
   async createSession(
@@ -2528,18 +3269,36 @@ export class AppController {
     );
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get an active session by token' })
+  @ApiParam({ name: 'session_token', description: 'Session token', example: 'a1b2c3d4e5' })
+  @ApiResponse({ status: 200, description: 'Active session' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/session/active/:session_token')
   async getActiveSession(@Param('session_token') session_token: string) {
     return await this.sessionsService.findActiveSession(session_token);
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all active sessions for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of active sessions' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/session/user-sessions/:mem_code')
   async getUserActiveSessions(@Param('mem_code') mem_code: string) {
     return await this.sessionsService.findUserActiveSessions(mem_code);
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update last activity timestamp of a session' })
+  @ApiParam({ name: 'session_token', description: 'Session token', example: 'a1b2c3d4e5' })
+  @ApiResponse({ status: 200, description: 'Session activity updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/session/update-activity/:session_token')
   async updateSessionActivity(@Param('session_token') session_token: string) {
@@ -2547,6 +3306,18 @@ export class AppController {
     return { message: 'Session activity updated successfully' };
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Logout a single session' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { session_token: { type: 'string', example: 'a1b2c3d4e5', description: 'Required; not empty' } },
+      required: ['session_token'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Logout successful' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/session/logout')
   async logoutSession(@Body() data: { session_token: string }) {
@@ -2554,6 +3325,18 @@ export class AppController {
     return { message: 'Logout successful' };
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Logout all sessions of a member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' } },
+      required: ['mem_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'All sessions logged out' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/session/logout-all')
   async logoutAllSessions(@Body() data: { mem_code: string }) {
@@ -2561,6 +3344,18 @@ export class AppController {
     return { message: 'All sessions logged out successfully' };
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Logout recently active sessions of a member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' } },
+      required: ['mem_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Recently active sessions logged out' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/session/logout-recent')
   async logoutRecentSessions(@Body() data: { mem_code: string }) {
@@ -2568,6 +3363,12 @@ export class AppController {
     return { message: 'Recently active sessions logged out successfully' };
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Validate whether a session token is still active' })
+  @ApiParam({ name: 'session_token', description: 'Session token', example: 'a1b2c3d4e5' })
+  @ApiResponse({ status: 200, description: 'Validation result' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/session/validate/:session_token')
   async validateSession(@Param('session_token') session_token: string) {
@@ -2575,6 +3376,12 @@ export class AppController {
     return { is_valid: isValid };
   }
 
+  @ApiTags('Session')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Count active sessions of a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'Active session count' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/session/count/:mem_code')
   async countActiveSessions(@Param('mem_code') mem_code: string) {
@@ -2582,6 +3389,10 @@ export class AppController {
     return { active_sessions_count: count };
   }
 
+  @ApiTags('Password')
+  @ApiOperation({ summary: 'Check whether a member has an email on file for password reset' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'Email check result' })
   @Get('/ecom/password/check-email/:mem_code')
   async checkEmail(@Param('mem_code') mem_code: string): Promise<{
     RefKey?: string;
@@ -2593,6 +3404,16 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Password')
+  @ApiOperation({ summary: 'Request an OTP for password reset' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' } },
+      required: ['mem_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'OTP request result' })
   @Post('/ecom/password/request-otp')
   async requestOtp(@Body('mem_code') mem_code: string): Promise<{
     valid: boolean;
@@ -2603,6 +3424,20 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Password')
+  @ApiOperation({ summary: 'Validate an OTP for password reset' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        mem_username: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+        otp: { type: 'string', example: '123456', description: 'Required; not empty' },
+        timeNow: { type: 'string', example: '2026-06-23T10:00:00.000Z', description: 'Required; ISO datetime' },
+      },
+      required: ['mem_username', 'otp', 'timeNow'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'OTP validation result' })
   @Post('/ecom/password/validate-otp')
   async validateOtp(
     @Body()
@@ -2616,6 +3451,22 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Password')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Change password for current member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        new_password: { type: 'string', example: 'NewP@ssw0rd', description: 'Required; not empty' },
+        old_password: { type: 'string', example: 'OldP@ssw0rd', description: 'Required; not empty' },
+        logout_all_devices: { type: 'boolean', example: false, description: 'Optional; defaults to false' },
+      },
+      required: ['new_password', 'old_password'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Password change result' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/password/change-password')
   async changePassword(
@@ -2647,6 +3498,20 @@ export class AppController {
     }
   }
 
+  @ApiTags('Password')
+  @ApiOperation({ summary: 'Reset password using a validated OTP' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        mem_username: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+        new_password: { type: 'string', example: 'NewP@ssw0rd', description: 'Required; not empty' },
+        otp: { type: 'string', example: '123456', description: 'Required; not empty' },
+      },
+      required: ['mem_username', 'new_password', 'otp'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Password reset result' })
   @Put('/ecom/password/reset-password')
   async resetPassword(
     @Body()
@@ -2659,6 +3524,27 @@ export class AppController {
     return this.changePasswordService.forgotPasswordUpdate(body);
   }
 
+  @ApiTags('Products')
+  @ApiOperation({ summary: 'Bulk add new-arrival product batches' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+          LOT: { type: 'string', example: 'L2026001', description: 'Required; not empty' },
+          MFG: { type: 'string', example: '2026-01-01', description: 'Required; format YYYY-MM-DD' },
+          EXP: { type: 'string', example: '2028-01-01', description: 'Required; format YYYY-MM-DD' },
+          createdAt: { type: 'string', format: 'date-time', example: '2026-06-23T10:00:00.000Z', description: 'Required; ISO datetime' },
+          amount: { type: 'number', example: 100, description: 'Required' },
+          unit: { type: 'string', example: 'กล่อง', description: 'Required; not empty' },
+        },
+        required: ['pro_code', 'LOT', 'MFG', 'EXP', 'createdAt', 'amount', 'unit'],
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'New arrivals added' })
   @Post('/ecom/new-arrivals')
   async NewArrivals(
     @Body()
@@ -2681,6 +3567,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get up to 30 new-arrival products for current member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code (unused, taken from JWT)', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of new-arrival products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/new-arrivals/list/:mem_code')
   async getNewArrivalsLimit30(@Req() req: Request & { user: JwtPayload }) {
@@ -2691,11 +3583,20 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiOperation({ summary: 'Find a hotdeal by product code' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Hotdeal detail' })
   @Get('/ecom/hotdeal/find/:pro_code')
   find(@Param('pro_code') pro_code: string): Promise<any> {
     return this.hotdealService.find(pro_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get wangday data grouped by product (requires permission)' })
+  @ApiResponse({ status: 200, description: 'Wangday data by product' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/wangday')
   async getProductWangday(@Req() req: Request & { user: JwtPayload }): Promise<{
@@ -2712,6 +3613,11 @@ export class AppController {
     return await this.wangdayService.getProductWangday();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all company-day promotions (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of promotions' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/company-days')
   async getCompanyDays(@Req() req: Request & { user: JwtPayload }): Promise<{
@@ -2724,6 +3630,11 @@ export class AppController {
     return await this.promotionService.getPromotions();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all banners (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of banners' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/banner')
   async getBanner(
@@ -2736,6 +3647,11 @@ export class AppController {
     return await this.bannerService.findAllBanners();
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all hotdeals (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of hotdeals' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/hotdeals')
   async getHotdeals(
@@ -2748,6 +3664,11 @@ export class AppController {
     return await this.hotdealService.findAllHotdeals();
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all flash sales (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of flash sales' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/flashsales')
   async getFlashsales(@Req() req: Request & { user: JwtPayload }) {
@@ -2757,6 +3678,11 @@ export class AppController {
     }
     return await this.flashsaleService.findAllFlashSales();
   }
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all "fix free" products (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of free products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/product-free')
   async getProductFree(
@@ -2769,6 +3695,11 @@ export class AppController {
     return await this.productsService.findProductFree();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all promotional products (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of promotional products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/product-promotion')
   async getProductPromotion(@Req() req: Request & { user: JwtPayload }) {
@@ -2779,6 +3710,42 @@ export class AppController {
     return await this.productsService.findProductPromotion();
   }
 
+  @ApiTags('Debtor / Reduction')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Bulk import reduction invoice data' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          date: { type: 'string', example: '2026-06-23', description: 'Required; format YYYY-MM-DD' },
+          invoice: { type: 'string', example: 'INV00123', description: 'Required; not empty' },
+          mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+          date_due: { type: 'string', example: '2026-07-23', description: 'Required; format YYYY-MM-DD' },
+          total: { type: 'string', example: '1000.00', description: 'Required; not empty' },
+          payment: { type: 'string', example: '500.00', description: 'Required; not empty' },
+          balance: { type: 'string', example: '500.00', description: 'Required; not empty' },
+          bill_list: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                date: { type: 'string', example: '2026-06-23', description: 'Required; format YYYY-MM-DD' },
+                invoice: { type: 'string', example: 'INV00123', description: 'Required; not empty' },
+                price: { type: 'string', example: '500.00', description: 'Required; not empty' },
+                comments: { type: 'string', example: '', description: 'Optional; empty string allowed' },
+              },
+              required: ['date', 'invoice', 'price'],
+            },
+          },
+        },
+        required: ['date', 'invoice', 'mem_code', 'date_due', 'total', 'payment', 'balance', 'bill_list'],
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Invoices imported' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/reduct-invoice/add-invoice')
   async importData(
@@ -2796,6 +3763,43 @@ export class AppController {
     }
   }
 
+  @ApiTags('Debtor / Reduction')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Bulk import reduction RT (return) data' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          invoice: { type: 'string', example: 'INV00123', description: 'Required; not empty' },
+          date: { type: 'string', example: '2026-06-23', description: 'Required; format YYYY-MM-DD' },
+          mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+          pro_amount: { type: 'string', example: '10', description: 'Required; not empty' },
+          dis_price: { type: 'string', example: '50.00', description: 'Required; not empty' },
+          comments: { type: 'string', example: '', description: 'Optional; empty string allowed' },
+          pro_list: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+                pro_name: { type: 'string', example: 'ยาพาราเซตามอล', description: 'Required; not empty' },
+                pro_amount: { type: 'string', example: '10', description: 'Required; not empty' },
+                pro_unit: { type: 'string', example: 'กล่อง', description: 'Required; not empty' },
+                pro_price_per_unit: { type: 'string', example: '5.00', description: 'Required; not empty' },
+                pro_discount: { type: 'string', example: '0.00', description: 'Required; not empty' },
+              },
+              required: ['pro_code', 'pro_name', 'pro_amount', 'pro_unit', 'pro_price_per_unit', 'pro_discount'],
+            },
+          },
+        },
+        required: ['invoice', 'date', 'mem_code', 'pro_amount', 'dis_price', 'pro_list'],
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'RT entries imported' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/reduct-invoice/add-rt')
   async importDataRT(
@@ -2813,6 +3817,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Debtor / Reduction')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Find a reduction invoice by invoice id for current member' })
+  @ApiParam({ name: 'invoice', description: 'Invoice number', example: 'INV00123' })
+  @ApiResponse({ status: 200, description: 'Debtor/invoice record' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/reduct-invoice/invoice/id/:invoice')
   async findReductionInvoices(
@@ -2829,6 +3839,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Debtor / Reduction')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Find a reduction RT (return) record by id for current member' })
+  @ApiParam({ name: 'rt', description: 'RT (return) number', example: 'RT00123' })
+  @ApiResponse({ status: 200, description: 'Reduction RT record' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/reduct-invoice/rt/id/:rt')
   async findReductionRTs(
@@ -2845,6 +3861,22 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update search keywords for a product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        keysearch: { type: 'string', example: 'พารา,แก้ปวด', description: 'Optional; empty string allowed' },
+        viewers: { type: 'number', example: 0, description: 'Optional' },
+      },
+      required: ['pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Keyword updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/keysearch/update-product-keysearch')
   async updateKeysearch(
@@ -2853,12 +3885,23 @@ export class AppController {
     await this.productKeySearch.updateKeyword(data);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get keysearch info for one product' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Keysearch info' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/keysearch/get-one/:pro_code')
   async keysearchProductGetOne(@Param('pro_code') pro_code: string) {
     return await this.productKeySearch.getProductOne(pro_code);
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check/refresh latest purchase date for current member' })
+  @ApiResponse({ status: 200, description: 'Check result' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/usercheck_latest_purchase')
   async checkLatestPurchase(@Req() req: Request & { user: JwtPayload }) {
@@ -2870,12 +3913,44 @@ export class AppController {
     return { message: 'Check initiated' };
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all employees' })
+  @ApiResponse({ status: 200, description: 'List of employees' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/user/employee/list')
   async getEmployeeList() {
     return this.employeesService.getAllEmployees();
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create or update an employee record' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        emp_code: { type: 'string', example: 'E00123', description: 'Required; not empty' },
+        data: {
+          type: 'object',
+          properties: {
+            emp_code: { type: 'string', example: 'E00123', description: 'Required; not empty' },
+            emp_nickname: { type: 'string', example: 'นัท', description: 'Optional; empty string allowed' },
+            emp_firstname: { type: 'string', example: 'สมชาย', description: 'Optional; empty string allowed' },
+            emp_lastname: { type: 'string', example: 'ใจดี', description: 'Optional; empty string allowed' },
+            emp_mobile: { type: 'string', example: '0812345678', description: 'Optional; empty string allowed' },
+            emp_email: { type: 'string', example: 'somchai@example.com', description: 'Optional; empty string allowed' },
+            emp_ID_line: { type: 'string', example: 'somchai_line', description: 'Optional; empty string allowed' },
+          },
+          required: ['emp_code'],
+        },
+      },
+      required: ['emp_code', 'data'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Employee upserted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/user/employee/upsert-employee')
   async upsertEmployee(
@@ -2908,6 +3983,24 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Bulk update daily sale amount for products' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+          amount: { type: 'number', example: 25, description: 'Required' },
+        },
+        required: ['pro_code', 'amount'],
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Sale amounts updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/product/pro-sale-amount-update')
   async updateProductProSaleAmount(
@@ -2916,6 +4009,22 @@ export class AppController {
     return await this.productsService.updateSaleDayly(data);
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update or clear VIP tag for a member (requires permission)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+        message: { type: 'string', example: 'อนุมัติ VIP แล้ว', description: 'Required; not empty' },
+        tagVIP: { type: 'string', example: 'VIP', description: 'Optional; empty string/omit clears the tag' },
+      },
+      required: ['mem_code', 'message'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'VIP tag updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/user/employee/user-vip')
   async updateAndDeleteUserVIP(
@@ -2938,6 +4047,11 @@ export class AppController {
     );
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all VIP-tagged members' })
+  @ApiResponse({ status: 200, description: 'List of VIP members' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/user/employee/user-vip-list')
   async getUserVIPList(): Promise<
@@ -2957,6 +4071,11 @@ export class AppController {
     }));
   }
 
+  @ApiTags('Shopping Cart')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get total item count in cart for current member' })
+  @ApiResponse({ status: 200, description: 'Cart item total' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/cart/summary')
   async summaryCart(
@@ -2967,24 +4086,62 @@ export class AppController {
     return data.total;
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all recommend tags' })
+  @ApiResponse({ status: 200, description: 'List of recommend tags' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/recommend/tags')
   async getRecommendTags() {
     return await this.recommendService.getAllTags();
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Insert a recommend tag' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { tag: { type: 'string', example: 'สินค้าขายดี', description: 'Required; not empty' } },
+      required: ['tag'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Tag inserted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/insertTag')
   async insertRecommendTag(@Body() data: { tag: string }) {
     return await this.recommendService.insertTag(data.tag);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get products under a recommend tag' })
+  @ApiParam({ name: 'tag_id', description: 'Recommend tag id', example: 1 })
+  @ApiResponse({ status: 200, description: 'List of products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/recommend/products/:tag_id')
   async getRecommendProductsByTag(@Param('tag_id') tag_id: number) {
     return await this.recommendService.getProductsByTag(tag_id);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Attach a recommend tag to a product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        tag_id: { type: 'number', example: 1, description: 'Required' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      },
+      required: ['tag_id', 'pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Tag attached to product' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/updateTagToProduct')
   async updateTagToProduct(@Body() data: { tag_id: number; pro_code: string }) {
@@ -2994,6 +4151,21 @@ export class AppController {
     );
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update display rank for a recommended product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        rank: { type: 'number', example: 1, description: 'Required' },
+      },
+      required: ['pro_code', 'rank'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Rank updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/updateRank')
   async updateRecommendRank(@Body() data: { pro_code: string; rank: number }) {
@@ -3001,24 +4173,76 @@ export class AppController {
     return await this.recommendService.UpdateRank(data.pro_code, data.rank);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove all recommend tags from a product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } },
+      required: ['pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Tags removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/removeTagFromProduct')
   async removeTagFromProduct(@Body() data: { pro_code: string }) {
     return await this.recommendService.DeleteTagFromProduct(data.pro_code);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete display rank for a recommended product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } },
+      required: ['pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Rank deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/deleteRank')
   async deleteRecommendRank(@Body() data: { pro_code: string }) {
     return await this.recommendService.DeleteRank(data.pro_code);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a recommend tag' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { tag_id: { type: 'number', example: 1, description: 'Required' } },
+      required: ['tag_id'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Tag deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/deleteTag')
   async deleteRecommendTag(@Body() data: { tag_id: number }) {
     return await this.recommendService.deleteTag(data.tag_id);
   }
 
+  @ApiTags('Recommend')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get recommended products by recommend ids for current member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        pro_code: { type: 'array', items: { type: 'string', example: 'P00123' }, description: 'Optional; not used by the implementation' },
+        recommend_id: { type: 'array', items: { type: 'number', example: 1 }, description: 'Required; not empty' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Optional; overridden by JWT mem_code if present' },
+      },
+      required: ['recommend_id'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'List of recommended products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/recommend/recommend-products')
   async getRecommendProducts(
@@ -3038,6 +4262,21 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Set promotion status for all products under a tier' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        tier_id: { type: 'number', example: 1, description: 'Required' },
+        status: { type: 'boolean', example: true, description: 'Required' },
+      },
+      required: ['tier_id', 'status'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Promotion status updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/set-all-product')
   async setAllProductPromotion(
@@ -3049,6 +4288,21 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check the promotion tier applicable to a product for a member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+      },
+      required: ['pro_code', 'mem_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Tier/promotion info' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/check-product-promotion')
   async checkProductPromotion(
@@ -3060,6 +4314,11 @@ export class AppController {
     );
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all image-debug records (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of image-debug records' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/image-bug/all-imagedebug')
   async getAllImagedebug(@Req() req: Request & { user: JwtPayload }) {
@@ -3070,12 +4329,23 @@ export class AppController {
     return await this.imagedebugService.getAllImagedebug();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get promotion tier list for all products' })
+  @ApiResponse({ status: 200, description: 'Tier list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/tier-list-all-product')
   async getPromotionTierList() {
     return await this.promotionService.getTierAllProduct();
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get reward products for a promotion tier' })
+  @ApiParam({ name: 'tier_id', description: 'Tier id', example: 1 })
+  @ApiResponse({ status: 200, description: 'List of reward products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/promotion/tier-list-all-product-reward/:tier_id')
   async getPromotionTierListReward(
@@ -3089,6 +4359,23 @@ export class AppController {
     );
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload a banner/contract-log image' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary', description: 'Required; image file' },
+        name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed' },
+        type: { type: 'string', enum: ['wang', 'attestor', 'creditor', 'banner'], example: 'banner', description: 'Optional' },
+        bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed' },
+      },
+      required: ['file'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'File uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/create-log-banner')
   @UseInterceptors(FileInterceptor('file'))
@@ -3118,6 +4405,23 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get contract-log banner(s) by id or all' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        bannerId: {
+          oneOf: [{ type: 'number' }, { type: 'string', enum: ['all'] }],
+          example: 'all',
+          description: 'Optional; banner id, or "all" to get every banner',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Banner(s) found' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/banner')
   async getContractLogBanner(
@@ -3127,6 +4431,21 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get dropdown data for contract-log forms (e.g. attestor/creditor lists)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        group: { type: 'string', example: 'attestor', description: 'Required; not empty' },
+        type: { type: 'string', example: 'attestor', description: 'Required; not empty' },
+      },
+      required: ['group', 'type'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Dropdown data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/dropdown')
   async selectDataDropdown(
@@ -3140,6 +4459,30 @@ export class AppController {
     return { type: data.type, data: result.data };
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a contract-log banner record' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        selectedWang: { type: 'number', example: 1, description: 'Optional' },
+        selectedAttestor: { type: 'number', example: 1, description: 'Optional' },
+        selectedAttestor2: { type: 'number', example: 2, description: 'Optional' },
+        selectedCreditor: { type: 'number', example: 1, description: 'Optional' },
+        bannerId: { type: 'number', example: 1, description: 'Optional' },
+        bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed' },
+        signingDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime' },
+        creditorCode: { type: 'string', example: 'C00123', description: 'Optional; empty string allowed' },
+        startDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime' },
+        endDate: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime' },
+        paymentDue: { type: 'string', format: 'date-time', example: '2026-07-23T00:00:00.000Z', description: 'Optional; ISO datetime' },
+        address: { type: 'string', example: '99/1 ถนนสุขุมวิท', description: 'Optional; empty string allowed' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Banner record created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/create-banner')
   async createContractLogBanner(
@@ -3165,6 +4508,17 @@ export class AppController {
     return result;
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search creditors by keyword for contract-log forms' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { keyword: { type: 'string', example: 'บริษัท วังเภสัช', description: 'Optional; empty string allowed' } },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'List of matching creditors' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/search-creditor')
   async getDataCreditor(
@@ -3173,6 +4527,24 @@ export class AppController {
     return await this.productsService.getDataCreditor(keyword);
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a contract-log creditor/banner image and info' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        contractId: { type: 'number', example: 1, description: 'Required' },
+        name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed' },
+        type: { type: 'string', enum: ['creditor', 'banner'], example: 'creditor', description: 'Optional' },
+        bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed' },
+        file: { type: 'string', format: 'binary', description: 'Optional; image file' },
+      },
+      required: ['contractId'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Contract log updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/update-creditor-person')
   @UseInterceptors(FileInterceptor('file'))
@@ -3198,6 +4570,22 @@ export class AppController {
     });
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload a signed contract file' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        contractId: { type: 'number', example: 1, description: 'Required' },
+        name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed' },
+        file: { type: 'string', format: 'binary', description: 'Required; signed contract file' },
+      },
+      required: ['contractId', 'file'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Signed contract uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/upload-signed-contract')
   @UseInterceptors(FileInterceptor('file'))
@@ -3213,6 +4601,23 @@ export class AppController {
     });
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get contract-log company-day record(s) by id or all' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        companyDayId: {
+          oneOf: [{ type: 'number' }, { type: 'string', enum: ['all'] }],
+          example: 'all',
+          description: 'Optional; company-day record id, or "all" to get every record',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Company-day record(s)' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/contract-details')
   async getContractCompanyDays(
@@ -3224,6 +4629,21 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update reward redemption limit for a product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        limit: { type: 'number', example: 50, description: 'Required' },
+      },
+      required: ['pro_code', 'limit'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Limit updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/limit-update')
   async updatePromotionLimit(
@@ -3235,12 +4655,41 @@ export class AppController {
     );
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Reset reward redemption count for a product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } },
+      required: ['pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Limit count reset' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/promotion/reset-limit-count')
   async resetLimitReward(@Body() data: { pro_code: string }) {
     return await this.promotionService.resetCountLimit(data.pro_code);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Set a replacement product for a discontinued product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+        replace_pro_code: { type: 'string', example: 'P00456', description: 'Required; not empty' },
+        note: { type: 'string', example: 'สินค้าหมดสายผลิต', description: 'Optional; empty string allowed' },
+        date_end: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime' },
+      },
+      required: ['pro_code', 'replace_pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Replacement product set' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/replace/replace-product')
   async ReplaceProduct(
@@ -3261,6 +4710,39 @@ export class AppController {
     );
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a contract-log company-day record' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        selectedWang: { type: 'number', example: 1, description: 'Optional' },
+        selectedAttestor: { type: 'number', example: 1, description: 'Optional' },
+        selectedAttestor2: { type: 'number', example: 2, description: 'Optional' },
+        selectedCreditor: { type: 'number', example: 1, description: 'Optional' },
+        bannerId: { type: 'number', example: 1, description: 'Optional' },
+        bannerName: { type: 'string', example: 'แบนเนอร์โปรโมชั่น', description: 'Optional; empty string allowed' },
+        signingDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime' },
+        creditorCode: { type: 'string', example: 'C00123', description: 'Optional; empty string allowed' },
+        startDate: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Optional; ISO datetime' },
+        endDate: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime' },
+        address: { type: 'string', example: '99/1 ถนนสุขุมวิท', description: 'Optional; empty string allowed' },
+        reportDueDate: { type: 'string', format: 'date-time', example: '2026-12-31T00:00:00.000Z', description: 'Optional; ISO datetime' },
+        finalPaymentAmount: { type: 'number', example: 5000, description: 'Optional' },
+        totalSupportValue: { type: 'number', example: 10000, description: 'Optional' },
+        supportDeliveryDate: { type: 'string', format: 'date-time', example: '2026-07-01T00:00:00.000Z', description: 'Optional; ISO datetime' },
+        numberOfInstallments: { type: 'number', example: 3, description: 'Optional' },
+        installmentIntervalDays: { type: 'number', example: 30, description: 'Optional' },
+        firstInstallmentAmount: { type: 'number', example: 3000, description: 'Optional' },
+        firstPaymentCondition: { type: 'string', example: 'ชำระทันทีหลังเซ็นสัญญา', description: 'Optional; empty string allowed' },
+        finalInstallmentAmount: { type: 'number', example: 2000, description: 'Optional' },
+        productsToOrder: { type: 'string', example: 'P00123, P00456', description: 'Optional; empty string allowed' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Company-day record created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/create-company-day')
   async createContractCompanyDay(
@@ -3293,6 +4775,23 @@ export class AppController {
     return await this.contractLogService.createContractLogCompanyDay(data);
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a contract-log company-day record (creditor image)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        contractId: { type: 'number', example: 1, description: 'Required' },
+        name: { type: 'string', example: 'สมชาย ใจดี', description: 'Optional; empty string allowed' },
+        type: { type: 'string', enum: ['creditor'], example: 'creditor', description: 'Optional' },
+        file: { type: 'string', format: 'binary', description: 'Optional; image file' },
+      },
+      required: ['contractId'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Company-day record updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/update-company-day')
   @UseInterceptors(FileInterceptor('file'))
@@ -3319,6 +4818,21 @@ export class AppController {
     });
   }
 
+  @ApiTags('Contract Log')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload a signed company-day contract file' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        contractId: { type: 'number', example: 1, description: 'Required' },
+        file: { type: 'string', format: 'binary', description: 'Required; signed contract file' },
+      },
+      required: ['contractId', 'file'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Signed contract uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/contract-log/upload-signed-company-day')
   @UseInterceptors(FileInterceptor('file'))
@@ -3334,18 +4848,53 @@ export class AppController {
     });
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get the replacement product info for a product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } },
+      required: ['pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Replacement product info' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/replace/get-product')
   async GetProductAndReplace(@Body() data: { pro_code: string }) {
     return await this.recommendService.GetProductAndReplace(data.pro_code);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Clear the replacement product for a product' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } },
+      required: ['pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Replacement product cleared' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/replace/replace-product-null')
   async UpdateProductAndReplaceNull(@Body() data: { pro_code: string }) {
     return await this.recommendService.RemoveReplaceProduct(data.pro_code);
   }
 
+  @ApiTags('Policy Document')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Find policy document categories (optionally by name)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { name: { type: 'string', example: 'นโยบายความเป็นส่วนตัว', description: 'Optional; empty string allowed' } },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'List of policy categories' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/policy/option-catagory')
   async findOptionCatagoryPolicy(@Body('name') name?: string) {
@@ -3353,6 +4902,22 @@ export class AppController {
     return await this.policyDocService.findOptionCatagoryPolicy(name);
   }
 
+  @ApiTags('Policy Document')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Save a new policy document version' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        content: { type: 'string', example: '<p>เนื้อหานโยบาย</p>', description: 'Required; not empty' },
+        category: { type: 'number', example: 1, description: 'Required' },
+        type: { type: 'number', example: 1, description: 'Required' },
+      },
+      required: ['content', 'category', 'type'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Policy document saved' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/policy/upload-policy')
   async savePolicyDoc(
@@ -3368,6 +4933,11 @@ export class AppController {
     return await this.policyDocService.savePolicyDoc(content, category, type);
   }
 
+  @ApiTags('Policy Document')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check and get the correct (latest unsigned) policy for current member' })
+  @ApiResponse({ status: 200, description: 'Applicable policy document' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/policy/check-policy')
   async ensureUserHasPolicyMember(@Req() req: Request & { user: JwtPayload }) {
@@ -3375,6 +4945,18 @@ export class AppController {
     return await this.policyDocService.checkAndGetCorrectPolicy(mem_code);
   }
 
+  @ApiTags('Policy Document')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Agree to a policy document for current member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { policyID: { type: 'number', example: 1, description: 'Required' } },
+      required: ['policyID'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Agreement recorded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/policy/agree')
   async agreeToPolicyDoc(
@@ -3387,6 +4969,11 @@ export class AppController {
     return await this.policyDocService.agreePolicyDoc(mem_code, body.policyID);
   }
 
+  @ApiTags('Policy Document')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all policy documents' })
+  @ApiResponse({ status: 200, description: 'List of policy documents' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/policy/all-policies')
   async getAllPolicies(): Promise<
@@ -3403,6 +4990,11 @@ export class AppController {
     return await this.policyDocService.getAllPolicies();
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all campaigns' })
+  @ApiResponse({ status: 200, description: 'List of campaigns' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns')
   async getAllCampaigns() {
@@ -3421,6 +5013,21 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a campaign' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', example: 'แคมเปญสิ้นปี 2026', description: 'Required; not empty' },
+        description: { type: 'string', example: 'แคมเปญลดราคาสิ้นปี', description: 'Optional; empty string allowed' },
+      },
+      required: ['name'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Campaign created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns')
   async createCampaign(@Body() body: { name: string; description?: string }) {
@@ -3438,6 +5045,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a campaign' })
+  @ApiParam({ name: 'id', description: 'Campaign id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Campaign deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/campaigns/:id')
   async deleteCampaign(@Param('id') id: string) {
@@ -3458,6 +5071,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get tracking data for a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Campaign data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns/:campaignId/data')
   async getCampaignData(@Param('campaignId') campaignId: string) {
@@ -3475,6 +5094,24 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a data row in a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        set_number: { type: 'number', example: 1, description: 'Required' },
+        condition: { type: 'string', example: 'ซื้อครบ 1000 บาท', description: 'Optional; empty string allowed' },
+        target: { type: 'string', example: 'P00123', description: 'Optional; empty string allowed' },
+        con_percent: { type: 'string', example: '10', description: 'Optional; empty string allowed' },
+      },
+      required: ['set_number'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Row created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/data')
   async createRow(
@@ -3498,6 +5135,29 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a campaign data row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        target: { type: 'string', example: 'P00123', description: 'Optional; empty string allowed' },
+        con_percent: { type: 'string', example: '10', description: 'Optional; empty string allowed' },
+        condition: { type: 'string', example: 'ซื้อครบ 1000 บาท', description: 'Optional; empty string allowed' },
+        set_number: { type: 'number', example: 1, description: 'Optional' },
+        price_per_set: { type: 'string', example: '500.00', description: 'Optional; empty string allowed' },
+        number_of_sets: { type: 'number', example: 2, description: 'Optional' },
+        unit_price: { type: 'number', example: 250, description: 'Optional' },
+        quantity: { type: 'number', example: 2, description: 'Optional' },
+        discounted_price: { type: 'number', example: 450, description: 'Optional' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Row updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/campaigns/:campaignId/data/:rowId')
   async updateRow(
@@ -3528,6 +5188,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a campaign data row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Row deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/campaigns/:campaignId/data/:rowId')
   async deleteRow(
@@ -3545,6 +5212,23 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a reward column for a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', example: 'ของแถม', description: 'Required; not empty' },
+        unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed' },
+        value_per_unit: { type: 'string', example: '10.00', description: 'Optional; empty string allowed' },
+      },
+      required: ['name'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Reward column created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/columns')
   async createRewardColumn(
@@ -3566,6 +5250,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a reward column from a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'columnId', description: 'Reward column id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Reward column deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/campaigns/:campaignId/columns/:columnId')
   async deleteRewardColumn(
@@ -3591,6 +5282,11 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all products available to add to campaigns' })
+  @ApiResponse({ status: 200, description: 'List of products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns/products')
   async getProducts() {
@@ -3609,6 +5305,20 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a product to a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } },
+      required: ['pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product added to row' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/data/:rowId/products')
   async addProductToRow(
@@ -3639,6 +5349,20 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a product from a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' } },
+      required: ['pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Product removed from row' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/data/:rowId/products-delete')
   async removeProductFromRow(
@@ -3672,6 +5396,26 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a promo reward value to a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        reward_column_id: { type: 'string', example: '1', description: 'Required; not empty' },
+        quantity: { type: 'string', example: '2', description: 'Optional; empty string allowed' },
+        unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed' },
+        price: { type: 'string', example: '10.00', description: 'Optional; empty string allowed' },
+        value: { type: 'string', example: '20.00', description: 'Optional; empty string allowed' },
+      },
+      required: ['reward_column_id'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Promo reward added' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/data/:rowId/rewards')
   async addPromoReward(
@@ -3701,6 +5445,25 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a promo reward value in a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiParam({ name: 'rewardId', description: 'Reward id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        quantity: { type: 'string', example: '2', description: 'Optional; empty string allowed' },
+        unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed' },
+        price: { type: 'string', example: '10.00', description: 'Optional; empty string allowed' },
+        value: { type: 'string', example: '20.00', description: 'Optional; empty string allowed' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Promo reward updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/campaigns/:campaignId/data/:rowId/rewards/:rewardId')
   async updatePromoReward(
@@ -3737,6 +5500,14 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a promo reward from a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiParam({ name: 'rewardId', description: 'Reward id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Promo reward deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/campaigns/:campaignId/data/:rowId/rewards/:rewardId')
   async deletePromoReward(
@@ -3762,6 +5533,22 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a reward column image/product link' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        reward_id: { type: 'string', example: '1', description: 'Required; not empty' },
+        url: { type: 'string', example: 'https://example.com/image.png', description: 'Required; not empty' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      },
+      required: ['reward_id', 'url', 'pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Reward column updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/update-collumn-reward')
   async updateRewardColumn(
@@ -3785,6 +5572,21 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload an image for a campaign reward' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary', description: 'Required; image file' },
+        reward_id: { type: 'string', example: '1', description: 'Required; not empty' },
+      },
+      required: ['file', 'reward_id'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Image uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/upload-reward-image')
   @UseInterceptors(FileInterceptor('file'))
@@ -3806,6 +5608,18 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload a generic campaign image' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary', description: 'Required; image file' } },
+      required: ['file'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Image uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/upload-image')
   @UseInterceptors(FileInterceptor('file'))
@@ -3821,6 +5635,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get purchase products listed in a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiResponse({ status: 200, description: 'List of purchase products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns/:campaignId/purchase-products')
   async getPurchaseProducts(@Param('campaignId') campaignId: string) {
@@ -3835,6 +5655,19 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a purchase product entry for a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { name: { type: 'string', example: 'แชมพูสมุนไพร', description: 'Required; not empty' } },
+      required: ['name'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Purchase product created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/purchase-products')
   async createPurchaseProduct(
@@ -3855,6 +5688,22 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a purchase product entry' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'productId', description: 'Purchase product id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', example: 'แชมพูสมุนไพร', description: 'Optional; empty string allowed' },
+        img_url: { type: 'string', example: 'https://example.com/image.png', description: 'Optional; empty string allowed' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Purchase product updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Patch('/campaigns/:campaignId/purchase-products/:productId')
   async updatePurchaseProduct(
@@ -3877,6 +5726,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a purchase product entry' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'productId', description: 'Purchase product id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Purchase product deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/campaigns/:campaignId/purchase-products/:productId')
   async deletePurchaseProduct(
@@ -3894,6 +5750,20 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload an image for a purchase product' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'productId', description: 'Purchase product id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary', description: 'Required; image file' } },
+      required: ['file'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Image uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/purchase-products/:productId/upload-image')
   @UseInterceptors(FileInterceptor('file'))
@@ -3920,6 +5790,33 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiOperation({ summary: 'Generate a campaign poster image via AI' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        prompt: { type: 'string', example: 'โปสเตอร์โปรโมชั่นสินค้าฤดูร้อน', description: 'Required; not empty' },
+        aspectRatio: { type: 'string', example: '1:1', description: 'Required; not empty' },
+        imageItems: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              url: { type: 'string', example: 'https://example.com/image.png', description: 'Required; not empty' },
+              name: { type: 'string', example: 'แชมพูสมุนไพร', description: 'Required; not empty' },
+              quantity: { type: 'number', example: 1, description: 'Required' },
+              unit: { type: 'string', example: 'ชิ้น', description: 'Optional; empty string allowed' },
+            },
+            required: ['url', 'name', 'quantity'],
+          },
+        },
+        session_cookies: { type: 'string', example: '', description: 'Optional; empty string allowed' },
+      },
+      required: ['prompt', 'aspectRatio'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Poster generation request id' })
   // @UseGuards(JwtAuthGuard)
   @Post('/campaigns/generate-poster')
   async generatePoster(
@@ -3944,6 +5841,16 @@ export class AppController {
     );
   }
 
+  @ApiTags('Campaigns')
+  @ApiOperation({ summary: 'Poll for AI poster generation result by request id' })
+  @ApiParam({ name: 'requestId', description: 'Poster generation request id', example: 'req_00123' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { session_cookies: { type: 'string', example: '', description: 'Optional; empty string allowed' } },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Generation result' })
   @Post('/campaigns/get-response-id/:requestId')
   async getResponseId(
     @Param('requestId') requestId: string,
@@ -3955,6 +5862,12 @@ export class AppController {
     );
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get reward columns for a campaign' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiResponse({ status: 200, description: 'List of reward columns' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns/:campaignId/columns')
   async getRewardColumns(@Param('campaignId') campaignId: string) {
@@ -3962,6 +5875,20 @@ export class AppController {
     return { success: true, data: columns };
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update value-per-unit for a reward column' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'columnId', description: 'Reward column id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { value_per_unit: { type: 'number', example: 10, description: 'Required' } },
+      required: ['value_per_unit'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Value per unit updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Patch('/campaigns/:campaignId/columns/:columnId')
   async updateRewardColumnValuePerUnit(
@@ -3977,6 +5904,20 @@ export class AppController {
     return { success: true };
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Save a generated poster image to a campaign row history' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { img_url: { type: 'string', example: 'https://example.com/poster.png', description: 'Required; not empty' } },
+      required: ['img_url'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Poster history saved' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/campaigns/:campaignId/data/:rowId/poster-history')
   async savePosterHistory(
@@ -3997,6 +5938,32 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a banner from a poster history image and link it' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiParam({ name: 'historyId', description: 'Poster history id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        img_url: { type: 'string', example: 'https://example.com/poster.png', description: 'Required; not empty' },
+        banner_name: { type: 'string', example: 'โปสเตอร์โปรโมชั่นฤดูร้อน', description: 'Optional; empty string allowed' },
+        banner_location: {
+          type: 'string',
+          enum: ['store_carousel', 'landing_hero', 'popup', 'sidebar'],
+          example: 'store_carousel',
+          description: 'Required; not empty',
+        },
+        date_start: { type: 'string', format: 'date-time', example: '2026-06-23T00:00:00.000Z', description: 'Required; ISO datetime' },
+        date_end: { type: 'string', format: 'date-time', example: '2026-07-23T00:00:00.000Z', description: 'Required; ISO datetime' },
+      },
+      required: ['img_url', 'banner_location', 'date_start', 'date_end'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Banner created and linked' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post(
     '/campaigns/:campaignId/data/:rowId/poster-history/:historyId/banner-links',
@@ -4035,6 +6002,15 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a banner link from poster history (keeps the banner image file)' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiParam({ name: 'historyId', description: 'Poster history id', example: '1' })
+  @ApiParam({ name: 'linkId', description: 'Banner link id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Banner link removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete(
     '/campaigns/:campaignId/data/:rowId/poster-history/:historyId/banner-links/:linkId',
@@ -4054,6 +6030,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get poster history for a campaign row' })
+  @ApiParam({ name: 'campaignId', description: 'Campaign id', example: '1' })
+  @ApiParam({ name: 'rowId', description: 'Row id', example: '1' })
+  @ApiResponse({ status: 200, description: 'List of poster history items' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/campaigns/:campaignId/data/:rowId/poster-history')
   async getPosterHistory(@Param('rowId') rowId: string) {
@@ -4068,6 +6051,10 @@ export class AppController {
     }
   }
 
+  @ApiTags('Campaigns')
+  @ApiOperation({ summary: 'Proxy-download an ideogram.ai generated image (avoids CORS)' })
+  @ApiQuery({ name: 'url', description: 'Must start with https://ideogram.ai/', example: 'https://ideogram.ai/api/images/example.png' })
+  @ApiResponse({ status: 200, description: 'Image binary stream' })
   @Get('/campaigns/proxy-image')
   async proxyImage(@Query('url') url: string, @Res() res: Response) {
     if (!url || !url.startsWith('https://ideogram.ai/')) {
@@ -4089,6 +6076,11 @@ export class AppController {
     res.send(Buffer.from(response.data));
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search banner-eligible products (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/products-banner')
   async searchProductsBanner(@Req() req: Request & { user: JwtPayload }) {
@@ -4099,6 +6091,11 @@ export class AppController {
     return await this.productsService.searchProductsBanner();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all creditors (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of creditors' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/data/get-creditor')
   async getCreditors(@Req() req: Request & { user: JwtPayload }) {
@@ -4109,6 +6106,10 @@ export class AppController {
     return await this.productsService.getCreditors();
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Get delivery tracking location for an order' })
+  @ApiParam({ name: 'sh_running', description: 'Shopping head running number', example: 'SO00123' })
+  @ApiResponse({ status: 200, description: 'Order tracking location' })
   @Get('/ecom/track-order/:sh_running')
   async trackOrder(@Param('sh_running') sh_running: string) {
     try {
@@ -4127,6 +6128,12 @@ export class AppController {
   // ========== Product Return APIs ==========
 
   // Customer: Get eligible orders for return
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get orders eligible for return for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of eligible orders' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/returns/eligible-orders/:mem_code')
   async getEligibleOrders(@Param('mem_code') mem_code: string) {
@@ -4147,6 +6154,12 @@ export class AppController {
   }
 
   // Customer: Get order items for return selection
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get order items available for return selection' })
+  @ApiParam({ name: 'soh_running', description: 'Shopping order head running number', example: 'SO00123' })
+  @ApiResponse({ status: 200, description: 'List of order items' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/returns/order-items/:soh_running')
   async getOrderItemsForReturn(
@@ -4173,6 +6186,50 @@ export class AppController {
   }
 
   // Customer: Create return request
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a product return request (customer-initiated)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        soh_id: { type: 'number', example: 12345, description: 'Required' },
+        mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+        reason: {
+          type: 'string',
+          enum: ['damaged', 'expired', 'wrong_item', 'disaster', 'other'],
+          example: 'damaged',
+          description: 'Required; not empty',
+        },
+        reason_detail: { type: 'string', example: 'สินค้าชำรุดตอนเปิดกล่อง', description: 'Optional; empty string allowed' },
+        resolution_type: {
+          type: 'string',
+          enum: ['refund', 'replacement'],
+          example: 'refund',
+          description: 'Required; not empty',
+        },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+              qty: { type: 'number', example: 2, description: 'Required' },
+              unit: { type: 'string', example: 'กล่อง', description: 'Required; not empty' },
+              price_per_unit: { type: 'number', example: 150, description: 'Required' },
+              item_reason: { type: 'string', example: 'สินค้าชำรุด', description: 'Optional; empty string allowed' },
+              expiry_date: { type: 'string', example: '2026-12-31', description: 'Optional; format YYYY-MM-DD' },
+            },
+            required: ['pro_code', 'qty', 'unit', 'price_per_unit'],
+          },
+        },
+        notes: { type: 'string', example: '', description: 'Optional; empty string allowed' },
+      },
+      required: ['soh_id', 'mem_code', 'reason', 'resolution_type', 'items'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Return request created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/returns/create')
   async createReturn(
@@ -4214,6 +6271,21 @@ export class AppController {
   }
 
   // Customer: Upload evidence images
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload evidence images for a return request (up to 5 files)' })
+  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        files: { type: 'array', items: { type: 'string', format: 'binary' }, description: 'Optional; up to 5 image files' },
+        description: { type: 'string', example: '', description: 'Optional; empty string allowed' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Images uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/returns/:return_id/images')
   @UseInterceptors(FileFieldsInterceptor([{ name: 'files', maxCount: 5 }]))
@@ -4243,6 +6315,12 @@ export class AppController {
   }
 
   // Customer: Submit return request
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Submit a draft return request for review' })
+  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiResponse({ status: 201, description: 'Return request submitted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/returns/:return_id/submit')
   async submitReturn(
@@ -4269,6 +6347,15 @@ export class AppController {
   }
 
   // Customer: Get my returns
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get return requests for a member' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiQuery({ name: 'status', required: false, type: String, example: 'pending' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiQuery({ name: 'offset', required: false, type: String, example: '0' })
+  @ApiResponse({ status: 200, description: 'List of return requests' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/returns/my-returns/:mem_code')
   async getMyReturns(
@@ -4298,6 +6385,12 @@ export class AppController {
   }
 
   // Customer: Get return detail
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get detail of a return request' })
+  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Return request detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/returns/:return_id')
   async getReturnDetail(@Param('return_id') return_id: string) {
@@ -4320,6 +6413,12 @@ export class AppController {
   }
 
   // Customer: Delete draft return
+  @ApiTags('Product Returns')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a draft (unsubmitted) return request' })
+  @ApiParam({ name: 'return_id', description: 'Return request id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Draft return deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/returns/:return_id')
   async deleteDraftReturn(
@@ -4402,6 +6501,14 @@ export class AppController {
   // }
 
   // Get user behavior (for personalization)
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get tracked behavior events for a member (for personalization)' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'User behavior data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/tracking/user/:mem_code')
   async getUserBehavior(
@@ -4430,6 +6537,14 @@ export class AppController {
   }
 
   // Admin: Get product analytics
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get product view/interaction analytics (requires permission)' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'Product analytics data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/product/:pro_code')
   async getProductAnalytics(
@@ -4463,6 +6578,13 @@ export class AppController {
   }
 
   // Admin: Get search analytics
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get search behavior analytics (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'Search analytics data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/searches')
   async getSearchAnalytics(
@@ -4494,6 +6616,13 @@ export class AppController {
   }
 
   // Admin: Get dashboard stats
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get behavior tracking dashboard stats (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'Dashboard stats' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/dashboard')
   async getTrackingDashboard(
@@ -4525,6 +6654,13 @@ export class AppController {
   }
 
   // Admin: Get daily trend
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get daily behavior trend (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'Daily trend data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/daily-trend')
   async getDailyTrend(
@@ -4556,6 +6692,14 @@ export class AppController {
   }
 
   // Admin: Get top products
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get top viewed/purchased products (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '10' })
+  @ApiResponse({ status: 200, description: 'List of top products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/top-products')
   async getTopProducts(
@@ -4589,6 +6733,12 @@ export class AppController {
   }
 
   // Admin: Get recent activity feed
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get recent customer activity feed (requires permission)' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '50' })
+  @ApiResponse({ status: 200, description: 'Recent activity feed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/recent-activity')
   async getRecentActivity(
@@ -4618,6 +6768,12 @@ export class AppController {
   }
 
   // Admin: Get user journeys
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get user navigation journeys (requires permission)' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiResponse({ status: 200, description: 'List of user journeys' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/user-journeys')
   async getUserJourneys(
@@ -4647,6 +6803,14 @@ export class AppController {
   }
 
   // Admin: Get zero result searches
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get search queries that returned zero results (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: false, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: false, type: String, example: '2026-06-23' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '30' })
+  @ApiResponse({ status: 200, description: 'List of zero-result searches' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/zero-result-searches')
   async getZeroResultSearches(
@@ -4680,6 +6844,13 @@ export class AppController {
   }
 
   // Admin: Get stock alerts based on demand
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get demand-based stock alerts (requires permission)' })
+  @ApiQuery({ name: 'days', required: false, type: String, example: '7' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiResponse({ status: 200, description: 'List of stock alerts' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/stock-alerts')
   async getStockAlerts(
@@ -4711,6 +6882,13 @@ export class AppController {
   }
 
   // Admin: Get cart conversion analytics
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get cart-to-purchase conversion analytics (requires permission)' })
+  @ApiQuery({ name: 'days', required: false, type: String, example: '30' })
+  @ApiQuery({ name: 'limit', required: false, type: String, example: '20' })
+  @ApiResponse({ status: 200, description: 'Cart conversion analytics' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/cart-analytics')
   async getCartConversionAnalytics(
@@ -4742,6 +6920,12 @@ export class AppController {
   }
 
   // Admin: Get customer segments
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get customer segmentation analysis (requires permission)' })
+  @ApiQuery({ name: 'days', required: false, type: String, example: '90' })
+  @ApiResponse({ status: 200, description: 'Customer segments' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/customer-segments')
   async getCustomerSegments(
@@ -4771,6 +6955,12 @@ export class AppController {
   }
 
   // Admin: Get retention analysis
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get customer retention analysis (requires permission)' })
+  @ApiQuery({ name: 'weeks', required: false, type: String, example: '8' })
+  @ApiResponse({ status: 200, description: 'Retention analysis' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/retention')
   async getRetentionAnalysis(
@@ -4800,6 +6990,12 @@ export class AppController {
   }
 
   // Admin: Get repeat purchase patterns
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get repeat purchase patterns (requires permission)' })
+  @ApiQuery({ name: 'days', required: false, type: String, example: '180' })
+  @ApiResponse({ status: 200, description: 'Repeat purchase patterns' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/repeat-purchases')
   async getRepeatPurchasePatterns(
@@ -4829,6 +7025,13 @@ export class AppController {
   }
 
   // Admin: Get purchase interval box plot data
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get purchase interval box-plot data (requires permission)' })
+  @ApiQuery({ name: 'days', required: false, type: String, example: '180' })
+  @ApiQuery({ name: 'group_by', required: false, type: String, example: 'overall', description: 'one of: overall, product, segment, month' })
+  @ApiResponse({ status: 200, description: 'Box-plot data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/purchase-intervals-boxplot')
   async getPurchaseIntervalBoxPlot(
@@ -4860,6 +7063,13 @@ export class AppController {
   }
 
   // Admin: Get user journey sankey
+  @ApiTags('Behavior Tracking')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get user journey sankey diagram data (requires permission)' })
+  @ApiQuery({ name: 'from_date', required: true, type: String, example: '2026-06-01' })
+  @ApiQuery({ name: 'to_date', required: true, type: String, example: '2026-06-23' })
+  @ApiResponse({ status: 200, description: 'Sankey diagram data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/tracking/user-journey-sankey')
   async getUserJourneySankey(
@@ -4877,6 +7087,22 @@ export class AppController {
     );
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Change a member\'s role/permission (Admin only)' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        newRole: { type: 'string', enum: ['User', 'Admin', 'Sales'], example: 'Sales', description: 'Required; not empty' },
+        permission: { type: 'boolean', example: true, description: 'Optional; defaults to false' },
+      },
+      required: ['newRole'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Role changed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/change-role/:mem_code')
   async changeUserRole(
@@ -4903,6 +7129,11 @@ export class AppController {
     );
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all staff users (Admin only)' })
+  @ApiResponse({ status: 200, description: 'List of staff users' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/user/staff-list')
   async getStaffUsers(@Req() req: Request & { user: JwtPayload }) {
@@ -4914,6 +7145,12 @@ export class AppController {
     return await this.usersService.getStaffUsers();
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Look up a member for role management (Admin only)' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'Member info for role management' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/user/lookup/:mem_code')
   async lookupUserForRoleManage(
@@ -4926,6 +7163,12 @@ export class AppController {
     return await this.usersService.findUserForRoleManageByMemCode(mem_code);
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search members for role management (Admin only)' })
+  @ApiQuery({ name: 'q', required: false, type: String, example: 'สมชาย' })
+  @ApiResponse({ status: 200, description: 'List of matching members' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/user/search')
   async searchUsersForRoleManage(
@@ -4938,6 +7181,25 @@ export class AppController {
     return await this.usersService.searchUsersForRoleManage(query ?? '');
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update enabled feature flags for a member (Admin only)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        mem_code: { type: 'string', example: 'M00123', description: 'Required; not empty' },
+        features: {
+          type: 'array',
+          items: { type: 'string', example: 'happy_hour' },
+          description: 'Required; list of feature flag keys',
+        },
+      },
+      required: ['mem_code', 'features'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Features updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('/ecom/admin/user/update-features')
   async updateUserFeatures(
@@ -4958,6 +7220,13 @@ export class AppController {
     );
   }
 
+  @ApiTags('Users')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get paginated admin role-change action logs (Admin only)' })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 20 })
+  @ApiResponse({ status: 200, description: 'Paginated admin action logs' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/user/role-logs')
   async getAdminActionLogs(
@@ -4971,12 +7240,31 @@ export class AppController {
     return await this.usersService.getAdminActionLogs(page, limit);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get RT (return) order notifications from the last 3 days' })
+  @ApiParam({ name: 'mem_code', description: 'Member code', example: 'M00123' })
+  @ApiResponse({ status: 200, description: 'List of RT notifications' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/get-notification-rt/:mem_code')
   async getRTNotifications(@Param('mem_code') mem_code: string) {
     return await this.notifyRtService.getRTOrdersInTheLast3Days(mem_code);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiOperation({ summary: 'Update RT (return) notification read status' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        soh_running: { type: 'string', example: 'SO00123', description: 'Required; not empty' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      },
+      required: ['soh_running', 'pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'RT notification status updated' })
   @Post('/ecom/update-notification-rt')
   async updateRTNotification(
     @Body() data: { soh_running: string; pro_code: string },
@@ -4985,6 +7273,18 @@ export class AppController {
     return await this.notifyRtService.updateRTStatus(data);
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Register a push notification token for current member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { token: { type: 'string', example: 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]', description: 'Required; not empty' } },
+      required: ['token'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Token registered' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/qc/add-token-for-notification')
   async addTokenForNotification(
@@ -4998,6 +7298,18 @@ export class AppController {
     });
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a push notification token for current member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { token: { type: 'string', example: 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]', description: 'Required; not empty' } },
+      required: ['token'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Token removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/qc/remove-token-for-notification')
   async removeTokenForNotification(
@@ -5011,6 +7323,21 @@ export class AppController {
     });
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload a banner image for a hotdeal' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 1, description: 'Required' },
+        file: { type: 'string', format: 'binary', description: 'Required; image file' },
+      },
+      required: ['id', 'file'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Banner uploaded' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/admin/hotdeal/upload-banner')
   @UseInterceptors(FileInterceptor('file'))
@@ -5021,18 +7348,36 @@ export class AppController {
     return await this.hotdealService.uploadBannerHotdeal(file, body.id);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all hotdeals with their banners' })
+  @ApiResponse({ status: 200, description: 'List of hotdeals with banners' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/admin/hotdeal/get-banner')
   async getHotdealBanner() {
     return await this.hotdealService.getAllHotdealsWithBanners();
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a hotdeal banner' })
+  @ApiParam({ name: 'id', description: 'Hotdeal banner id', example: '1' })
+  @ApiResponse({ status: 200, description: 'Banner deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('/ecom/admin/hotdeal/delete-banner/:id')
   async deleteHotdealBanner(@Param('id') id: number) {
     return await this.hotdealService.deleteBannerHotdeal(id);
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get paginated list of products with a replacement set' })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 10 })
+  @ApiResponse({ status: 200, description: 'Paginated replacement products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/replace-product')
   async getReplacementProduct(
@@ -5042,6 +7387,21 @@ export class AppController {
     return await this.recommendService.getAllReplaceProducts(page, limit);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Upload/update the poster image for a promotion tier' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        tier_id: { type: 'string', example: '1', description: 'Required; not empty' },
+        file: { type: 'string', format: 'binary', description: 'Required; image file' },
+      },
+      required: ['tier_id', 'file'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Tier poster updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('ecom/promotion/update-tier-poster')
   @UseInterceptors(FileInterceptor('file'))
@@ -5052,6 +7412,19 @@ export class AppController {
     return this.promotionService.updateTierPoster(Number(tier_id), file);
   }
 
+  @ApiTags('Promotion & Tier')
+  @ApiOperation({ summary: 'Check/recalculate tier-turn-back reward price for an order item' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        sh_running: { type: 'string', example: 'SO00123', description: 'Required; not empty' },
+        pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+      },
+      required: ['sh_running', 'pro_code'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Tier price result' })
   @Post('/ecom/get-tier-price')
   async getTierPrice(@Body() body: { sh_running: string; pro_code: string }) {
     return await this.shoppingOrderService.checkOrderTurnBackReward(
@@ -5060,6 +7433,19 @@ export class AppController {
     );
   }
 
+  @ApiTags('Happy Hour')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Check and adjust happy-hour reward for an order (requires permission)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { sh_running: { type: 'string', example: 'SO00123', description: 'Required; not empty' } },
+      required: ['sh_running'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Happy-hour reward adjusted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/check-happy-hour-reward')
   async checkHappyHourReward(
@@ -5074,6 +7460,12 @@ export class AppController {
     );
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get hotdeal detail by product code for current member' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Hotdeal detail' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/hotdeal/:pro_code')
   async getHotdealByProCode(
@@ -5084,6 +7476,32 @@ export class AppController {
     return await this.hotdealService.getHotdealFromproCode(pro_code, mem_code);
   }
 
+  @ApiTags('Hotdeal & Flash Sale')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add hotdeal freebie products to cart for current member' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        freebies: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              pro_code: { type: 'string', example: 'P00123', description: 'Required; not empty' },
+              unit: { type: 'string', example: 'กล่อง', description: 'Required; not empty' },
+              amount: { type: 'number', example: 1, description: 'Required' },
+              pro_code1: { type: 'string', example: 'P00100', description: 'Required; not empty; the qualifying product code' },
+            },
+            required: ['pro_code', 'unit', 'amount', 'pro_code1'],
+          },
+        },
+      },
+      required: ['freebies'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Freebies added to cart' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('/ecom/hotdeal/add-other-product')
   async createHotdeal(
@@ -5110,6 +7528,11 @@ export class AppController {
     return results;
   }
 
+  @ApiTags('Products')
+  @ApiOperation({ summary: 'Get product image by product code' })
+  @ApiParam({ name: 'pro_code', description: 'Product code', example: 'P00123' })
+  @ApiResponse({ status: 200, description: 'Product image data' })
+  @ApiResponse({ status: 404, description: 'Product not found' })
   @Get('/ecom/get-product-image/:pro_code')
   async getProductImage(@Param('pro_code') pro_code: string) {
     this.logger.log('Fetching product image for pro_code:', pro_code);
@@ -5137,12 +7560,23 @@ export class AppController {
     }
   }
 
+  @ApiTags('Misc / Admin Tools')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Manually trigger the company-day promotion cart re-check' })
+  @ApiResponse({ status: 200, description: 'Check triggered' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/trigger/check-promotion-company-day')
   async triggerCheckPromotionCompanyDay() {
     await this.shoppingCartService.callCheckCartPromotion();
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Autocomplete product search against the external product source' })
+  @ApiQuery({ name: 'search', description: 'Search keyword', example: 'แชมพู' })
+  @ApiResponse({ status: 200, description: 'List of matching products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/product-search-autocomplete')
   async productSearchAutoComplete(@Query('search') search: string) {
@@ -5156,6 +7590,12 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search Lotus gift card products (requires permission)' })
+  @ApiResponse({ status: 200, description: 'List of Lotus card products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   @UseGuards(JwtAuthGuard)
   @Get('/ecom/products/lotus-cards')
   async searchLotusCards(@Req() req: Request & { user: JwtPayload }) {
@@ -5167,6 +7607,13 @@ export class AppController {
     }
   }
 
+  @ApiTags('Products')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Search products by name for admin (requires permission)' })
+  @ApiQuery({ name: 'keyword', required: false, type: String, example: 'แชมพู' })
+  @ApiResponse({ status: 200, description: 'List of matching products' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   @UseGuards(JwtAuthGuard)
   @Get('ecom/admin/products/search')
   async productSearchProductName(

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,15 +1,59 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 
+@ApiTags('Auth')
 @Controller('ecom/auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  @ApiOperation({
+    summary: 'เข้าสู่ระบบด้วย LINE access token (public)',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['lineAccessToken'],
+      properties: {
+        lineAccessToken: {
+          type: 'string',
+          example: 'eyJhbGciOiJIUzI1NiJ9.line-access-token-example',
+          description: 'Required; not empty; Access token ที่ได้จาก LINE Login',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'เข้าสู่ระบบสำเร็จ คืนค่า token และ refresh_token',
+  })
+  @ApiResponse({ status: 401, description: 'LINE access token ไม่ถูกต้อง' })
   @Post('line-login')
   async lineLogin(@Body() body: { lineAccessToken: string }) {
     return this.authService.signinWithLine(body.lineAccessToken);
   }
 
+  @ApiOperation({
+    summary: 'เข้าสู่ระบบด้วย LINE user id โดยตรง (public)',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['lineUserId'],
+      properties: {
+        lineUserId: {
+          type: 'string',
+          example: 'U1234567890abcdef1234567890abcdef',
+          description: 'Required; not empty; LINE user id ของผู้ใช้',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'เข้าสู่ระบบสำเร็จ คืนค่า token และ refresh_token',
+  })
+  @ApiResponse({ status: 401, description: 'LINE user id ไม่ถูกต้อง' })
   @Post('line-login-by-id')
   async lineLoginById(@Body() body: { lineUserId: string }) {
     return this.authService.signinWithLineUserId(body.lineUserId);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,15 +1,57 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 
+@ApiTags('Auth')
 @Controller('ecom/auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  @ApiOperation({
+    summary: 'เข้าสู่ระบบด้วย LINE access token (public)',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['lineAccessToken'],
+      properties: {
+        lineAccessToken: {
+          type: 'string',
+          description: 'Access token ที่ได้จาก LINE Login',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'เข้าสู่ระบบสำเร็จ คืนค่า token และ refresh_token',
+  })
+  @ApiResponse({ status: 401, description: 'LINE access token ไม่ถูกต้อง' })
   @Post('line-login')
   async lineLogin(@Body() body: { lineAccessToken: string }) {
     return this.authService.signinWithLine(body.lineAccessToken);
   }
 
+  @ApiOperation({
+    summary: 'เข้าสู่ระบบด้วย LINE user id โดยตรง (public)',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['lineUserId'],
+      properties: {
+        lineUserId: {
+          type: 'string',
+          description: 'LINE user id ของผู้ใช้',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'เข้าสู่ระบบสำเร็จ คืนค่า token และ refresh_token',
+  })
+  @ApiResponse({ status: 401, description: 'LINE user id ไม่ถูกต้อง' })
   @Post('line-login-by-id')
   async lineLoginById(@Body() body: { lineUserId: string }) {
     return this.authService.signinWithLineUserId(body.lineUserId);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -17,7 +17,8 @@ export class AuthController {
       properties: {
         lineAccessToken: {
           type: 'string',
-          description: 'Access token ที่ได้จาก LINE Login',
+          example: 'eyJhbGciOiJIUzI1NiJ9.line-access-token-example',
+          description: 'Required; not empty; Access token ที่ได้จาก LINE Login',
         },
       },
     },
@@ -42,7 +43,8 @@ export class AuthController {
       properties: {
         lineUserId: {
           type: 'string',
-          description: 'LINE user id ของผู้ใช้',
+          example: 'U1234567890abcdef1234567890abcdef',
+          description: 'Required; not empty; LINE user id ของผู้ใช้',
         },
       },
     },

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -138,7 +138,7 @@ export class AuthService {
     }
   }
 
-  async updateUserData(data: UserEntity) {
+  async updateUserData(data: Partial<UserEntity>) {
     try {
       await this.userRepo.update({ mem_code: data.mem_code }, { ...data });
       await this.updateDataToOldSystem(data);
@@ -148,7 +148,7 @@ export class AuthService {
     }
   }
 
-  async updateDataToOldSystem(data: UserEntity) {
+  async updateDataToOldSystem(data: Partial<UserEntity>) {
     // Skip external API call in dev mode
     if (process.env.DISABLE_EXTERNAL_API === 'true') {
       console.log('[DEV] External API call to wangpharma.com skipped');

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateCustomerDataDto {
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+
+  @ApiProperty({ example: 'ร้านยาตัวอย่าง', description: 'Required; not empty' })
+  mem_nameSite: string;
+
+  @ApiProperty({ example: 'pharmacy01', description: 'Required; not empty' })
+  mem_username: string;
+
+  @ApiProperty({ example: 'P@ssw0rd123', description: 'Required; not empty' })
+  mem_password: string;
+
+  @ApiProperty({ example: 'A', description: 'Required; not empty' })
+  mem_price: string;
+
+  @ApiProperty({ example: 'E001', description: 'Required; not empty' })
+  emp_saleoffice: string;
+
+  @ApiProperty({ example: '2026-06-01', description: 'Required; not empty' })
+  latest_purchase: string;
+
+  @ApiPropertyOptional({ example: 'E001', description: 'Optional; empty string allowed' })
+  emp_id_ref?: string | null;
+}
+
+export class RefreshTokenDto {
+  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIs...', description: 'Required; not empty; refresh token' })
+  token: string;
+}

--- a/src/auth/dto/signin.dto.ts
+++ b/src/auth/dto/signin.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SigninDto {
+  @ApiProperty({ example: 'pharmacy01', description: 'Required; not empty' })
+  username: string;
+
+  @ApiProperty({ example: 'P@ssw0rd123', description: 'Required; not empty' })
+  password: string;
+}

--- a/src/backend/dto/upload-log-file.dto.ts
+++ b/src/backend/dto/upload-log-file.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UploadLogFileDto {
+  @ApiProperty({ example: 'wangday-import', description: 'Required; not empty' })
+  feature: string;
+
+  @ApiProperty({ example: 'import-2026-06-23.csv', description: 'Required; not empty' })
+  filename: string;
+}

--- a/src/banner/dto/create-banner-from-url.dto.ts
+++ b/src/banner/dto/create-banner-from-url.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateBannerFromUrlDto {
+  @ApiProperty({ example: 'https://cdn.wangpharma.com/banners/abc.jpg', description: 'Required' })
+  img_url: string;
+
+  @ApiPropertyOptional({ example: 'Summer Sale', description: 'Optional; empty string allowed' })
+  banner_name?: string;
+
+  @ApiPropertyOptional({
+    enum: ['store_carousel', 'landing_hero', 'popup', 'sidebar'],
+    example: 'landing_hero',
+    description: 'Optional',
+  })
+  banner_location?: 'store_carousel' | 'landing_hero' | 'popup' | 'sidebar';
+
+  @ApiProperty({ example: '2026-07-01T00:00:00Z', description: 'Required' })
+  date_start: Date;
+
+  @ApiProperty({ example: '2026-07-31T23:59:59Z', description: 'Required' })
+  date_end: Date;
+}

--- a/src/banner/dto/update-banner.dto.ts
+++ b/src/banner/dto/update-banner.dto.ts
@@ -1,0 +1,90 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateBannerDto {
+  @ApiPropertyOptional({
+    example: 'https://wang-storage.sgp1.digitaloceanspaces.com/banners/summer.jpg',
+    description: 'Optional; empty string allowed',
+  })
+  banner_image?: string;
+
+  @ApiPropertyOptional({ example: 'Summer Sale', description: 'Optional; empty string allowed' })
+  banner_name?: string;
+
+  @ApiPropertyOptional({
+    enum: ['store_carousel', 'landing_hero', 'popup', 'sidebar'],
+    example: 'landing_hero',
+    description: 'Optional',
+  })
+  banner_location?: 'store_carousel' | 'landing_hero' | 'popup' | 'sidebar';
+
+  @ApiPropertyOptional({ example: '2026-07-01T00:00:00Z', description: 'Optional' })
+  date_start?: Date;
+
+  @ApiPropertyOptional({ example: '2026-07-31T23:59:59Z', description: 'Optional' })
+  date_end?: Date;
+
+  @ApiPropertyOptional({ example: 'https://wangpharma.com/promo', description: 'Optional; empty string allowed' })
+  link_url?: string;
+
+  @ApiPropertyOptional({ example: true, description: 'Optional; defaults to true' })
+  is_active?: boolean;
+
+  @ApiPropertyOptional({
+    enum: ['image_only', 'text_only', 'image_with_text'],
+    example: 'image_with_text',
+    description: 'Optional',
+  })
+  display_type?: 'image_only' | 'text_only' | 'image_with_text';
+
+  @ApiPropertyOptional({ example: 'ลดราคาช่วงซัมเมอร์', description: 'Optional; empty string allowed' })
+  title?: string;
+
+  @ApiPropertyOptional({ example: 'สูงสุด 50%', description: 'Optional; empty string allowed' })
+  subtitle?: string;
+
+  @ApiPropertyOptional({ example: 'โปรโมชั่นพิเศษเฉพาะเดือนนี้', description: 'Optional; empty string allowed' })
+  description?: string;
+
+  @ApiPropertyOptional({ example: 'ดูเพิ่มเติม', description: 'Optional; empty string allowed' })
+  cta_text?: string;
+
+  @ApiPropertyOptional({ example: 'https://wangpharma.com/promo', description: 'Optional; empty string allowed' })
+  cta_url?: string;
+
+  @ApiPropertyOptional({ example: 'ปิด', description: 'Optional; empty string allowed' })
+  cta_secondary_text?: string;
+
+  @ApiPropertyOptional({ example: '', description: 'Optional; empty string allowed' })
+  cta_secondary_url?: string;
+
+  @ApiPropertyOptional({ enum: ['light', 'dark'], example: 'light', description: 'Optional; defaults to dark' })
+  text_color?: 'light' | 'dark';
+
+  @ApiPropertyOptional({
+    enum: ['left', 'center', 'right'],
+    example: 'center',
+    description: 'Optional; defaults to left',
+  })
+  text_position?: 'left' | 'center' | 'right';
+
+  @ApiPropertyOptional({
+    example: 'linear-gradient(90deg,#000,#fff)',
+    description: 'Optional; empty string allowed',
+  })
+  bg_gradient?: string;
+
+  @ApiPropertyOptional({ example: 1, description: 'Optional; defaults to 0' })
+  sort_order?: number;
+
+  @ApiPropertyOptional({ example: false, description: 'Optional; defaults to false' })
+  is_drug?: boolean;
+
+  @ApiPropertyOptional({ example: 'ADV001', description: 'Optional; empty string allowed' })
+  advertise_code?: string;
+
+  @ApiPropertyOptional({ example: 'V001', description: 'Optional; empty string allowed' })
+  creditor?: string;
+
+  @ApiPropertyOptional({ example: 'A001,A002,A003', description: 'Optional; empty string allowed' })
+  product_list?: string;
+}

--- a/src/banner/dto/upload-banner.dto.ts
+++ b/src/banner/dto/upload-banner.dto.ts
@@ -1,0 +1,80 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UploadBannerDto {
+  @ApiProperty({ type: 'string', format: 'binary', description: 'Banner image file (required)' })
+  file: unknown;
+
+  @ApiProperty({ example: '2026-07-01T00:00:00Z', description: 'Required' })
+  date_start: Date;
+
+  @ApiProperty({ example: '2026-07-31T23:59:59Z', description: 'Required' })
+  date_end: Date;
+
+  @ApiPropertyOptional({ example: 'Summer Sale', description: 'Optional; empty string allowed' })
+  banner_name?: string;
+
+  @ApiPropertyOptional({
+    enum: ['store_carousel', 'landing_hero', 'popup', 'sidebar'],
+    example: 'landing_hero',
+    description: 'Optional',
+  })
+  banner_location?: 'store_carousel' | 'landing_hero' | 'popup' | 'sidebar';
+
+  @ApiPropertyOptional({ example: 'https://wangpharma.com/promo', description: 'Optional; empty string allowed' })
+  link_url?: string;
+
+  @ApiPropertyOptional({
+    enum: ['image_only', 'text_only', 'image_with_text'],
+    example: 'image_with_text',
+    description: 'Optional',
+  })
+  display_type?: 'image_only' | 'text_only' | 'image_with_text';
+
+  @ApiPropertyOptional({ example: 'ลดราคาช่วงซัมเมอร์', description: 'Optional; empty string allowed' })
+  title?: string;
+
+  @ApiPropertyOptional({ example: 'สูงสุด 50%', description: 'Optional; empty string allowed' })
+  subtitle?: string;
+
+  @ApiPropertyOptional({ example: 'โปรโมชั่นพิเศษเฉพาะเดือนนี้', description: 'Optional; empty string allowed' })
+  description?: string;
+
+  @ApiPropertyOptional({ example: 'ดูเพิ่มเติม', description: 'Optional; empty string allowed' })
+  cta_text?: string;
+
+  @ApiPropertyOptional({ example: 'https://wangpharma.com/promo', description: 'Optional; empty string allowed' })
+  cta_url?: string;
+
+  @ApiPropertyOptional({ example: 'ปิด', description: 'Optional; empty string allowed' })
+  cta_secondary_text?: string;
+
+  @ApiPropertyOptional({ example: '', description: 'Optional; empty string allowed' })
+  cta_secondary_url?: string;
+
+  @ApiPropertyOptional({ enum: ['light', 'dark'], example: 'light', description: 'Optional' })
+  text_color?: 'light' | 'dark';
+
+  @ApiPropertyOptional({ enum: ['left', 'center', 'right'], example: 'center', description: 'Optional' })
+  text_position?: 'left' | 'center' | 'right';
+
+  @ApiPropertyOptional({
+    example: 'linear-gradient(90deg,#000,#fff)',
+    description: 'Optional; empty string allowed',
+  })
+  bg_gradient?: string;
+
+  @ApiPropertyOptional({ example: false, description: 'Optional' })
+  is_drug?: boolean;
+
+  @ApiPropertyOptional({ example: 'ADV001', description: 'Optional; empty string allowed' })
+  advertise_code?: string;
+
+  @ApiPropertyOptional({ example: 'C001', description: 'Optional; empty string allowed' })
+  creditor?: string;
+
+  @ApiPropertyOptional({
+    example: 'P00123,P00124',
+    description: 'Optional comma-separated product codes; empty string allowed',
+  })
+  product_list?: string;
+}

--- a/src/change-password/dto/change-password.dto.ts
+++ b/src/change-password/dto/change-password.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class RequestOtpDto {
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+}
+
+export class ValidateOtpDto {
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_username: string;
+
+  @ApiProperty({ example: '123456', description: 'Required; not empty' })
+  otp: string;
+
+  @ApiProperty({ example: '2026-06-23T10:00:00.000Z', description: 'Required; ISO datetime' })
+  timeNow: string;
+}
+
+export class ChangePasswordDto {
+  @ApiProperty({ example: 'NewP@ssw0rd', description: 'Required; not empty' })
+  new_password: string;
+
+  @ApiProperty({ example: 'OldP@ssw0rd', description: 'Required; not empty' })
+  old_password: string;
+
+  @ApiPropertyOptional({ example: false, description: 'Optional; defaults to false' })
+  logout_all_devices?: boolean;
+}
+
+export class ResetPasswordDto {
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_username: string;
+
+  @ApiProperty({ example: 'NewP@ssw0rd', description: 'Required; not empty' })
+  new_password: string;
+
+  @ApiProperty({ example: '123456', description: 'Required; not empty' })
+  otp: string;
+}

--- a/src/common/dto-index.ts
+++ b/src/common/dto-index.ts
@@ -1,0 +1,129 @@
+// App Version
+export * from '../app-version/dto/check-app-version.dto';
+export * from '../app-version/dto/create-app-version.dto';
+export * from '../app-version/dto/legacy-check-app-version.dto';
+export * from '../app-version/dto/update-app-version.dto';
+
+// Auth
+export * from '../auth/dto/auth.dto';
+export * from '../auth/dto/signin.dto';
+
+// Backend
+export * from '../backend/dto/upload-log-file.dto';
+
+// Banner
+export * from '../banner/dto/create-banner-from-url.dto';
+export * from '../banner/dto/update-banner.dto';
+export * from '../banner/dto/upload-banner.dto';
+
+// Change Password
+export * from '../change-password/dto/change-password.dto';
+
+// Company Day Analytic
+export * from '../company-day-analytic/dto/track-company-day-view.dto';
+
+// Debtor
+export * from '../debtor/dto/debtor.dto';
+
+// Delivery Preference
+export * from '../delivery-preference/dto/set-preference.dto';
+
+// Edit Address
+export * from '../edit-address/dto/create-address.dto';
+
+// Favorite
+export * from '../favorite/dto/add-to-favorite.dto';
+export * from '../favorite/dto/delete-favorite.dto';
+
+// Feature Flags
+export * from '../feature-flags/dto/update-flag.dto';
+
+// Fix Free
+export * from '../fix-free/dto/fix-free.dto';
+
+// Flashsale
+export * from '../flashsale/dto/flashsale.dto';
+
+// Happy Hour
+export * from '../happy-hour/dto/cart-preview.dto';
+export * from '../happy-hour/dto/config-log-query.dto';
+export * from '../happy-hour/dto/create-slot.dto';
+export * from '../happy-hour/dto/simulate.dto';
+export * from '../happy-hour/dto/slot-log-query.dto';
+export * from '../happy-hour/dto/update-config.dto';
+export * from '../happy-hour/dto/update-slot.dto';
+
+// Hotdeal
+export * from '../hotdeal/dto/check-hotdeal-match.dto';
+export * from '../hotdeal/dto/delete-hotdeal.dto';
+export * from '../hotdeal/dto/save-hotdeal.dto';
+
+// Invisible Product
+export * from '../invisible-product/dto/invisible-product.dto';
+
+// LINE Register Meeting
+export * from '../line-register-meeting/dto/register-meeting.dto';
+
+// Lot
+export * from '../lot/dto/add-lots.dto';
+
+// Modal Main
+export * from '../modalmain/dto/save-modal-content.dto';
+
+// New Arrivals
+export * from '../new-arrivals/dto/new-arrival-item.dto';
+
+// Product Keyword
+export * from '../product-keyword/dto/update-keysearch.dto';
+
+// Products
+export * from '../products/dto/add-creditor.dto';
+export * from '../products/dto/back-office.dto';
+export * from '../products/dto/get-flashsale.dto';
+export * from '../products/dto/get-product-detail.dto';
+export * from '../products/dto/product-for-you.dto';
+export * from '../products/dto/search-category-products.dto';
+export * from '../products/dto/search-products.dto';
+export * from '../products/dto/upload-po-item.dto';
+export * from '../products/dto/upload-product-flashsale-item.dto';
+export * from '../products/dto/upload-product-l16.dto';
+export * from '../products/update-product-image.dto';
+
+// Promotion
+export * from '../promotion/dto/add-promotion-condition.dto';
+export * from '../promotion/dto/add-promotion-reward.dto';
+export * from '../promotion/dto/add-promotion.dto';
+export * from '../promotion/dto/add-tier.dto';
+export * from '../promotion/dto/delete-promotion-condition.dto';
+export * from '../promotion/dto/delete-promotion-reward.dto';
+export * from '../promotion/dto/delete-promotion.dto';
+export * from '../promotion/dto/delete-tier.dto';
+export * from '../promotion/dto/duplicate-promotion.dto';
+export * from '../promotion/dto/edit-promotion-reward.dto';
+export * from '../promotion/dto/edit-tier.dto';
+export * from '../promotion/dto/generate-code-promotion.dto';
+export * from '../promotion/dto/get-product-by-creditor.dto';
+export * from '../promotion/dto/get-product-tier.dto';
+export * from '../promotion/dto/update-promo-poster.dto';
+export * from '../promotion/dto/update-promotion-status.dto';
+export * from '../promotion/dto/update-promotion.dto';
+export * from '../promotion/dto/use-code-for-check-reward.dto';
+
+// Sessions
+export * from '../sessions/dto/sessions.dto';
+
+// Shopping Cart
+export * from '../shopping-cart/dto/add-product-cart.dto';
+export * from '../shopping-cart/dto/check-product-cart-all.dto';
+export * from '../shopping-cart/dto/check-product-cart.dto';
+export * from '../shopping-cart/dto/delete-product-cart.dto';
+
+// Shopping Order
+export * from '../shopping-order/dto/submit-order.dto';
+
+// Users
+export * from '../users/dto/update-user-data.dto';
+export * from '../users/dto/upload-image-user.dto';
+
+// Wangday
+export * from '../wangday/dto/import-wangday.dto';

--- a/src/common/swagger-helpers.ts
+++ b/src/common/swagger-helpers.ts
@@ -1,0 +1,20 @@
+import { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
+
+type SwaggerProp = SchemaObject & { optional?: boolean };
+
+/** Builds an OpenAPI object schema from a flat prop map; fields are required unless `optional: true` is set. */
+export function objectSchema(props: Record<string, SwaggerProp>): SchemaObject {
+  const properties: Record<string, SchemaObject> = {};
+  const required: string[] = [];
+  for (const [key, spec] of Object.entries(props)) {
+    const { optional, ...rest } = spec;
+    properties[key] = rest;
+    if (!optional) required.push(key);
+  }
+  return required.length ? { type: 'object', properties, required } : { type: 'object', properties };
+}
+
+/** Builds an OpenAPI array-of-objects schema from a flat prop map (same shorthand as objectSchema). */
+export function arraySchema(props: Record<string, SwaggerProp>): SchemaObject {
+  return { type: 'array', items: objectSchema(props) };
+}

--- a/src/company-day-analytic/dto/track-company-day-view.dto.ts
+++ b/src/company-day-analytic/dto/track-company-day-view.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TrackCompanyDayViewDto {
+  @ApiProperty({ example: 5, description: 'Required' })
+  promo_id: number;
+
+  @ApiProperty({ example: 'Company Day มิถุนายน', description: 'Required; not empty' })
+  promo_name: string;
+
+  @ApiProperty({ example: 'Gold', description: 'Required; not empty' })
+  tier: string;
+
+  @ApiProperty({ example: 'banner', description: 'Required; not empty' })
+  source: string;
+}

--- a/src/debtor/dto/debtor.dto.ts
+++ b/src/debtor/dto/debtor.dto.ts
@@ -1,0 +1,84 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ImportInvoiceBillItemDto {
+  @ApiProperty({ example: '2026-06-23', description: 'Required; format YYYY-MM-DD' })
+  date: string;
+
+  @ApiProperty({ example: 'INV00123', description: 'Required; not empty' })
+  invoice: string;
+
+  @ApiProperty({ example: '500.00', description: 'Required; not empty' })
+  price: string;
+
+  @ApiProperty({ example: '', description: 'Optional; empty string allowed' })
+  comments: string;
+}
+
+export class ImportDataInvoiceDto {
+  @ApiProperty({ example: '2026-06-23', description: 'Required; format YYYY-MM-DD' })
+  date: string;
+
+  @ApiProperty({ example: 'INV00123', description: 'Required; not empty' })
+  invoice: string;
+
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+
+  @ApiProperty({ example: '2026-07-23', description: 'Required; format YYYY-MM-DD' })
+  date_due: string;
+
+  @ApiProperty({ example: '1000.00', description: 'Required; not empty' })
+  total: string;
+
+  @ApiProperty({ example: '500.00', description: 'Required; not empty' })
+  payment: string;
+
+  @ApiProperty({ example: '500.00', description: 'Required; not empty' })
+  balance: string;
+
+  @ApiProperty({ type: [ImportInvoiceBillItemDto] })
+  bill_list: ImportInvoiceBillItemDto[];
+}
+
+export class ImportRtProductItemDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiProperty({ example: 'ยาพาราเซตามอล', description: 'Required; not empty' })
+  pro_name: string;
+
+  @ApiProperty({ example: '10', description: 'Required; not empty' })
+  pro_amount: string;
+
+  @ApiProperty({ example: 'กล่อง', description: 'Required; not empty' })
+  pro_unit: string;
+
+  @ApiProperty({ example: '5.00', description: 'Required; not empty' })
+  pro_price_per_unit: string;
+
+  @ApiProperty({ example: '0.00', description: 'Required; not empty' })
+  pro_discount: string;
+}
+
+export class ImportDataRtDto {
+  @ApiProperty({ example: 'INV00123', description: 'Required; not empty' })
+  invoice: string;
+
+  @ApiProperty({ example: '2026-06-23', description: 'Required; format YYYY-MM-DD' })
+  date: string;
+
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+
+  @ApiProperty({ example: '10', description: 'Required; not empty' })
+  pro_amount: string;
+
+  @ApiProperty({ example: '50.00', description: 'Required; not empty' })
+  dis_price: string;
+
+  @ApiProperty({ example: '', description: 'Optional; empty string allowed' })
+  comments: string;
+
+  @ApiProperty({ type: [ImportRtProductItemDto] })
+  pro_list: ImportRtProductItemDto[];
+}

--- a/src/delivery-preference/delivery-preference.controller.ts
+++ b/src/delivery-preference/delivery-preference.controller.ts
@@ -12,7 +12,7 @@ import { Request } from 'express';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { JwtPayload } from '../app.controller';
 import { DeliveryPreferenceService } from './delivery-preference.service';
-import { SetPreferenceDto } from './dto/set-preference.dto';
+import { SetPreferenceDto } from 'src/common/dto-index';
 
 @UseGuards(JwtAuthGuard)
 @Controller('ecom/delivery-preference')

--- a/src/edit-address/dto/create-address.dto.ts
+++ b/src/edit-address/dto/create-address.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateAddressBodyDto {
+  @ApiPropertyOptional({ example: 'บ้าน', description: 'Optional; empty string allowed' })
+  name?: string;
+
+  @ApiProperty({ example: 'สมชาย ใจดี', description: 'Required; not empty' })
+  fullName: string;
+
+  @ApiPropertyOptional({ example: '99/1', description: 'Optional; empty string allowed' })
+  mem_address?: string;
+
+  @ApiPropertyOptional({ example: 'หมู่ 5', description: 'Optional; empty string allowed' })
+  mem_village?: string;
+
+  @ApiPropertyOptional({ example: 'ซอย 1', description: 'Optional; empty string allowed' })
+  mem_alley?: string;
+
+  @ApiPropertyOptional({ example: 'ถนนสุขุมวิท', description: 'Optional; empty string allowed' })
+  mem_road?: string;
+
+  @ApiProperty({ example: 'กรุงเทพมหานคร', description: 'Required; not empty' })
+  mem_province: string;
+
+  @ApiProperty({ example: 'บางนา', description: 'Required; not empty' })
+  mem_amphur: string;
+
+  @ApiProperty({ example: 'บางนา', description: 'Required; not empty' })
+  mem_tumbon: string;
+
+  @ApiProperty({ example: '10260', description: 'Required; not empty' })
+  mem_post: string;
+
+  @ApiProperty({ example: '0812345678', description: 'Required; not empty' })
+  phoneNumber: string;
+
+  @ApiPropertyOptional({ example: 'ฝากไว้กับยาม', description: 'Optional; empty string allowed' })
+  Note?: string;
+
+  @ApiPropertyOptional({ example: false, description: 'Optional; defaults to false' })
+  defaults?: boolean;
+
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+}

--- a/src/favorite/dto/add-to-favorite.dto.ts
+++ b/src/favorite/dto/add-to-favorite.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AddToFavoriteDto {
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+}

--- a/src/favorite/dto/delete-favorite.dto.ts
+++ b/src/favorite/dto/delete-favorite.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class DeleteFavoriteDto {
+  @ApiProperty({ example: 101, description: 'Required' })
+  fav_id: number;
+
+  @ApiProperty({ example: 'M00123', description: 'Required, but overridden by JWT member code' })
+  mem_code: string;
+
+  @ApiPropertyOptional({ example: 1, description: 'Optional' })
+  sort_by?: number;
+}

--- a/src/feature-flags/dto/update-flag.dto.ts
+++ b/src/feature-flags/dto/update-flag.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateFlagDto {
+  @ApiProperty({ example: 'new_checkout', description: 'Required' })
+  flag: string;
+
+  @ApiProperty({ example: true, description: 'Required' })
+  status: boolean;
+}

--- a/src/fix-free/dto/fix-free.dto.ts
+++ b/src/fix-free/dto/fix-free.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AddProductFreeDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiProperty({ example: 100, description: 'Required' })
+  pro_point: number;
+}
+
+export class DeleteProductFreeDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+}
+
+export class EditProductFreeDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiProperty({ example: 150, description: 'Required' })
+  pro_point: number;
+}

--- a/src/flashsale/dto/flashsale.dto.ts
+++ b/src/flashsale/dto/flashsale.dto.ts
@@ -1,0 +1,83 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AddFlashsaleDto {
+  @ApiProperty({ example: 'Flash Sale วันศุกร์', description: 'Required; not empty' })
+  promotion_name: string;
+
+  @ApiProperty({ example: '2026-07-03', description: 'Required; not empty' })
+  date: string;
+
+  @ApiProperty({ example: '10:00', description: 'Required; not empty' })
+  time_start: string;
+
+  @ApiProperty({ example: '14:00', description: 'Required; not empty' })
+  time_end: string;
+
+  @ApiProperty({ example: true, description: 'Required' })
+  is_active: boolean;
+}
+
+export class EditFlashsaleDto {
+  @ApiProperty({ example: 3, description: 'Required' })
+  promotion_id: number;
+
+  @ApiProperty({ example: 'Flash Sale วันหยุด', description: 'Required; not empty' })
+  promotion_name: string;
+
+  @ApiProperty({ example: '2026-06-23', description: 'Required; format YYYY-MM-DD' })
+  date: string;
+
+  @ApiProperty({ example: '09:00', description: 'Required; format HH:mm' })
+  time_start: string;
+
+  @ApiProperty({ example: '21:00', description: 'Required; format HH:mm' })
+  time_end: string;
+
+  @ApiProperty({ example: true, description: 'Required' })
+  is_active: boolean;
+}
+
+export class DeleteFlashsaleDto {
+  @ApiProperty({ example: 3, description: 'Required' })
+  id: number;
+}
+
+export class ChangeStatusFlashsaleDto {
+  @ApiProperty({ example: 10, description: 'Required' })
+  id: number;
+
+  @ApiProperty({ example: true, description: 'Required' })
+  is_active: boolean;
+}
+
+export class AddProductToFlashsaleDto {
+  @ApiProperty({ example: 3, description: 'Required' })
+  promotion_id: number;
+
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiProperty({ example: 50, description: 'Required' })
+  limit: number;
+}
+
+export class EditProductInFlashsaleDto {
+  @ApiProperty({ example: 10, description: 'Required' })
+  id: number;
+
+  @ApiProperty({ example: 50, description: 'Required' })
+  limit: number;
+}
+
+export class DeleteProductFlashsaleDto {
+  @ApiProperty({ example: 10, description: 'Required' })
+  id: number;
+}
+
+export class GetFlashsaleByDateDto {
+  @ApiPropertyOptional({ example: 20, description: 'Optional; max items to return' })
+  limit: number;
+
+  @ApiPropertyOptional({ example: 'M00123', description: 'Optional; overridden by JWT mem_code if present' })
+  mem_code: string;
+}

--- a/src/happy-hour/dto/cart-preview.dto.ts
+++ b/src/happy-hour/dto/cart-preview.dto.ts
@@ -7,21 +7,29 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CartItemDto {
+  @ApiProperty({ description: 'รหัสสินค้า' })
   @IsString()
   pro_code!: string;
 
+  @ApiProperty({ description: 'จำนวนสินค้าในตะกร้า ต้องไม่ติดลบ' })
   @IsNumber()
   @Min(0)
   amount!: number;
 }
 
 export class CartPreviewDto {
+  @ApiProperty({ description: 'ยอดสั่งซื้อรวมในตะกร้า ต้องไม่ติดลบ' })
   @IsNumber()
   @Min(0)
   order_amount!: number;
 
+  @ApiPropertyOptional({
+    description: 'รายการสินค้าในตะกร้า — ใช้คำนวณ scope filtering ของ Happy Hour',
+    type: [CartItemDto],
+  })
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })

--- a/src/happy-hour/dto/cart-preview.dto.ts
+++ b/src/happy-hour/dto/cart-preview.dto.ts
@@ -10,25 +10,32 @@ import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CartItemDto {
-  @ApiProperty({ description: 'รหัสสินค้า' })
+  @ApiProperty({ description: 'Required; not empty; รหัสสินค้า', example: 'A001' })
   @IsString()
   pro_code!: string;
 
-  @ApiProperty({ description: 'จำนวนสินค้าในตะกร้า ต้องไม่ติดลบ' })
+  @ApiProperty({
+    description: 'Required; จำนวนสินค้าในตะกร้า ต้องไม่ติดลบ',
+    example: 5,
+  })
   @IsNumber()
   @Min(0)
   amount!: number;
 }
 
 export class CartPreviewDto {
-  @ApiProperty({ description: 'ยอดสั่งซื้อรวมในตะกร้า ต้องไม่ติดลบ' })
+  @ApiProperty({
+    description: 'Required; ยอดสั่งซื้อรวมในตะกร้า ต้องไม่ติดลบ',
+    example: 1500,
+  })
   @IsNumber()
   @Min(0)
   order_amount!: number;
 
   @ApiPropertyOptional({
-    description: 'รายการสินค้าในตะกร้า — ใช้คำนวณ scope filtering ของ Happy Hour',
+    description: 'Optional; รายการสินค้าในตะกร้า — ใช้คำนวณ scope filtering ของ Happy Hour',
     type: [CartItemDto],
+    example: [{ pro_code: 'A001', amount: 5 }],
   })
   @IsOptional()
   @IsArray()

--- a/src/happy-hour/dto/cart-preview.dto.ts
+++ b/src/happy-hour/dto/cart-preview.dto.ts
@@ -7,21 +7,36 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CartItemDto {
+  @ApiProperty({ description: 'Required; not empty; รหัสสินค้า', example: 'A001' })
   @IsString()
   pro_code!: string;
 
+  @ApiProperty({
+    description: 'Required; จำนวนสินค้าในตะกร้า ต้องไม่ติดลบ',
+    example: 5,
+  })
   @IsNumber()
   @Min(0)
   amount!: number;
 }
 
 export class CartPreviewDto {
+  @ApiProperty({
+    description: 'Required; ยอดสั่งซื้อรวมในตะกร้า ต้องไม่ติดลบ',
+    example: 1500,
+  })
   @IsNumber()
   @Min(0)
   order_amount!: number;
 
+  @ApiPropertyOptional({
+    description: 'Optional; รายการสินค้าในตะกร้า — ใช้คำนวณ scope filtering ของ Happy Hour',
+    type: [CartItemDto],
+    example: [{ pro_code: 'A001', amount: 5 }],
+  })
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })

--- a/src/happy-hour/dto/config-log-query.dto.ts
+++ b/src/happy-hour/dto/config-log-query.dto.ts
@@ -1,23 +1,45 @@
 import { IsIn, IsInt, IsOptional, IsString, Min } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ConfigLogQueryDto {
   /** กรองตาม action: UPDATE | TOGGLE */
+  @ApiPropertyOptional({
+    description: 'Optional; กรองตาม action',
+    enum: ['UPDATE', 'TOGGLE'],
+    example: 'TOGGLE',
+  })
   @IsOptional()
   @IsIn(['UPDATE', 'TOGGLE'])
   action?: 'UPDATE' | 'TOGGLE';
 
   /** กรองตามผู้ดำเนินการ (บางส่วนก็ได้) */
+  @ApiPropertyOptional({
+    description: 'Optional; กรองตามผู้ดำเนินการ (username, ค้นหาแบบบางส่วนได้)',
+    example: 'admin01',
+  })
   @IsOptional()
   @IsString()
   performed_by?: string;
 
+  @ApiPropertyOptional({
+    description: 'Optional; defaults to 1; หน้าที่ต้องการ',
+    type: Number,
+    default: 1,
+    example: 1,
+  })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Optional; defaults to 20; จำนวนรายการต่อหน้า',
+    type: Number,
+    default: 20,
+    example: 20,
+  })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()

--- a/src/happy-hour/dto/config-log-query.dto.ts
+++ b/src/happy-hour/dto/config-log-query.dto.ts
@@ -1,23 +1,32 @@
 import { IsIn, IsInt, IsOptional, IsString, Min } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ConfigLogQueryDto {
   /** กรองตาม action: UPDATE | TOGGLE */
+  @ApiPropertyOptional({ description: 'กรองตาม action', enum: ['UPDATE', 'TOGGLE'] })
   @IsOptional()
   @IsIn(['UPDATE', 'TOGGLE'])
   action?: 'UPDATE' | 'TOGGLE';
 
   /** กรองตามผู้ดำเนินการ (บางส่วนก็ได้) */
+  @ApiPropertyOptional({ description: 'กรองตามผู้ดำเนินการ (username, ค้นหาแบบบางส่วนได้)' })
   @IsOptional()
   @IsString()
   performed_by?: string;
 
+  @ApiPropertyOptional({ description: 'หน้าที่ต้องการ (default 1)', type: Number, default: 1 })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'จำนวนรายการต่อหน้า (default 20)',
+    type: Number,
+    default: 20,
+  })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()

--- a/src/happy-hour/dto/config-log-query.dto.ts
+++ b/src/happy-hour/dto/config-log-query.dto.ts
@@ -4,18 +4,30 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ConfigLogQueryDto {
   /** กรองตาม action: UPDATE | TOGGLE */
-  @ApiPropertyOptional({ description: 'กรองตาม action', enum: ['UPDATE', 'TOGGLE'] })
+  @ApiPropertyOptional({
+    description: 'Optional; กรองตาม action',
+    enum: ['UPDATE', 'TOGGLE'],
+    example: 'TOGGLE',
+  })
   @IsOptional()
   @IsIn(['UPDATE', 'TOGGLE'])
   action?: 'UPDATE' | 'TOGGLE';
 
   /** กรองตามผู้ดำเนินการ (บางส่วนก็ได้) */
-  @ApiPropertyOptional({ description: 'กรองตามผู้ดำเนินการ (username, ค้นหาแบบบางส่วนได้)' })
+  @ApiPropertyOptional({
+    description: 'Optional; กรองตามผู้ดำเนินการ (username, ค้นหาแบบบางส่วนได้)',
+    example: 'admin01',
+  })
   @IsOptional()
   @IsString()
   performed_by?: string;
 
-  @ApiPropertyOptional({ description: 'หน้าที่ต้องการ (default 1)', type: Number, default: 1 })
+  @ApiPropertyOptional({
+    description: 'Optional; defaults to 1; หน้าที่ต้องการ',
+    type: Number,
+    default: 1,
+    example: 1,
+  })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()
@@ -23,9 +35,10 @@ export class ConfigLogQueryDto {
   page?: number = 1;
 
   @ApiPropertyOptional({
-    description: 'จำนวนรายการต่อหน้า (default 20)',
+    description: 'Optional; defaults to 20; จำนวนรายการต่อหน้า',
     type: Number,
     default: 20,
+    example: 20,
   })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))

--- a/src/happy-hour/dto/create-slot.dto.ts
+++ b/src/happy-hour/dto/create-slot.dto.ts
@@ -14,7 +14,7 @@ import { RewardType, MinOrderScope } from '../happy-hour-slot.entity';
 
 export class CreateSlotDto {
   @ApiProperty({
-    description: 'เวลาเริ่มต้นของ slot รูปแบบ HH:mm (00:00–23:59)',
+    description: 'Required; not empty; เวลาเริ่มต้นของ slot รูปแบบ HH:mm (00:00–23:59)',
     example: '09:00',
   })
   @Matches(/^([01]\d|2[0-3]):[0-5]\d$/, {
@@ -23,7 +23,7 @@ export class CreateSlotDto {
   start_time!: string;
 
   @ApiProperty({
-    description: 'เวลาสิ้นสุดของ slot รูปแบบ HH:mm (00:00–24:00)',
+    description: 'Required; not empty; เวลาสิ้นสุดของ slot รูปแบบ HH:mm (00:00–24:00)',
     example: '12:00',
   })
   @Matches(/^(([01]\d|2[0-3]):[0-5]\d|24:00)$/, {
@@ -31,36 +31,52 @@ export class CreateSlotDto {
   })
   end_time!: string;
 
-  @ApiProperty({ description: 'ยอดสั่งซื้อขั้นต่ำที่ต้องถึงเพื่อรับสิทธิ์ (ต้องมากกว่า 0)' })
+  @ApiProperty({
+    description: 'Required; ยอดสั่งซื้อขั้นต่ำที่ต้องถึงเพื่อรับสิทธิ์ (ต้องมากกว่า 0)',
+    example: 1000,
+  })
   @IsNumber()
   @Min(1, { message: 'min_order_amount ต้องมากกว่า 0' })
   min_order_amount!: number;
 
-  @ApiPropertyOptional({ description: 'มูลค่าบัตร (card_value) สำหรับ reward แบบ card' })
+  @ApiPropertyOptional({
+    description: 'Optional; มูลค่าบัตร (card_value) สำหรับ reward แบบ card',
+    example: 100,
+  })
   @IsOptional()
   @IsNumber()
   card_value!: number;
 
-  @ApiPropertyOptional({ description: 'เกณฑ์ส่วนเกิน (excess_threshold) ต้องไม่ติดลบ' })
+  @ApiPropertyOptional({
+    description: 'Optional; เกณฑ์ส่วนเกิน (excess_threshold) ต้องไม่ติดลบ',
+    example: 500,
+  })
   @IsOptional()
   @IsNumber()
   @Min(0, { message: 'excess_threshold ต้องไม่ติดลบ' })
   excess_threshold?: number;
 
-  @ApiPropertyOptional({ description: 'ส่วนลดต่อขั้น (discount_per_step) ต้องไม่ติดลบ' })
+  @ApiPropertyOptional({
+    description: 'Optional; ส่วนลดต่อขั้น (discount_per_step) ต้องไม่ติดลบ',
+    example: 50,
+  })
   @IsOptional()
   @IsNumber()
   @Min(0, { message: 'discount_per_step ต้องไม่ติดลบ' })
   discount_per_step?: number;
 
-  @ApiPropertyOptional({ description: 'สถานะเปิดใช้งาน slot นี้หรือไม่' })
+  @ApiPropertyOptional({
+    description: 'Optional; defaults to true; สถานะเปิดใช้งาน slot นี้หรือไม่',
+    example: true,
+  })
   @IsOptional()
   @IsBoolean()
   is_active?: boolean;
 
   @ApiPropertyOptional({
-    description: 'รหัสสินค้าที่เป็นของแถม (reward) สำหรับ slot นี้',
+    description: 'Optional; รหัสสินค้าที่เป็นของแถม (reward) สำหรับ slot นี้',
     type: [String],
+    example: ['A001', 'A002'],
   })
   @IsOptional()
   @IsArray()
@@ -68,22 +84,27 @@ export class CreateSlotDto {
   reward_pro_codes?: string[];
 
   @ApiPropertyOptional({
-    description: 'จำนวนของแถมที่สัมพันธ์กับ reward_pro_codes แต่ละตัว',
+    description: 'Optional; จำนวนของแถมที่สัมพันธ์กับ reward_pro_codes แต่ละตัว',
     type: [Number],
+    example: [1, 2],
   })
   @IsOptional()
   @IsArray()
   @IsNumber({}, { each: true })
   reward_amounts?: number[];
 
-  @ApiPropertyOptional({ description: 'จำนวนของแถม (ต้องมากกว่า 0)' })
+  @ApiPropertyOptional({
+    description: 'Optional; จำนวนของแถม (ต้องมากกว่า 0)',
+    example: 1,
+  })
   @IsOptional()
   @IsNumber()
   @Min(1, { message: 'reward_amount ต้องมากกว่า 0' })
   reward_amount?: number;
 
   @ApiPropertyOptional({
-    description: 'วันที่เริ่มต้นโปรโมชั่น (ISO date string) หรือ null',
+    description: 'Optional; nullable; วันที่เริ่มต้นโปรโมชั่น (ISO date string) หรือ null',
+    example: '2026-06-01T00:00:00.000Z',
     nullable: true,
   })
   @IsOptional()
@@ -91,7 +112,8 @@ export class CreateSlotDto {
   promo_start_date?: string | null;
 
   @ApiPropertyOptional({
-    description: 'วันที่สิ้นสุดโปรโมชั่น (ISO date string) หรือ null',
+    description: 'Optional; nullable; วันที่สิ้นสุดโปรโมชั่น (ISO date string) หรือ null',
+    example: '2026-06-30T23:59:59.000Z',
     nullable: true,
   })
   @IsOptional()
@@ -99,30 +121,36 @@ export class CreateSlotDto {
   promo_end_date?: string | null;
 
   @ApiPropertyOptional({
-    description: 'ประเภทของรางวัล',
+    description: 'Optional; ประเภทของรางวัล',
     enum: ['card', 'bill_discount'],
+    example: 'card',
   })
   @IsOptional()
   @IsEnum(['card', 'bill_discount'], { message: 'reward_type ต้องเป็น card หรือ bill_discount' })
   reward_type?: RewardType;
 
-  @ApiPropertyOptional({ description: 'มูลค่ารางวัล (reward_value) ต้องไม่ติดลบ' })
+  @ApiPropertyOptional({
+    description: 'Optional; มูลค่ารางวัล (reward_value) ต้องไม่ติดลบ',
+    example: 50,
+  })
   @IsOptional()
   @IsNumber()
   @Min(0, { message: 'reward_value ต้องไม่ติดลบ' })
   reward_value?: number;
 
   @ApiPropertyOptional({
-    description: 'ขอบเขตการคำนวณยอดสั่งซื้อขั้นต่ำ',
+    description: 'Optional; ขอบเขตการคำนวณยอดสั่งซื้อขั้นต่ำ',
     enum: ['all', 'specific', 'vendor'],
+    example: 'all',
   })
   @IsOptional()
   @IsEnum(['all', 'specific', 'vendor'], { message: 'min_order_scope ต้องเป็น all, specific หรือ vendor' })
   min_order_scope?: MinOrderScope;
 
   @ApiPropertyOptional({
-    description: 'รหัสสินค้าที่ใช้นับยอดขั้นต่ำเมื่อ min_order_scope = specific',
+    description: 'Optional; รหัสสินค้าที่ใช้นับยอดขั้นต่ำเมื่อ min_order_scope = specific',
     type: [String],
+    example: ['A001', 'A002'],
   })
   @IsOptional()
   @IsArray()
@@ -130,7 +158,8 @@ export class CreateSlotDto {
   min_order_pro_codes?: string[];
 
   @ApiPropertyOptional({
-    description: 'รหัสเจ้าหนี้/vendor ที่ใช้นับยอดขั้นต่ำเมื่อ min_order_scope = vendor',
+    description: 'Optional; nullable; รหัสเจ้าหนี้/vendor ที่ใช้นับยอดขั้นต่ำเมื่อ min_order_scope = vendor',
+    example: 'V001',
     nullable: true,
   })
   @IsOptional()

--- a/src/happy-hour/dto/create-slot.dto.ts
+++ b/src/happy-hour/dto/create-slot.dto.ts
@@ -9,82 +9,159 @@ import {
   Matches,
   Min,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { RewardType, MinOrderScope } from '../happy-hour-slot.entity';
 
 export class CreateSlotDto {
+  @ApiProperty({
+    description: 'Required; not empty; เวลาเริ่มต้นของ slot รูปแบบ HH:mm (00:00–23:59)',
+    example: '09:00',
+  })
   @Matches(/^([01]\d|2[0-3]):[0-5]\d$/, {
     message: 'start_time ต้องอยู่ในรูปแบบ HH:mm (00:00–23:59)',
   })
   start_time!: string;
 
+  @ApiProperty({
+    description: 'Required; not empty; เวลาสิ้นสุดของ slot รูปแบบ HH:mm (00:00–24:00)',
+    example: '12:00',
+  })
   @Matches(/^(([01]\d|2[0-3]):[0-5]\d|24:00)$/, {
     message: 'end_time ต้องอยู่ในรูปแบบ HH:mm (00:00–24:00)',
   })
   end_time!: string;
 
+  @ApiProperty({
+    description: 'Required; ยอดสั่งซื้อขั้นต่ำที่ต้องถึงเพื่อรับสิทธิ์ (ต้องมากกว่า 0)',
+    example: 1000,
+  })
   @IsNumber()
   @Min(1, { message: 'min_order_amount ต้องมากกว่า 0' })
   min_order_amount!: number;
 
+  @ApiPropertyOptional({
+    description: 'Optional; มูลค่าบัตร (card_value) สำหรับ reward แบบ card',
+    example: 100,
+  })
   @IsOptional()
   @IsNumber()
   card_value!: number;
 
+  @ApiPropertyOptional({
+    description: 'Optional; เกณฑ์ส่วนเกิน (excess_threshold) ต้องไม่ติดลบ',
+    example: 500,
+  })
   @IsOptional()
   @IsNumber()
   @Min(0, { message: 'excess_threshold ต้องไม่ติดลบ' })
   excess_threshold?: number;
 
+  @ApiPropertyOptional({
+    description: 'Optional; ส่วนลดต่อขั้น (discount_per_step) ต้องไม่ติดลบ',
+    example: 50,
+  })
   @IsOptional()
   @IsNumber()
   @Min(0, { message: 'discount_per_step ต้องไม่ติดลบ' })
   discount_per_step?: number;
 
+  @ApiPropertyOptional({
+    description: 'Optional; defaults to true; สถานะเปิดใช้งาน slot นี้หรือไม่',
+    example: true,
+  })
   @IsOptional()
   @IsBoolean()
   is_active?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Optional; รหัสสินค้าที่เป็นของแถม (reward) สำหรับ slot นี้',
+    type: [String],
+    example: ['A001', 'A002'],
+  })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
   reward_pro_codes?: string[];
 
+  @ApiPropertyOptional({
+    description: 'Optional; จำนวนของแถมที่สัมพันธ์กับ reward_pro_codes แต่ละตัว',
+    type: [Number],
+    example: [1, 2],
+  })
   @IsOptional()
   @IsArray()
   @IsNumber({}, { each: true })
   reward_amounts?: number[];
 
+  @ApiPropertyOptional({
+    description: 'Optional; จำนวนของแถม (ต้องมากกว่า 0)',
+    example: 1,
+  })
   @IsOptional()
   @IsNumber()
   @Min(1, { message: 'reward_amount ต้องมากกว่า 0' })
   reward_amount?: number;
 
+  @ApiPropertyOptional({
+    description: 'Optional; nullable; วันที่เริ่มต้นโปรโมชั่น (ISO date string) หรือ null',
+    example: '2026-06-01T00:00:00.000Z',
+    nullable: true,
+  })
   @IsOptional()
   @IsDateString()
   promo_start_date?: string | null;
 
+  @ApiPropertyOptional({
+    description: 'Optional; nullable; วันที่สิ้นสุดโปรโมชั่น (ISO date string) หรือ null',
+    example: '2026-06-30T23:59:59.000Z',
+    nullable: true,
+  })
   @IsOptional()
   @IsDateString()
   promo_end_date?: string | null;
 
+  @ApiPropertyOptional({
+    description: 'Optional; ประเภทของรางวัล',
+    enum: ['card', 'bill_discount'],
+    example: 'card',
+  })
   @IsOptional()
   @IsEnum(['card', 'bill_discount'], { message: 'reward_type ต้องเป็น card หรือ bill_discount' })
   reward_type?: RewardType;
 
+  @ApiPropertyOptional({
+    description: 'Optional; มูลค่ารางวัล (reward_value) ต้องไม่ติดลบ',
+    example: 50,
+  })
   @IsOptional()
   @IsNumber()
   @Min(0, { message: 'reward_value ต้องไม่ติดลบ' })
   reward_value?: number;
 
+  @ApiPropertyOptional({
+    description: 'Optional; ขอบเขตการคำนวณยอดสั่งซื้อขั้นต่ำ',
+    enum: ['all', 'specific', 'vendor'],
+    example: 'all',
+  })
   @IsOptional()
   @IsEnum(['all', 'specific', 'vendor'], { message: 'min_order_scope ต้องเป็น all, specific หรือ vendor' })
   min_order_scope?: MinOrderScope;
 
+  @ApiPropertyOptional({
+    description: 'Optional; รหัสสินค้าที่ใช้นับยอดขั้นต่ำเมื่อ min_order_scope = specific',
+    type: [String],
+    example: ['A001', 'A002'],
+  })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
   min_order_pro_codes?: string[];
 
+  @ApiPropertyOptional({
+    description: 'Optional; nullable; รหัสเจ้าหนี้/vendor ที่ใช้นับยอดขั้นต่ำเมื่อ min_order_scope = vendor',
+    example: 'V001',
+    nullable: true,
+  })
   @IsOptional()
   @IsString()
   min_order_vendor_code?: string | null;

--- a/src/happy-hour/dto/create-slot.dto.ts
+++ b/src/happy-hour/dto/create-slot.dto.ts
@@ -9,82 +9,130 @@ import {
   Matches,
   Min,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { RewardType, MinOrderScope } from '../happy-hour-slot.entity';
 
 export class CreateSlotDto {
+  @ApiProperty({
+    description: 'เวลาเริ่มต้นของ slot รูปแบบ HH:mm (00:00–23:59)',
+    example: '09:00',
+  })
   @Matches(/^([01]\d|2[0-3]):[0-5]\d$/, {
     message: 'start_time ต้องอยู่ในรูปแบบ HH:mm (00:00–23:59)',
   })
   start_time!: string;
 
+  @ApiProperty({
+    description: 'เวลาสิ้นสุดของ slot รูปแบบ HH:mm (00:00–24:00)',
+    example: '12:00',
+  })
   @Matches(/^(([01]\d|2[0-3]):[0-5]\d|24:00)$/, {
     message: 'end_time ต้องอยู่ในรูปแบบ HH:mm (00:00–24:00)',
   })
   end_time!: string;
 
+  @ApiProperty({ description: 'ยอดสั่งซื้อขั้นต่ำที่ต้องถึงเพื่อรับสิทธิ์ (ต้องมากกว่า 0)' })
   @IsNumber()
   @Min(1, { message: 'min_order_amount ต้องมากกว่า 0' })
   min_order_amount!: number;
 
+  @ApiPropertyOptional({ description: 'มูลค่าบัตร (card_value) สำหรับ reward แบบ card' })
   @IsOptional()
   @IsNumber()
   card_value!: number;
 
+  @ApiPropertyOptional({ description: 'เกณฑ์ส่วนเกิน (excess_threshold) ต้องไม่ติดลบ' })
   @IsOptional()
   @IsNumber()
   @Min(0, { message: 'excess_threshold ต้องไม่ติดลบ' })
   excess_threshold?: number;
 
+  @ApiPropertyOptional({ description: 'ส่วนลดต่อขั้น (discount_per_step) ต้องไม่ติดลบ' })
   @IsOptional()
   @IsNumber()
   @Min(0, { message: 'discount_per_step ต้องไม่ติดลบ' })
   discount_per_step?: number;
 
+  @ApiPropertyOptional({ description: 'สถานะเปิดใช้งาน slot นี้หรือไม่' })
   @IsOptional()
   @IsBoolean()
   is_active?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'รหัสสินค้าที่เป็นของแถม (reward) สำหรับ slot นี้',
+    type: [String],
+  })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
   reward_pro_codes?: string[];
 
+  @ApiPropertyOptional({
+    description: 'จำนวนของแถมที่สัมพันธ์กับ reward_pro_codes แต่ละตัว',
+    type: [Number],
+  })
   @IsOptional()
   @IsArray()
   @IsNumber({}, { each: true })
   reward_amounts?: number[];
 
+  @ApiPropertyOptional({ description: 'จำนวนของแถม (ต้องมากกว่า 0)' })
   @IsOptional()
   @IsNumber()
   @Min(1, { message: 'reward_amount ต้องมากกว่า 0' })
   reward_amount?: number;
 
+  @ApiPropertyOptional({
+    description: 'วันที่เริ่มต้นโปรโมชั่น (ISO date string) หรือ null',
+    nullable: true,
+  })
   @IsOptional()
   @IsDateString()
   promo_start_date?: string | null;
 
+  @ApiPropertyOptional({
+    description: 'วันที่สิ้นสุดโปรโมชั่น (ISO date string) หรือ null',
+    nullable: true,
+  })
   @IsOptional()
   @IsDateString()
   promo_end_date?: string | null;
 
+  @ApiPropertyOptional({
+    description: 'ประเภทของรางวัล',
+    enum: ['card', 'bill_discount'],
+  })
   @IsOptional()
   @IsEnum(['card', 'bill_discount'], { message: 'reward_type ต้องเป็น card หรือ bill_discount' })
   reward_type?: RewardType;
 
+  @ApiPropertyOptional({ description: 'มูลค่ารางวัล (reward_value) ต้องไม่ติดลบ' })
   @IsOptional()
   @IsNumber()
   @Min(0, { message: 'reward_value ต้องไม่ติดลบ' })
   reward_value?: number;
 
+  @ApiPropertyOptional({
+    description: 'ขอบเขตการคำนวณยอดสั่งซื้อขั้นต่ำ',
+    enum: ['all', 'specific', 'vendor'],
+  })
   @IsOptional()
   @IsEnum(['all', 'specific', 'vendor'], { message: 'min_order_scope ต้องเป็น all, specific หรือ vendor' })
   min_order_scope?: MinOrderScope;
 
+  @ApiPropertyOptional({
+    description: 'รหัสสินค้าที่ใช้นับยอดขั้นต่ำเมื่อ min_order_scope = specific',
+    type: [String],
+  })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
   min_order_pro_codes?: string[];
 
+  @ApiPropertyOptional({
+    description: 'รหัสเจ้าหนี้/vendor ที่ใช้นับยอดขั้นต่ำเมื่อ min_order_scope = vendor',
+    nullable: true,
+  })
   @IsOptional()
   @IsString()
   min_order_vendor_code?: string | null;

--- a/src/happy-hour/dto/simulate.dto.ts
+++ b/src/happy-hour/dto/simulate.dto.ts
@@ -11,18 +11,22 @@ import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class OrderItemDto {
-  @ApiProperty({ description: 'รหัสสินค้า' })
+  @ApiProperty({ description: 'Required; not empty; รหัสสินค้า', example: 'A001' })
   @IsString()
   pro_code!: string;
 
-  @ApiProperty({ description: 'จำนวน/ยอดของสินค้านี้ ต้องไม่ติดลบ' })
+  @ApiProperty({
+    description: 'Required; จำนวน/ยอดของสินค้านี้ ต้องไม่ติดลบ',
+    example: 500,
+  })
   @IsNumber()
   @Min(0, { message: 'amount ต้องไม่ติดลบ' })
   amount!: number;
 
   /** vendor_code ของสินค้า — ใช้สำหรับ min_order_scope = 'vendor' */
   @ApiPropertyOptional({
-    description: "vendor_code ของสินค้า — ใช้สำหรับ min_order_scope = 'vendor'",
+    description: "Optional; vendor_code ของสินค้า — ใช้สำหรับ min_order_scope = 'vendor'",
+    example: 'V001',
   })
   @IsOptional()
   @IsString()
@@ -30,13 +34,16 @@ export class OrderItemDto {
 }
 
 export class SimulateDto {
-  @ApiProperty({ description: 'ยอดสั่งซื้อรวม ต้องไม่ติดลบ' })
+  @ApiProperty({
+    description: 'Required; ยอดสั่งซื้อรวม ต้องไม่ติดลบ',
+    example: 1500,
+  })
   @IsNumber()
   @Min(0, { message: 'order_amount ต้องไม่ติดลบ' })
   order_amount!: number;
 
   @ApiProperty({
-    description: 'เวลาสั่งซื้อที่ต้องการจำลอง รูปแบบ HH:mm (00:00–23:59)',
+    description: 'Required; not empty; เวลาสั่งซื้อที่ต้องการจำลอง รูปแบบ HH:mm (00:00–23:59)',
     example: '10:30',
   })
   @Matches(/^([01]\d|2[0-3]):[0-5]\d$/, {
@@ -50,8 +57,9 @@ export class SimulateDto {
    */
   @ApiPropertyOptional({
     description:
-      "รายการสินค้าในคำสั่งซื้อ — ใช้สำหรับ min_order_scope = 'specific'. ถ้าไม่ส่ง จะใช้ order_amount ทั้งหมดในการเทียบ min_order_amount",
+      "Optional; รายการสินค้าในคำสั่งซื้อ — ใช้สำหรับ min_order_scope = 'specific'. ถ้าไม่ส่ง จะใช้ order_amount ทั้งหมดในการเทียบ min_order_amount",
     type: [OrderItemDto],
+    example: [{ pro_code: 'A001', amount: 500, vendor_code: 'V001' }],
   })
   @IsOptional()
   @IsArray()

--- a/src/happy-hour/dto/simulate.dto.ts
+++ b/src/happy-hour/dto/simulate.dto.ts
@@ -8,26 +8,44 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class OrderItemDto {
+  @ApiProperty({ description: 'Required; not empty; รหัสสินค้า', example: 'A001' })
   @IsString()
   pro_code!: string;
 
+  @ApiProperty({
+    description: 'Required; จำนวน/ยอดของสินค้านี้ ต้องไม่ติดลบ',
+    example: 500,
+  })
   @IsNumber()
   @Min(0, { message: 'amount ต้องไม่ติดลบ' })
   amount!: number;
 
   /** vendor_code ของสินค้า — ใช้สำหรับ min_order_scope = 'vendor' */
+  @ApiPropertyOptional({
+    description: "Optional; vendor_code ของสินค้า — ใช้สำหรับ min_order_scope = 'vendor'",
+    example: 'V001',
+  })
   @IsOptional()
   @IsString()
   vendor_code?: string;
 }
 
 export class SimulateDto {
+  @ApiProperty({
+    description: 'Required; ยอดสั่งซื้อรวม ต้องไม่ติดลบ',
+    example: 1500,
+  })
   @IsNumber()
   @Min(0, { message: 'order_amount ต้องไม่ติดลบ' })
   order_amount!: number;
 
+  @ApiProperty({
+    description: 'Required; not empty; เวลาสั่งซื้อที่ต้องการจำลอง รูปแบบ HH:mm (00:00–23:59)',
+    example: '10:30',
+  })
   @Matches(/^([01]\d|2[0-3]):[0-5]\d$/, {
     message: 'order_time ต้องอยู่ในรูปแบบ HH:mm (00:00–23:59)',
   })
@@ -37,6 +55,12 @@ export class SimulateDto {
    * รายการสินค้าในคำสั่งซื้อ — ใช้สำหรับ min_order_scope = 'specific'
    * ถ้าไม่ส่ง จะใช้ order_amount ทั้งหมดในการเทียบ min_order_amount
    */
+  @ApiPropertyOptional({
+    description:
+      "Optional; รายการสินค้าในคำสั่งซื้อ — ใช้สำหรับ min_order_scope = 'specific'. ถ้าไม่ส่ง จะใช้ order_amount ทั้งหมดในการเทียบ min_order_amount",
+    type: [OrderItemDto],
+    example: [{ pro_code: 'A001', amount: 500, vendor_code: 'V001' }],
+  })
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })

--- a/src/happy-hour/dto/simulate.dto.ts
+++ b/src/happy-hour/dto/simulate.dto.ts
@@ -8,26 +8,37 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class OrderItemDto {
+  @ApiProperty({ description: 'รหัสสินค้า' })
   @IsString()
   pro_code!: string;
 
+  @ApiProperty({ description: 'จำนวน/ยอดของสินค้านี้ ต้องไม่ติดลบ' })
   @IsNumber()
   @Min(0, { message: 'amount ต้องไม่ติดลบ' })
   amount!: number;
 
   /** vendor_code ของสินค้า — ใช้สำหรับ min_order_scope = 'vendor' */
+  @ApiPropertyOptional({
+    description: "vendor_code ของสินค้า — ใช้สำหรับ min_order_scope = 'vendor'",
+  })
   @IsOptional()
   @IsString()
   vendor_code?: string;
 }
 
 export class SimulateDto {
+  @ApiProperty({ description: 'ยอดสั่งซื้อรวม ต้องไม่ติดลบ' })
   @IsNumber()
   @Min(0, { message: 'order_amount ต้องไม่ติดลบ' })
   order_amount!: number;
 
+  @ApiProperty({
+    description: 'เวลาสั่งซื้อที่ต้องการจำลอง รูปแบบ HH:mm (00:00–23:59)',
+    example: '10:30',
+  })
   @Matches(/^([01]\d|2[0-3]):[0-5]\d$/, {
     message: 'order_time ต้องอยู่ในรูปแบบ HH:mm (00:00–23:59)',
   })
@@ -37,6 +48,11 @@ export class SimulateDto {
    * รายการสินค้าในคำสั่งซื้อ — ใช้สำหรับ min_order_scope = 'specific'
    * ถ้าไม่ส่ง จะใช้ order_amount ทั้งหมดในการเทียบ min_order_amount
    */
+  @ApiPropertyOptional({
+    description:
+      "รายการสินค้าในคำสั่งซื้อ — ใช้สำหรับ min_order_scope = 'specific'. ถ้าไม่ส่ง จะใช้ order_amount ทั้งหมดในการเทียบ min_order_amount",
+    type: [OrderItemDto],
+  })
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })

--- a/src/happy-hour/dto/slot-log-query.dto.ts
+++ b/src/happy-hour/dto/slot-log-query.dto.ts
@@ -5,15 +5,20 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 export class SlotLogQueryDto {
   /** กรองตาม action: CREATE | UPDATE | DELETE */
   @ApiPropertyOptional({
-    description: 'กรองตาม action',
+    description: 'Optional; กรองตาม action',
     enum: ['CREATE', 'UPDATE', 'DELETE'],
+    example: 'UPDATE',
   })
   @IsOptional()
   @IsIn(['CREATE', 'UPDATE', 'DELETE'])
   action?: 'CREATE' | 'UPDATE' | 'DELETE';
 
   /** กรองตาม slot_id */
-  @ApiPropertyOptional({ description: 'กรองตาม slot_id', type: Number })
+  @ApiPropertyOptional({
+    description: 'Optional; กรองตาม slot_id',
+    type: Number,
+    example: 1,
+  })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()
@@ -21,12 +26,20 @@ export class SlotLogQueryDto {
   slot_id?: number;
 
   /** กรองตามผู้ดำเนินการ (บางส่วนก็ได้) */
-  @ApiPropertyOptional({ description: 'กรองตามผู้ดำเนินการ (username, ค้นหาแบบบางส่วนได้)' })
+  @ApiPropertyOptional({
+    description: 'Optional; กรองตามผู้ดำเนินการ (username, ค้นหาแบบบางส่วนได้)',
+    example: 'admin01',
+  })
   @IsOptional()
   @IsString()
   performed_by?: string;
 
-  @ApiPropertyOptional({ description: 'หน้าที่ต้องการ (default 1)', type: Number, default: 1 })
+  @ApiPropertyOptional({
+    description: 'Optional; defaults to 1; หน้าที่ต้องการ',
+    type: Number,
+    default: 1,
+    example: 1,
+  })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()
@@ -34,9 +47,10 @@ export class SlotLogQueryDto {
   page?: number = 1;
 
   @ApiPropertyOptional({
-    description: 'จำนวนรายการต่อหน้า (default 20)',
+    description: 'Optional; defaults to 20; จำนวนรายการต่อหน้า',
     type: Number,
     default: 20,
+    example: 20,
   })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))

--- a/src/happy-hour/dto/slot-log-query.dto.ts
+++ b/src/happy-hour/dto/slot-log-query.dto.ts
@@ -1,13 +1,19 @@
 import { IsInt, IsIn, IsOptional, IsString, Min } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class SlotLogQueryDto {
   /** กรองตาม action: CREATE | UPDATE | DELETE */
+  @ApiPropertyOptional({
+    description: 'กรองตาม action',
+    enum: ['CREATE', 'UPDATE', 'DELETE'],
+  })
   @IsOptional()
   @IsIn(['CREATE', 'UPDATE', 'DELETE'])
   action?: 'CREATE' | 'UPDATE' | 'DELETE';
 
   /** กรองตาม slot_id */
+  @ApiPropertyOptional({ description: 'กรองตาม slot_id', type: Number })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()
@@ -15,16 +21,23 @@ export class SlotLogQueryDto {
   slot_id?: number;
 
   /** กรองตามผู้ดำเนินการ (บางส่วนก็ได้) */
+  @ApiPropertyOptional({ description: 'กรองตามผู้ดำเนินการ (username, ค้นหาแบบบางส่วนได้)' })
   @IsOptional()
   @IsString()
   performed_by?: string;
 
+  @ApiPropertyOptional({ description: 'หน้าที่ต้องการ (default 1)', type: Number, default: 1 })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'จำนวนรายการต่อหน้า (default 20)',
+    type: Number,
+    default: 20,
+  })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()

--- a/src/happy-hour/dto/slot-log-query.dto.ts
+++ b/src/happy-hour/dto/slot-log-query.dto.ts
@@ -1,13 +1,24 @@
 import { IsInt, IsIn, IsOptional, IsString, Min } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class SlotLogQueryDto {
   /** กรองตาม action: CREATE | UPDATE | DELETE */
+  @ApiPropertyOptional({
+    description: 'Optional; กรองตาม action',
+    enum: ['CREATE', 'UPDATE', 'DELETE'],
+    example: 'UPDATE',
+  })
   @IsOptional()
   @IsIn(['CREATE', 'UPDATE', 'DELETE'])
   action?: 'CREATE' | 'UPDATE' | 'DELETE';
 
   /** กรองตาม slot_id */
+  @ApiPropertyOptional({
+    description: 'Optional; กรองตาม slot_id',
+    type: Number,
+    example: 1,
+  })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()
@@ -15,16 +26,32 @@ export class SlotLogQueryDto {
   slot_id?: number;
 
   /** กรองตามผู้ดำเนินการ (บางส่วนก็ได้) */
+  @ApiPropertyOptional({
+    description: 'Optional; กรองตามผู้ดำเนินการ (username, ค้นหาแบบบางส่วนได้)',
+    example: 'admin01',
+  })
   @IsOptional()
   @IsString()
   performed_by?: string;
 
+  @ApiPropertyOptional({
+    description: 'Optional; defaults to 1; หน้าที่ต้องการ',
+    type: Number,
+    default: 1,
+    example: 1,
+  })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Optional; defaults to 20; จำนวนรายการต่อหน้า',
+    type: Number,
+    default: 20,
+    example: 20,
+  })
   @IsOptional()
   @Transform(({ value }: { value: unknown }) => Number(value))
   @IsInt()

--- a/src/happy-hour/dto/update-config.dto.ts
+++ b/src/happy-hour/dto/update-config.dto.ts
@@ -2,13 +2,17 @@ import { IsBoolean, IsDateString, IsOptional } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateConfigDto {
-  @ApiPropertyOptional({ description: 'เปิด/ปิดใช้งาน Happy Hour' })
+  @ApiPropertyOptional({
+    description: 'Optional; เปิด/ปิดใช้งาน Happy Hour',
+    example: true,
+  })
   @IsOptional()
   @IsBoolean()
   is_enabled?: boolean;
 
   @ApiPropertyOptional({
-    description: 'วันที่เริ่มต้นของ Happy Hour (ISO date string) หรือ null',
+    description: 'Optional; nullable; วันที่เริ่มต้นของ Happy Hour (ISO date string) หรือ null',
+    example: '2026-06-01T00:00:00.000Z',
     nullable: true,
   })
   @IsOptional()
@@ -16,7 +20,8 @@ export class UpdateConfigDto {
   start_date?: string | null;
 
   @ApiPropertyOptional({
-    description: 'วันที่สิ้นสุดของ Happy Hour (ISO date string) หรือ null',
+    description: 'Optional; nullable; วันที่สิ้นสุดของ Happy Hour (ISO date string) หรือ null',
+    example: '2026-06-30T23:59:59.000Z',
     nullable: true,
   })
   @IsOptional()

--- a/src/happy-hour/dto/update-config.dto.ts
+++ b/src/happy-hour/dto/update-config.dto.ts
@@ -1,14 +1,24 @@
 import { IsBoolean, IsDateString, IsOptional } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateConfigDto {
+  @ApiPropertyOptional({ description: 'เปิด/ปิดใช้งาน Happy Hour' })
   @IsOptional()
   @IsBoolean()
   is_enabled?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'วันที่เริ่มต้นของ Happy Hour (ISO date string) หรือ null',
+    nullable: true,
+  })
   @IsOptional()
   @IsDateString()
   start_date?: string | null;
 
+  @ApiPropertyOptional({
+    description: 'วันที่สิ้นสุดของ Happy Hour (ISO date string) หรือ null',
+    nullable: true,
+  })
   @IsOptional()
   @IsDateString()
   end_date?: string | null;

--- a/src/happy-hour/dto/update-config.dto.ts
+++ b/src/happy-hour/dto/update-config.dto.ts
@@ -1,14 +1,29 @@
 import { IsBoolean, IsDateString, IsOptional } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateConfigDto {
+  @ApiPropertyOptional({
+    description: 'Optional; เปิด/ปิดใช้งาน Happy Hour',
+    example: true,
+  })
   @IsOptional()
   @IsBoolean()
   is_enabled?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Optional; nullable; วันที่เริ่มต้นของ Happy Hour (ISO date string) หรือ null',
+    example: '2026-06-01T00:00:00.000Z',
+    nullable: true,
+  })
   @IsOptional()
   @IsDateString()
   start_date?: string | null;
 
+  @ApiPropertyOptional({
+    description: 'Optional; nullable; วันที่สิ้นสุดของ Happy Hour (ISO date string) หรือ null',
+    example: '2026-06-30T23:59:59.000Z',
+    nullable: true,
+  })
   @IsOptional()
   @IsDateString()
   end_date?: string | null;

--- a/src/happy-hour/happy-hour.controller.ts
+++ b/src/happy-hour/happy-hour.controller.ts
@@ -17,6 +17,15 @@ import {
 } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { Logger } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { HappyHourService } from './happy-hour.service';
 import { CreateSlotDto } from './dto/create-slot.dto';
 import { UpdateSlotDto } from './dto/update-slot.dto';
@@ -34,6 +43,8 @@ interface JwtUser {
   role?: string;
 }
 
+@ApiTags('Happy Hour')
+@ApiBearerAuth()
 @Controller('admin/happy-hour')
 @UseGuards(JwtAuthGuard)
 @UsePipes(
@@ -49,6 +60,11 @@ export class HappyHourController {
   constructor(private readonly happyHourService: HappyHourService) {}
 
   /** ดึงทุกอย่างใน 1 เส้น: config (พร้อม is_enabled computed) + slots ทั้งหมด */
+  @ApiOperation({
+    summary: 'ดึงข้อมูลภาพรวม Happy Hour ใน 1 เส้น (config พร้อม is_enabled computed + slots ทั้งหมด)',
+  })
+  @ApiResponse({ status: 200, description: 'ข้อมูล config และ slots ของ Happy Hour' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('overview')
   async getOverview() {
     const [config, slots] = await Promise.all([
@@ -58,11 +74,18 @@ export class HappyHourController {
     return { config, slots };
   }
 
+  @ApiOperation({ summary: 'ดึงค่า config ปัจจุบันของ Happy Hour (พร้อม is_enabled computed)' })
+  @ApiResponse({ status: 200, description: 'ค่า config ปัจจุบันของ Happy Hour' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('config')
   getConfig() {
     return this.happyHourService.getConfigResponse();
   }
 
+  @ApiOperation({ summary: 'แก้ไขค่า config ของ Happy Hour (เปิด/ปิด, ช่วงวันที่)' })
+  @ApiBody({ type: UpdateConfigDto })
+  @ApiResponse({ status: 200, description: 'แก้ไข config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Patch('config')
   updateConfig(@Body() dto: UpdateConfigDto, @Req() req: { user: JwtUser }) {
     this.logger.log(`User ${req.user.username} is updating happy hour config`, {
@@ -71,6 +94,9 @@ export class HappyHourController {
     return this.happyHourService.updateConfig(dto, req.user.username);
   }
 
+  @ApiOperation({ summary: 'สลับสถานะเปิด/ปิดการใช้งาน Happy Hour' })
+  @ApiResponse({ status: 200, description: 'สลับสถานะสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Patch('toggle')
   toggle(@Req() req: { user: JwtUser }) {
     this.logger.log(`User ${req.user.username} is toggling happy hour`, {
@@ -81,16 +107,28 @@ export class HappyHourController {
     return this.happyHourService.toggle(req.user.username);
   }
 
+  @ApiOperation({ summary: 'ดึงรายการ slots ของ Happy Hour ทั้งหมด' })
+  @ApiResponse({ status: 200, description: 'รายการ slots ทั้งหมด' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('slots')
   getSlots() {
     return this.happyHourService.getSlots();
   }
 
+  @ApiOperation({ summary: 'สร้าง slot ใหม่สำหรับ Happy Hour' })
+  @ApiBody({ type: CreateSlotDto })
+  @ApiResponse({ status: 201, description: 'สร้าง slot สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Post('slots')
   createSlot(@Body() dto: CreateSlotDto, @Req() req: { user: JwtUser }) {
     return this.happyHourService.createSlot(dto, req.user.username);
   }
 
+  @ApiOperation({ summary: 'แก้ไข slot ของ Happy Hour ตาม id' })
+  @ApiParam({ name: 'id', description: 'รหัส slot', example: '1' })
+  @ApiBody({ type: UpdateSlotDto })
+  @ApiResponse({ status: 200, description: 'แก้ไข slot สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Put('slots/:id')
   updateSlot(
     @Param('id', ParseIntPipe) id: number,
@@ -100,6 +138,10 @@ export class HappyHourController {
     return this.happyHourService.updateSlot(id, dto, req.user.username);
   }
 
+  @ApiOperation({ summary: 'ลบ slot ของ Happy Hour ตาม id' })
+  @ApiParam({ name: 'id', description: 'รหัส slot', example: '1' })
+  @ApiResponse({ status: 204, description: 'ลบ slot สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Delete('slots/:id')
   @HttpCode(204)
   deleteSlot(
@@ -109,6 +151,10 @@ export class HappyHourController {
     return this.happyHourService.deleteSlot(id, req.user.username);
   }
 
+  @ApiOperation({ summary: 'จำลองการคำนวณ Happy Hour ตามยอดสั่งซื้อและเวลาที่กำหนด' })
+  @ApiBody({ type: SimulateDto })
+  @ApiResponse({ status: 201, description: 'ผลลัพธ์การจำลองการคำนวณ Happy Hour' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Post('simulate')
   simulate(@Body() dto: SimulateDto) {
     return this.happyHourService.simulate(dto);
@@ -119,11 +165,21 @@ export class HappyHourController {
    * คำนวณ Happy Hour สำหรับแสดงผลในตะกร้าสินค้า
    * Backend คำนวณทุกอย่าง (scope filtering, reward amounts) — frontend display ตรงได้เลย
    */
+  @ApiOperation({
+    summary:
+      'คำนวณ Happy Hour สำหรับแสดงผลในตะกร้าสินค้า (scope filtering, reward amounts คำนวณฝั่ง backend ทั้งหมด)',
+  })
+  @ApiBody({ type: CartPreviewDto })
+  @ApiResponse({ status: 201, description: 'ผลลัพธ์การคำนวณ Happy Hour สำหรับตะกร้าสินค้า' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Post('cart-preview')
   cartPreview(@Body() dto: CartPreviewDto) {
     return this.happyHourService.getCartPreview(dto);
   }
 
+  @ApiOperation({ summary: 'ดึงรายการบัตร Lotus ที่ใช้เป็นรางวัลใน Happy Hour' })
+  @ApiResponse({ status: 200, description: 'รายการบัตร Lotus' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('lotus-cards')
   getLotusCards() {
     return this.happyHourService.getLotusCards();
@@ -140,6 +196,16 @@ export class HappyHourController {
    *   page          — default 1
    *   limit         — default 20
    */
+  @ApiOperation({
+    summary: 'ดึง audit log การ CREATE / UPDATE / DELETE slot พร้อม pagination',
+  })
+  @ApiQuery({ name: 'action', required: false, enum: ['CREATE', 'UPDATE', 'DELETE'], example: 'UPDATE', description: 'Optional; กรองตาม action' })
+  @ApiQuery({ name: 'slot_id', required: false, example: '1', description: 'Optional; กรองตาม slot id' })
+  @ApiQuery({ name: 'performed_by', required: false, example: 'admin01', description: 'Optional; กรองตาม username (บางส่วนก็ได้)' })
+  @ApiQuery({ name: 'page', required: false, example: '1', description: 'Optional; หน้าที่ต้องการ (default 1)' })
+  @ApiQuery({ name: 'limit', required: false, example: '20', description: 'Optional; จำนวนรายการต่อหน้า (default 20)' })
+  @ApiResponse({ status: 200, description: 'รายการ audit log ของ slot พร้อม pagination' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('slot-logs')
   getSlotLogs(@Query() query: SlotLogQueryDto) {
     return this.happyHourService.getSlotLogs(query);
@@ -155,6 +221,15 @@ export class HappyHourController {
    *   page          — default 1
    *   limit         — default 20
    */
+  @ApiOperation({
+    summary: 'ดึง audit log การเปลี่ยน config (UPDATE / TOGGLE) พร้อม pagination',
+  })
+  @ApiQuery({ name: 'action', required: false, enum: ['UPDATE', 'TOGGLE'], example: 'TOGGLE', description: 'Optional; กรองตาม action' })
+  @ApiQuery({ name: 'performed_by', required: false, example: 'admin01', description: 'Optional; กรองตาม username (บางส่วนก็ได้)' })
+  @ApiQuery({ name: 'page', required: false, example: '1', description: 'Optional; หน้าที่ต้องการ (default 1)' })
+  @ApiQuery({ name: 'limit', required: false, example: '20', description: 'Optional; จำนวนรายการต่อหน้า (default 20)' })
+  @ApiResponse({ status: 200, description: 'รายการ audit log ของ config พร้อม pagination' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('config-logs')
   getConfigLogs(@Query() query: ConfigLogQueryDto) {
     return this.happyHourService.getConfigLogs(query);
@@ -170,12 +245,30 @@ export class HappyHourController {
    * ดึงหน่วยที่เล็กที่สุดของสินค้าหลายตัวพร้อมกัน
    * Response: [{ pro_code, unit }]
    */
+  @ApiOperation({ summary: 'ดึงหน่วยที่เล็กที่สุดของสินค้าหลายตัวพร้อมกัน' })
+  @ApiQuery({
+    name: 'codes',
+    required: false,
+    example: 'A001,A002',
+    description: "Optional; รหัสสินค้าหลายตัวคั่นด้วย comma เช่น 'A001,A002'",
+  })
+  @ApiResponse({ status: 200, description: 'รายการ [{ pro_code, unit }]' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('product-units')
   getProductUnits(@Query('codes') codes: string) {
     const list = codes ? codes.split(',').map((c) => c.trim()).filter(Boolean) : [];
     return this.happyHourService.getProductUnits(list);
   }
 
+  /**
+   * GET /admin/happy-hour/vendors/search?keyword=xxx
+   * ค้นหา vendor (creditor) สำหรับ min_order_scope = 'vendor'
+   * Response: [{ vendor_code, vendor_name }]
+   */
+  @ApiOperation({ summary: "ค้นหา vendor (เจ้าหนี้) สำหรับ min_order_scope = 'vendor'" })
+  @ApiQuery({ name: 'keyword', required: false, example: 'บริษัท ยา', description: 'Optional; คำค้นหาชื่อ/รหัส vendor' })
+  @ApiResponse({ status: 200, description: 'รายการ [{ vendor_code, vendor_name }]' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('vendors/search')
   searchVendors(@Query('keyword') keyword: string) {
     return this.happyHourService.searchVendors(keyword ?? '');
@@ -186,6 +279,12 @@ export class HappyHourController {
    * ดึงรายการสินค้าทั้งหมดของเจ้าหนี้ที่ระบุ (ใช้ query param เพราะ vendor_code อาจมี '/')
    * Response: [{ pro_code, pro_name }]
    */
+  @ApiOperation({
+    summary: "ดึงรายการสินค้าทั้งหมดของเจ้าหนี้ (vendor) ที่ระบุ (ใช้ query param เพราะ vendor_code อาจมี '/')",
+  })
+  @ApiQuery({ name: 'vendor_code', required: false, example: 'V001', description: 'Optional; รหัสเจ้าหนี้/vendor' })
+  @ApiResponse({ status: 200, description: 'รายการ [{ pro_code, pro_name }]' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('vendors/products')
   getVendorProducts(@Query('vendor_code') vendorCode: string) {
     return this.happyHourService.getVendorProducts(vendorCode ?? '');

--- a/src/happy-hour/happy-hour.controller.ts
+++ b/src/happy-hour/happy-hour.controller.ts
@@ -17,6 +17,15 @@ import {
 } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { Logger } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { HappyHourService } from './happy-hour.service';
 import { CreateSlotDto } from './dto/create-slot.dto';
 import { UpdateSlotDto } from './dto/update-slot.dto';
@@ -34,6 +43,8 @@ interface JwtUser {
   role?: string;
 }
 
+@ApiTags('Happy Hour')
+@ApiBearerAuth()
 @Controller('admin/happy-hour')
 @UseGuards(JwtAuthGuard)
 @UsePipes(
@@ -49,6 +60,11 @@ export class HappyHourController {
   constructor(private readonly happyHourService: HappyHourService) {}
 
   /** ดึงทุกอย่างใน 1 เส้น: config (พร้อม is_enabled computed) + slots ทั้งหมด */
+  @ApiOperation({
+    summary: 'ดึงข้อมูลภาพรวม Happy Hour ใน 1 เส้น (config พร้อม is_enabled computed + slots ทั้งหมด)',
+  })
+  @ApiResponse({ status: 200, description: 'ข้อมูล config และ slots ของ Happy Hour' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('overview')
   async getOverview() {
     const [config, slots] = await Promise.all([
@@ -58,11 +74,18 @@ export class HappyHourController {
     return { config, slots };
   }
 
+  @ApiOperation({ summary: 'ดึงค่า config ปัจจุบันของ Happy Hour (พร้อม is_enabled computed)' })
+  @ApiResponse({ status: 200, description: 'ค่า config ปัจจุบันของ Happy Hour' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('config')
   getConfig() {
     return this.happyHourService.getConfigResponse();
   }
 
+  @ApiOperation({ summary: 'แก้ไขค่า config ของ Happy Hour (เปิด/ปิด, ช่วงวันที่)' })
+  @ApiBody({ type: UpdateConfigDto })
+  @ApiResponse({ status: 200, description: 'แก้ไข config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Patch('config')
   updateConfig(@Body() dto: UpdateConfigDto, @Req() req: { user: JwtUser }) {
     this.logger.log(`User ${req.user.username} is updating happy hour config`, {
@@ -71,6 +94,9 @@ export class HappyHourController {
     return this.happyHourService.updateConfig(dto, req.user.username);
   }
 
+  @ApiOperation({ summary: 'สลับสถานะเปิด/ปิดการใช้งาน Happy Hour' })
+  @ApiResponse({ status: 200, description: 'สลับสถานะสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Patch('toggle')
   toggle(@Req() req: { user: JwtUser }) {
     this.logger.log(`User ${req.user.username} is toggling happy hour`, {
@@ -81,16 +107,28 @@ export class HappyHourController {
     return this.happyHourService.toggle(req.user.username);
   }
 
+  @ApiOperation({ summary: 'ดึงรายการ slots ของ Happy Hour ทั้งหมด' })
+  @ApiResponse({ status: 200, description: 'รายการ slots ทั้งหมด' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('slots')
   getSlots() {
     return this.happyHourService.getSlots();
   }
 
+  @ApiOperation({ summary: 'สร้าง slot ใหม่สำหรับ Happy Hour' })
+  @ApiBody({ type: CreateSlotDto })
+  @ApiResponse({ status: 201, description: 'สร้าง slot สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Post('slots')
   createSlot(@Body() dto: CreateSlotDto, @Req() req: { user: JwtUser }) {
     return this.happyHourService.createSlot(dto, req.user.username);
   }
 
+  @ApiOperation({ summary: 'แก้ไข slot ของ Happy Hour ตาม id' })
+  @ApiParam({ name: 'id', description: 'รหัส slot' })
+  @ApiBody({ type: UpdateSlotDto })
+  @ApiResponse({ status: 200, description: 'แก้ไข slot สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Put('slots/:id')
   updateSlot(
     @Param('id', ParseIntPipe) id: number,
@@ -100,6 +138,10 @@ export class HappyHourController {
     return this.happyHourService.updateSlot(id, dto, req.user.username);
   }
 
+  @ApiOperation({ summary: 'ลบ slot ของ Happy Hour ตาม id' })
+  @ApiParam({ name: 'id', description: 'รหัส slot' })
+  @ApiResponse({ status: 204, description: 'ลบ slot สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Delete('slots/:id')
   @HttpCode(204)
   deleteSlot(
@@ -109,6 +151,10 @@ export class HappyHourController {
     return this.happyHourService.deleteSlot(id, req.user.username);
   }
 
+  @ApiOperation({ summary: 'จำลองการคำนวณ Happy Hour ตามยอดสั่งซื้อและเวลาที่กำหนด' })
+  @ApiBody({ type: SimulateDto })
+  @ApiResponse({ status: 201, description: 'ผลลัพธ์การจำลองการคำนวณ Happy Hour' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Post('simulate')
   simulate(@Body() dto: SimulateDto) {
     return this.happyHourService.simulate(dto);
@@ -119,11 +165,21 @@ export class HappyHourController {
    * คำนวณ Happy Hour สำหรับแสดงผลในตะกร้าสินค้า
    * Backend คำนวณทุกอย่าง (scope filtering, reward amounts) — frontend display ตรงได้เลย
    */
+  @ApiOperation({
+    summary:
+      'คำนวณ Happy Hour สำหรับแสดงผลในตะกร้าสินค้า (scope filtering, reward amounts คำนวณฝั่ง backend ทั้งหมด)',
+  })
+  @ApiBody({ type: CartPreviewDto })
+  @ApiResponse({ status: 201, description: 'ผลลัพธ์การคำนวณ Happy Hour สำหรับตะกร้าสินค้า' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Post('cart-preview')
   cartPreview(@Body() dto: CartPreviewDto) {
     return this.happyHourService.getCartPreview(dto);
   }
 
+  @ApiOperation({ summary: 'ดึงรายการบัตร Lotus ที่ใช้เป็นรางวัลใน Happy Hour' })
+  @ApiResponse({ status: 200, description: 'รายการบัตร Lotus' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('lotus-cards')
   getLotusCards() {
     return this.happyHourService.getLotusCards();
@@ -140,6 +196,16 @@ export class HappyHourController {
    *   page          — default 1
    *   limit         — default 20
    */
+  @ApiOperation({
+    summary: 'ดึง audit log การ CREATE / UPDATE / DELETE slot พร้อม pagination',
+  })
+  @ApiQuery({ name: 'action', required: false, enum: ['CREATE', 'UPDATE', 'DELETE'], description: 'กรองตาม action' })
+  @ApiQuery({ name: 'slot_id', required: false, description: 'กรองตาม slot id' })
+  @ApiQuery({ name: 'performed_by', required: false, description: 'กรองตาม username (บางส่วนก็ได้)' })
+  @ApiQuery({ name: 'page', required: false, description: 'หน้าที่ต้องการ (default 1)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'จำนวนรายการต่อหน้า (default 20)' })
+  @ApiResponse({ status: 200, description: 'รายการ audit log ของ slot พร้อม pagination' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('slot-logs')
   getSlotLogs(@Query() query: SlotLogQueryDto) {
     return this.happyHourService.getSlotLogs(query);
@@ -155,6 +221,15 @@ export class HappyHourController {
    *   page          — default 1
    *   limit         — default 20
    */
+  @ApiOperation({
+    summary: 'ดึง audit log การเปลี่ยน config (UPDATE / TOGGLE) พร้อม pagination',
+  })
+  @ApiQuery({ name: 'action', required: false, enum: ['UPDATE', 'TOGGLE'], description: 'กรองตาม action' })
+  @ApiQuery({ name: 'performed_by', required: false, description: 'กรองตาม username (บางส่วนก็ได้)' })
+  @ApiQuery({ name: 'page', required: false, description: 'หน้าที่ต้องการ (default 1)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'จำนวนรายการต่อหน้า (default 20)' })
+  @ApiResponse({ status: 200, description: 'รายการ audit log ของ config พร้อม pagination' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('config-logs')
   getConfigLogs(@Query() query: ConfigLogQueryDto) {
     return this.happyHourService.getConfigLogs(query);
@@ -170,12 +245,29 @@ export class HappyHourController {
    * ดึงหน่วยที่เล็กที่สุดของสินค้าหลายตัวพร้อมกัน
    * Response: [{ pro_code, unit }]
    */
+  @ApiOperation({ summary: 'ดึงหน่วยที่เล็กที่สุดของสินค้าหลายตัวพร้อมกัน' })
+  @ApiQuery({
+    name: 'codes',
+    required: false,
+    description: "รหัสสินค้าหลายตัวคั่นด้วย comma เช่น 'A001,A002'",
+  })
+  @ApiResponse({ status: 200, description: 'รายการ [{ pro_code, unit }]' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('product-units')
   getProductUnits(@Query('codes') codes: string) {
     const list = codes ? codes.split(',').map((c) => c.trim()).filter(Boolean) : [];
     return this.happyHourService.getProductUnits(list);
   }
 
+  /**
+   * GET /admin/happy-hour/vendors/search?keyword=xxx
+   * ค้นหา vendor (creditor) สำหรับ min_order_scope = 'vendor'
+   * Response: [{ vendor_code, vendor_name }]
+   */
+  @ApiOperation({ summary: "ค้นหา vendor (เจ้าหนี้) สำหรับ min_order_scope = 'vendor'" })
+  @ApiQuery({ name: 'keyword', required: false, description: 'คำค้นหาชื่อ/รหัส vendor' })
+  @ApiResponse({ status: 200, description: 'รายการ [{ vendor_code, vendor_name }]' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('vendors/search')
   searchVendors(@Query('keyword') keyword: string) {
     return this.happyHourService.searchVendors(keyword ?? '');
@@ -186,6 +278,12 @@ export class HappyHourController {
    * ดึงรายการสินค้าทั้งหมดของเจ้าหนี้ที่ระบุ (ใช้ query param เพราะ vendor_code อาจมี '/')
    * Response: [{ pro_code, pro_name }]
    */
+  @ApiOperation({
+    summary: "ดึงรายการสินค้าทั้งหมดของเจ้าหนี้ (vendor) ที่ระบุ (ใช้ query param เพราะ vendor_code อาจมี '/')",
+  })
+  @ApiQuery({ name: 'vendor_code', required: false, description: 'รหัสเจ้าหนี้/vendor' })
+  @ApiResponse({ status: 200, description: 'รายการ [{ pro_code, pro_name }]' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('vendors/products')
   getVendorProducts(@Query('vendor_code') vendorCode: string) {
     return this.happyHourService.getVendorProducts(vendorCode ?? '');

--- a/src/happy-hour/happy-hour.controller.ts
+++ b/src/happy-hour/happy-hour.controller.ts
@@ -125,7 +125,7 @@ export class HappyHourController {
   }
 
   @ApiOperation({ summary: 'แก้ไข slot ของ Happy Hour ตาม id' })
-  @ApiParam({ name: 'id', description: 'รหัส slot' })
+  @ApiParam({ name: 'id', description: 'รหัส slot', example: '1' })
   @ApiBody({ type: UpdateSlotDto })
   @ApiResponse({ status: 200, description: 'แก้ไข slot สำเร็จ' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -139,7 +139,7 @@ export class HappyHourController {
   }
 
   @ApiOperation({ summary: 'ลบ slot ของ Happy Hour ตาม id' })
-  @ApiParam({ name: 'id', description: 'รหัส slot' })
+  @ApiParam({ name: 'id', description: 'รหัส slot', example: '1' })
   @ApiResponse({ status: 204, description: 'ลบ slot สำเร็จ' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Delete('slots/:id')
@@ -199,11 +199,11 @@ export class HappyHourController {
   @ApiOperation({
     summary: 'ดึง audit log การ CREATE / UPDATE / DELETE slot พร้อม pagination',
   })
-  @ApiQuery({ name: 'action', required: false, enum: ['CREATE', 'UPDATE', 'DELETE'], description: 'กรองตาม action' })
-  @ApiQuery({ name: 'slot_id', required: false, description: 'กรองตาม slot id' })
-  @ApiQuery({ name: 'performed_by', required: false, description: 'กรองตาม username (บางส่วนก็ได้)' })
-  @ApiQuery({ name: 'page', required: false, description: 'หน้าที่ต้องการ (default 1)' })
-  @ApiQuery({ name: 'limit', required: false, description: 'จำนวนรายการต่อหน้า (default 20)' })
+  @ApiQuery({ name: 'action', required: false, enum: ['CREATE', 'UPDATE', 'DELETE'], example: 'UPDATE', description: 'Optional; กรองตาม action' })
+  @ApiQuery({ name: 'slot_id', required: false, example: '1', description: 'Optional; กรองตาม slot id' })
+  @ApiQuery({ name: 'performed_by', required: false, example: 'admin01', description: 'Optional; กรองตาม username (บางส่วนก็ได้)' })
+  @ApiQuery({ name: 'page', required: false, example: '1', description: 'Optional; หน้าที่ต้องการ (default 1)' })
+  @ApiQuery({ name: 'limit', required: false, example: '20', description: 'Optional; จำนวนรายการต่อหน้า (default 20)' })
   @ApiResponse({ status: 200, description: 'รายการ audit log ของ slot พร้อม pagination' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('slot-logs')
@@ -224,10 +224,10 @@ export class HappyHourController {
   @ApiOperation({
     summary: 'ดึง audit log การเปลี่ยน config (UPDATE / TOGGLE) พร้อม pagination',
   })
-  @ApiQuery({ name: 'action', required: false, enum: ['UPDATE', 'TOGGLE'], description: 'กรองตาม action' })
-  @ApiQuery({ name: 'performed_by', required: false, description: 'กรองตาม username (บางส่วนก็ได้)' })
-  @ApiQuery({ name: 'page', required: false, description: 'หน้าที่ต้องการ (default 1)' })
-  @ApiQuery({ name: 'limit', required: false, description: 'จำนวนรายการต่อหน้า (default 20)' })
+  @ApiQuery({ name: 'action', required: false, enum: ['UPDATE', 'TOGGLE'], example: 'TOGGLE', description: 'Optional; กรองตาม action' })
+  @ApiQuery({ name: 'performed_by', required: false, example: 'admin01', description: 'Optional; กรองตาม username (บางส่วนก็ได้)' })
+  @ApiQuery({ name: 'page', required: false, example: '1', description: 'Optional; หน้าที่ต้องการ (default 1)' })
+  @ApiQuery({ name: 'limit', required: false, example: '20', description: 'Optional; จำนวนรายการต่อหน้า (default 20)' })
   @ApiResponse({ status: 200, description: 'รายการ audit log ของ config พร้อม pagination' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('config-logs')
@@ -249,7 +249,8 @@ export class HappyHourController {
   @ApiQuery({
     name: 'codes',
     required: false,
-    description: "รหัสสินค้าหลายตัวคั่นด้วย comma เช่น 'A001,A002'",
+    example: 'A001,A002',
+    description: "Optional; รหัสสินค้าหลายตัวคั่นด้วย comma เช่น 'A001,A002'",
   })
   @ApiResponse({ status: 200, description: 'รายการ [{ pro_code, unit }]' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -265,7 +266,7 @@ export class HappyHourController {
    * Response: [{ vendor_code, vendor_name }]
    */
   @ApiOperation({ summary: "ค้นหา vendor (เจ้าหนี้) สำหรับ min_order_scope = 'vendor'" })
-  @ApiQuery({ name: 'keyword', required: false, description: 'คำค้นหาชื่อ/รหัส vendor' })
+  @ApiQuery({ name: 'keyword', required: false, example: 'บริษัท ยา', description: 'Optional; คำค้นหาชื่อ/รหัส vendor' })
   @ApiResponse({ status: 200, description: 'รายการ [{ vendor_code, vendor_name }]' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('vendors/search')
@@ -281,7 +282,7 @@ export class HappyHourController {
   @ApiOperation({
     summary: "ดึงรายการสินค้าทั้งหมดของเจ้าหนี้ (vendor) ที่ระบุ (ใช้ query param เพราะ vendor_code อาจมี '/')",
   })
-  @ApiQuery({ name: 'vendor_code', required: false, description: 'รหัสเจ้าหนี้/vendor' })
+  @ApiQuery({ name: 'vendor_code', required: false, example: 'V001', description: 'Optional; รหัสเจ้าหนี้/vendor' })
   @ApiResponse({ status: 200, description: 'รายการ [{ pro_code, pro_name }]' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('vendors/products')

--- a/src/happy-hour/happy-hour.controller.ts
+++ b/src/happy-hour/happy-hour.controller.ts
@@ -27,13 +27,15 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { HappyHourService } from './happy-hour.service';
-import { CreateSlotDto } from './dto/create-slot.dto';
-import { UpdateSlotDto } from './dto/update-slot.dto';
-import { UpdateConfigDto } from './dto/update-config.dto';
-import { SimulateDto } from './dto/simulate.dto';
-import { CartPreviewDto } from './dto/cart-preview.dto';
-import { SlotLogQueryDto } from './dto/slot-log-query.dto';
-import { ConfigLogQueryDto } from './dto/config-log-query.dto';
+import {
+  CreateSlotDto,
+  UpdateSlotDto,
+  UpdateConfigDto,
+  SimulateDto,
+  CartPreviewDto,
+  SlotLogQueryDto,
+  ConfigLogQueryDto,
+} from 'src/common/dto-index';
 interface JwtUser {
   username: string;
   name: string;

--- a/src/hotdeal/dto/check-hotdeal-match.dto.ts
+++ b/src/hotdeal/dto/check-hotdeal-match.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ShoppingCartItemDto {
+  @ApiProperty({ example: 'กล่อง' })
+  pro1_unit: string;
+
+  @ApiProperty({ example: '2' })
+  pro1_amount: string;
+}
+
+export class HotDealMatchItemDto {
+  @ApiProperty({ example: 'P00123' })
+  pro_code: string;
+
+  @ApiProperty({ type: [ShoppingCartItemDto] })
+  shopping_cart: ShoppingCartItemDto[];
+}
+
+export class CheckHotdealMatchDto {
+  @ApiProperty({ type: [HotDealMatchItemDto], description: 'Required' })
+  hotDeal: HotDealMatchItemDto[];
+}

--- a/src/hotdeal/dto/delete-hotdeal.dto.ts
+++ b/src/hotdeal/dto/delete-hotdeal.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteHotdealDto {
+  @ApiProperty({ example: 5, description: 'Required' })
+  id: number;
+
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+}

--- a/src/hotdeal/dto/save-hotdeal.dto.ts
+++ b/src/hotdeal/dto/save-hotdeal.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { HotdealInput } from '../hotdeal.service';
+
+export class SaveHotdealDto {
+  @ApiProperty({
+    type: Object,
+    description: 'Required; hotdeal input payload (pro_code, dates, discount, freebies, etc.)',
+  })
+  data: HotdealInput;
+
+  @ApiPropertyOptional({ example: 5, description: 'Optional; omit to create, provide to update' })
+  id?: number;
+
+  @ApiPropertyOptional({ example: 1, description: 'Optional' })
+  order?: number;
+
+  @ApiPropertyOptional({ example: false, description: 'Optional' })
+  special_deal?: boolean;
+}

--- a/src/invisible-product/dto/invisible-product.dto.ts
+++ b/src/invisible-product/dto/invisible-product.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AddInvisibleTopicDto {
+  @ApiProperty({ example: 'ซ่อนสินค้าโปรโมชั่น', description: 'Required; not empty' })
+  invisible_name: string;
+
+  @ApiProperty({ example: '2026-12-31', description: 'Required; format YYYY-MM-DD' })
+  date_end: string;
+
+  @ApiProperty({ example: 'C00123', description: 'Required; not empty' })
+  creditor_code: string;
+}
+
+export class AddInvisibleProductDto {
+  @ApiProperty({ example: 1, description: 'Required' })
+  invisible_id: number;
+
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+}
+
+export class DeleteInvisibleProductDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+}
+
+export class DeleteInvisibleTopicDto {
+  @ApiProperty({ example: '1', description: 'Required; not empty' })
+  invisible_id: string;
+}

--- a/src/landing/contact/contact.controller.ts
+++ b/src/landing/contact/contact.controller.ts
@@ -9,21 +9,44 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { ContactService, CreateContactDto } from './contact.service';
 import { ContactEntity, ContactStatus } from './contact.entity';
 
+@ApiTags('Landing - Contact')
 @Controller('ecom')
 export class ContactController {
   constructor(private readonly contactService: ContactService) {}
 
   // Public: Submit contact form
+  @ApiOperation({ summary: 'ส่งข้อความติดต่อจากแบบฟอร์มหน้า Landing Page (Public)' })
+  @ApiBody({ type: CreateContactDto })
+  @ApiResponse({ status: 201, description: 'ส่งข้อความติดต่อสำเร็จ', type: ContactEntity })
   @Post('landing/contact')
   async submitContact(@Body() data: CreateContactDto): Promise<ContactEntity> {
     return this.contactService.submitContact(data);
   }
 
   // Admin: Get all contacts with optional status filter
+  @ApiOperation({ summary: 'ดึงรายการข้อความติดต่อทั้งหมด สามารถกรองตามสถานะได้ (Admin)' })
+  @ApiBearerAuth()
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ContactStatus,
+    description: 'กรองตามสถานะของข้อความติดต่อ',
+  })
+  @ApiResponse({ status: 200, description: 'รายการข้อความติดต่อ', type: [ContactEntity] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/contacts')
   async getAllContacts(
@@ -33,6 +56,11 @@ export class ContactController {
   }
 
   // Admin: Get contact by ID
+  @ApiOperation({ summary: 'ดึงข้อมูลข้อความติดต่อตามรหัส (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของข้อความติดต่อ', example: '1' })
+  @ApiResponse({ status: 200, description: 'ข้อมูลข้อความติดต่อ', type: ContactEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/contacts/:id')
   async getContactById(@Param('id') id: string): Promise<ContactEntity | null> {
@@ -40,6 +68,10 @@ export class ContactController {
   }
 
   // Admin: Get contacts statistics
+  @ApiOperation({ summary: 'ดึงสถิติจำนวนข้อความติดต่อแยกตามสถานะ (Admin)' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, description: 'สถิติจำนวนข้อความติดต่อแยกตามสถานะ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/contacts/stats')
   async getContactsStats(): Promise<Record<string, number>> {
@@ -47,6 +79,10 @@ export class ContactController {
   }
 
   // Admin: Get pending contacts count
+  @ApiOperation({ summary: 'ดึงจำนวนข้อความติดต่อที่ยังรอดำเนินการ (Admin)' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, description: 'จำนวนข้อความติดต่อที่รอดำเนินการ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/contacts/pending-count')
   async getPendingCount(): Promise<{ count: number }> {
@@ -55,6 +91,11 @@ export class ContactController {
   }
 
   // Admin: Mark as read
+  @ApiOperation({ summary: 'ตั้งสถานะข้อความติดต่อเป็น "อ่านแล้ว" (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของข้อความติดต่อ', example: '1' })
+  @ApiResponse({ status: 200, description: 'อัปเดตสถานะเป็นอ่านแล้วสำเร็จ', type: ContactEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/contacts/:id/read')
   async markAsRead(@Param('id') id: string): Promise<ContactEntity | null> {
@@ -62,6 +103,21 @@ export class ContactController {
   }
 
   // Admin: Mark as replied
+  @ApiOperation({ summary: 'ตั้งสถานะข้อความติดต่อเป็น "ตอบกลับแล้ว" (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของข้อความติดต่อ', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        repliedBy: { type: 'string', description: 'ชื่อแอดมินผู้ตอบกลับ', example: 'admin01' },
+        adminNotes: { type: 'string', description: 'บันทึกเพิ่มเติม', example: 'ตอบกลับทางอีเมลแล้ว' },
+      },
+      required: ['repliedBy'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'อัปเดตสถานะเป็นตอบกลับแล้วสำเร็จ', type: ContactEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/contacts/:id/replied')
   async markAsReplied(
@@ -72,6 +128,19 @@ export class ContactController {
   }
 
   // Admin: Close contact
+  @ApiOperation({ summary: 'ปิดข้อความติดต่อ (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของข้อความติดต่อ', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        adminNotes: { type: 'string', description: 'บันทึกเพิ่มเติม', example: 'จบการสนทนาแล้ว' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'ปิดข้อความติดต่อสำเร็จ', type: ContactEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/contacts/:id/close')
   async closeContact(
@@ -82,6 +151,22 @@ export class ContactController {
   }
 
   // Admin: Update contact status
+  @ApiOperation({ summary: 'อัปเดตสถานะของข้อความติดต่อ (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของข้อความติดต่อ', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        status: { enum: Object.values(ContactStatus), description: 'สถานะใหม่ของข้อความติดต่อ' },
+        adminNotes: { type: 'string', description: 'บันทึกเพิ่มเติม' },
+        repliedBy: { type: 'string', description: 'ชื่อแอดมินผู้ตอบกลับ' },
+      },
+      required: ['status'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'อัปเดตสถานะสำเร็จ', type: ContactEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/contacts/:id/status')
   async updateContactStatus(
@@ -97,6 +182,11 @@ export class ContactController {
   }
 
   // Admin: Delete contact
+  @ApiOperation({ summary: 'ลบข้อความติดต่อ (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของข้อความติดต่อ', example: '1' })
+  @ApiResponse({ status: 200, description: 'ลบข้อความติดต่อสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('admin/landing/contacts/:id')
   async deleteContact(@Param('id') id: string): Promise<void> {

--- a/src/landing/contact/contact.entity.ts
+++ b/src/landing/contact/contact.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export enum ContactStatus {
   PENDING = 'pending',
@@ -15,27 +16,39 @@ export enum ContactStatus {
 
 @Entity({ name: 'landing_contacts' })
 export class ContactEntity {
+  @ApiProperty({ description: 'รหัสของข้อความติดต่อ', example: 1 })
   @PrimaryGeneratedColumn()
   id: number;
 
+  @ApiProperty({ description: 'ชื่อผู้ติดต่อ', example: 'สมชาย ใจดี' })
   @Column({ length: 100 })
   name: string;
 
+  @ApiProperty({ description: 'อีเมลผู้ติดต่อ', example: 'somchai@example.com' })
   @Column({ length: 100 })
   email: string;
 
+  @ApiPropertyOptional({ description: 'เบอร์โทรศัพท์', example: '0812345678' })
   @Column({ length: 20, nullable: true })
   phone: string;
 
+  @ApiPropertyOptional({ description: 'ชื่อบริษัท/ร้าน', example: 'ร้านยาสมชาย' })
   @Column({ length: 100, nullable: true })
   company: string;
 
+  @ApiProperty({ description: 'หัวข้อเรื่องที่ติดต่อ', example: 'สอบถามเรื่องสินค้า' })
   @Column({ length: 200 })
   subject: string;
 
+  @ApiProperty({ description: 'เนื้อหาข้อความ', example: 'อยากสอบถามเรื่องราคาสินค้า' })
   @Column({ type: 'text' })
   message: string;
 
+  @ApiProperty({
+    description: 'สถานะของข้อความติดต่อ',
+    enum: ContactStatus,
+    example: ContactStatus.PENDING,
+  })
   @Column({
     type: 'enum',
     enum: ContactStatus,
@@ -43,18 +56,23 @@ export class ContactEntity {
   })
   status: ContactStatus;
 
+  @ApiPropertyOptional({ description: 'บันทึกของแอดมิน', example: 'ติดต่อกลับแล้ว' })
   @Column({ type: 'text', nullable: true })
   admin_notes: string;
 
+  @ApiPropertyOptional({ description: 'ชื่อแอดมินผู้ตอบกลับ', example: 'admin01' })
   @Column({ length: 100, nullable: true })
   replied_by: string;
 
+  @ApiPropertyOptional({ description: 'วันเวลาที่ตอบกลับ' })
   @Column({ nullable: true })
   replied_at: Date;
 
+  @ApiProperty({ description: 'วันเวลาที่สร้างข้อความ' })
   @CreateDateColumn()
   created_at: Date;
 
+  @ApiProperty({ description: 'วันเวลาที่แก้ไขล่าสุด' })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/src/landing/contact/contact.service.ts
+++ b/src/landing/contact/contact.service.ts
@@ -1,14 +1,26 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ContactEntity, ContactStatus } from './contact.entity';
 
-export interface CreateContactDto {
+export class CreateContactDto {
+  @ApiProperty({ description: 'ชื่อผู้ติดต่อ', example: 'สมชาย ใจดี' })
   name: string;
+
+  @ApiProperty({ description: 'อีเมลผู้ติดต่อ', example: 'somchai@example.com' })
   email: string;
+
+  @ApiPropertyOptional({ description: 'เบอร์โทรศัพท์', example: '0812345678' })
   phone?: string;
+
+  @ApiPropertyOptional({ description: 'ชื่อบริษัท/ร้าน', example: 'ร้านยาสมชาย' })
   company?: string;
+
+  @ApiProperty({ description: 'หัวข้อเรื่องที่ติดต่อ', example: 'สอบถามเรื่องสินค้า' })
   subject: string;
+
+  @ApiProperty({ description: 'เนื้อหาข้อความ', example: 'อยากสอบถามเรื่องราคาสินค้า' })
   message: string;
 }
 

--- a/src/landing/faq/faq.controller.ts
+++ b/src/landing/faq/faq.controller.ts
@@ -8,21 +8,35 @@ import {
   Param,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiParam,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { FaqService } from './faq.service';
 import { FaqEntity } from './faq.entity';
 
+@ApiTags('Landing - FAQ')
 @Controller('ecom')
 export class FaqController {
   constructor(private readonly faqService: FaqService) {}
 
   // Public: Get all active FAQs
+  @ApiOperation({ summary: 'ดึงรายการคำถามที่พบบ่อยที่เปิดใช้งานทั้งหมด (Public)' })
+  @ApiResponse({ status: 200, description: 'รายการคำถามที่พบบ่อย', type: [FaqEntity] })
   @Get('landing/faqs')
   async getActiveFaqs(): Promise<FaqEntity[]> {
     return this.faqService.getActiveFaqs();
   }
 
   // Public: Get FAQs by category
+  @ApiOperation({ summary: 'ดึงรายการคำถามที่พบบ่อยตามหมวดหมู่ (Public)' })
+  @ApiParam({ name: 'category', description: 'ชื่อหมวดหมู่ของคำถาม', example: 'การสมัครสมาชิก' })
+  @ApiResponse({ status: 200, description: 'รายการคำถามที่พบบ่อยตามหมวดหมู่', type: [FaqEntity] })
   @Get('landing/faqs/category/:category')
   async getFaqsByCategory(
     @Param('category') category: string,
@@ -31,6 +45,10 @@ export class FaqController {
   }
 
   // Admin: Get all FAQs
+  @ApiOperation({ summary: 'ดึงรายการคำถามที่พบบ่อยทั้งหมด รวมที่ปิดใช้งาน (Admin)' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, description: 'รายการคำถามที่พบบ่อยทั้งหมด', type: [FaqEntity] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/faqs')
   async getAllFaqs(): Promise<FaqEntity[]> {
@@ -38,6 +56,11 @@ export class FaqController {
   }
 
   // Admin: Get FAQ by ID
+  @ApiOperation({ summary: 'ดึงข้อมูลคำถามที่พบบ่อยตามรหัส (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของคำถาม', example: '1' })
+  @ApiResponse({ status: 200, description: 'ข้อมูลคำถามที่พบบ่อย', type: FaqEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/faqs/:id')
   async getFaqById(@Param('id') id: string): Promise<FaqEntity | null> {
@@ -45,6 +68,23 @@ export class FaqController {
   }
 
   // Admin: Create FAQ
+  @ApiOperation({ summary: 'สร้างคำถามที่พบบ่อยใหม่ (Admin)' })
+  @ApiBearerAuth()
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        question: { type: 'string', description: 'คำถาม', example: 'สมัครสมาชิกอย่างไร' },
+        answer: { type: 'string', description: 'คำตอบ', example: 'กรอกแบบฟอร์มลงทะเบียน' },
+        category: { type: 'string', description: 'หมวดหมู่', example: 'การสมัครสมาชิก' },
+        display_order: { type: 'number', description: 'ลำดับการแสดงผล', example: 0 },
+        is_active: { type: 'boolean', description: 'สถานะเปิดใช้งาน', example: true },
+      },
+      required: ['question', 'answer'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้างคำถามที่พบบ่อยสำเร็จ', type: FaqEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('admin/landing/faqs')
   async createFaq(@Body() data: Partial<FaqEntity>): Promise<FaqEntity> {
@@ -52,6 +92,23 @@ export class FaqController {
   }
 
   // Admin: Update FAQ
+  @ApiOperation({ summary: 'แก้ไขคำถามที่พบบ่อย (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของคำถาม', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        question: { type: 'string', description: 'คำถาม' },
+        answer: { type: 'string', description: 'คำตอบ' },
+        category: { type: 'string', description: 'หมวดหมู่' },
+        display_order: { type: 'number', description: 'ลำดับการแสดงผล' },
+        is_active: { type: 'boolean', description: 'สถานะเปิดใช้งาน' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'แก้ไขคำถามที่พบบ่อยสำเร็จ', type: FaqEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/faqs/:id')
   async updateFaq(
@@ -62,6 +119,11 @@ export class FaqController {
   }
 
   // Admin: Delete FAQ
+  @ApiOperation({ summary: 'ลบคำถามที่พบบ่อย (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของคำถาม', example: '1' })
+  @ApiResponse({ status: 200, description: 'ลบคำถามที่พบบ่อยสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('admin/landing/faqs/:id')
   async deleteFaq(@Param('id') id: string): Promise<void> {
@@ -69,6 +131,11 @@ export class FaqController {
   }
 
   // Admin: Toggle FAQ status
+  @ApiOperation({ summary: 'สลับสถานะเปิด/ปิดใช้งานคำถามที่พบบ่อย (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของคำถาม', example: '1' })
+  @ApiResponse({ status: 200, description: 'สลับสถานะสำเร็จ', type: FaqEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/faqs/:id/toggle')
   async toggleFaqStatus(@Param('id') id: string): Promise<FaqEntity | null> {
@@ -76,6 +143,24 @@ export class FaqController {
   }
 
   // Admin: Reorder FAQs
+  @ApiOperation({ summary: 'จัดลำดับการแสดงผลคำถามที่พบบ่อยใหม่ (Admin)' })
+  @ApiBearerAuth()
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        ids: {
+          type: 'array',
+          items: { type: 'number' },
+          description: 'รายการรหัสคำถามเรียงตามลำดับใหม่',
+          example: [3, 1, 2],
+        },
+      },
+      required: ['ids'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'จัดลำดับสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/faqs/reorder')
   async reorderFaqs(@Body() body: { ids: number[] }): Promise<void> {

--- a/src/landing/faq/faq.entity.ts
+++ b/src/landing/faq/faq.entity.ts
@@ -5,30 +5,39 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 @Entity({ name: 'landing_faqs' })
 export class FaqEntity {
+  @ApiProperty({ description: 'รหัสของคำถาม', example: 1 })
   @PrimaryGeneratedColumn()
   id: number;
 
+  @ApiProperty({ description: 'คำถาม', example: 'สมัครสมาชิกอย่างไร' })
   @Column({ length: 500 })
   question: string;
 
+  @ApiProperty({ description: 'คำตอบ', example: 'กรอกแบบฟอร์มลงทะเบียนและอัปโหลดเอกสาร' })
   @Column({ type: 'text' })
   answer: string;
 
+  @ApiPropertyOptional({ description: 'หมวดหมู่ของคำถาม', example: 'การสมัครสมาชิก' })
   @Column({ length: 100, nullable: true })
   category: string;
 
+  @ApiPropertyOptional({ description: 'ลำดับการแสดงผล', example: 0 })
   @Column({ default: 0 })
   display_order: number;
 
+  @ApiPropertyOptional({ description: 'สถานะเปิดใช้งาน', example: true })
   @Column({ default: true })
   is_active: boolean;
 
+  @ApiProperty({ description: 'วันเวลาที่สร้าง' })
   @CreateDateColumn()
   created_at: Date;
 
+  @ApiProperty({ description: 'วันเวลาที่แก้ไขล่าสุด' })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/src/landing/partners/partner.controller.ts
+++ b/src/landing/partners/partner.controller.ts
@@ -8,21 +8,35 @@ import {
   Param,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiParam,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { PartnerService } from './partner.service';
 import { PartnerEntity } from './partner.entity';
 
+@ApiTags('Landing - Partners')
 @Controller('ecom')
 export class PartnerController {
   constructor(private readonly partnerService: PartnerService) {}
 
   // Public: Get all active partners
+  @ApiOperation({ summary: 'ดึงรายการพาร์ทเนอร์ที่เปิดใช้งานทั้งหมด (Public)' })
+  @ApiResponse({ status: 200, description: 'รายการพาร์ทเนอร์', type: [PartnerEntity] })
   @Get('landing/partners')
   async getActivePartners(): Promise<PartnerEntity[]> {
     return this.partnerService.getActivePartners();
   }
 
   // Public: Get partners by category
+  @ApiOperation({ summary: 'ดึงรายการพาร์ทเนอร์ตามหมวดหมู่ (Public)' })
+  @ApiParam({ name: 'category', description: 'ชื่อหมวดหมู่ของพาร์ทเนอร์', example: 'ผู้จัดจำหน่าย' })
+  @ApiResponse({ status: 200, description: 'รายการพาร์ทเนอร์ตามหมวดหมู่', type: [PartnerEntity] })
   @Get('landing/partners/category/:category')
   async getPartnersByCategory(
     @Param('category') category: string,
@@ -31,6 +45,10 @@ export class PartnerController {
   }
 
   // Admin: Get all partners
+  @ApiOperation({ summary: 'ดึงรายการพาร์ทเนอร์ทั้งหมด รวมที่ปิดใช้งาน (Admin)' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, description: 'รายการพาร์ทเนอร์ทั้งหมด', type: [PartnerEntity] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/partners')
   async getAllPartners(): Promise<PartnerEntity[]> {
@@ -38,6 +56,11 @@ export class PartnerController {
   }
 
   // Admin: Get partner by ID
+  @ApiOperation({ summary: 'ดึงข้อมูลพาร์ทเนอร์ตามรหัส (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของพาร์ทเนอร์', example: '1' })
+  @ApiResponse({ status: 200, description: 'ข้อมูลพาร์ทเนอร์', type: PartnerEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/partners/:id')
   async getPartnerById(@Param('id') id: string): Promise<PartnerEntity | null> {
@@ -45,6 +68,30 @@ export class PartnerController {
   }
 
   // Admin: Create partner
+  @ApiOperation({ summary: 'สร้างพาร์ทเนอร์ใหม่ (Admin)' })
+  @ApiBearerAuth()
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'ชื่อพาร์ทเนอร์', example: 'บริษัท ตัวอย่าง จำกัด' },
+        logo_url: { type: 'string', description: 'URL โลโก้พาร์ทเนอร์' },
+        website: { type: 'string', description: 'URL เว็บไซต์พาร์ทเนอร์' },
+        description: { type: 'string', description: 'คำอธิบายพาร์ทเนอร์' },
+        category: { type: 'string', description: 'หมวดหมู่พาร์ทเนอร์' },
+        creditor_codes: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'รายการรหัสเจ้าหนี้ที่เกี่ยวข้อง',
+        },
+        display_order: { type: 'number', description: 'ลำดับการแสดงผล' },
+        is_active: { type: 'boolean', description: 'สถานะเปิดใช้งาน' },
+      },
+      required: ['name'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้างพาร์ทเนอร์สำเร็จ', type: PartnerEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('admin/landing/partners')
   async createPartner(
@@ -54,6 +101,30 @@ export class PartnerController {
   }
 
   // Admin: Update partner
+  @ApiOperation({ summary: 'แก้ไขข้อมูลพาร์ทเนอร์ (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของพาร์ทเนอร์', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'ชื่อพาร์ทเนอร์' },
+        logo_url: { type: 'string', description: 'URL โลโก้พาร์ทเนอร์' },
+        website: { type: 'string', description: 'URL เว็บไซต์พาร์ทเนอร์' },
+        description: { type: 'string', description: 'คำอธิบายพาร์ทเนอร์' },
+        category: { type: 'string', description: 'หมวดหมู่พาร์ทเนอร์' },
+        creditor_codes: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'รายการรหัสเจ้าหนี้ที่เกี่ยวข้อง',
+        },
+        display_order: { type: 'number', description: 'ลำดับการแสดงผล' },
+        is_active: { type: 'boolean', description: 'สถานะเปิดใช้งาน' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'แก้ไขพาร์ทเนอร์สำเร็จ', type: PartnerEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/partners/:id')
   async updatePartner(
@@ -64,6 +135,11 @@ export class PartnerController {
   }
 
   // Admin: Delete partner
+  @ApiOperation({ summary: 'ลบพาร์ทเนอร์ (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของพาร์ทเนอร์', example: '1' })
+  @ApiResponse({ status: 200, description: 'ลบพาร์ทเนอร์สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('admin/landing/partners/:id')
   async deletePartner(@Param('id') id: string): Promise<void> {
@@ -71,6 +147,11 @@ export class PartnerController {
   }
 
   // Admin: Toggle partner status
+  @ApiOperation({ summary: 'สลับสถานะเปิด/ปิดใช้งานพาร์ทเนอร์ (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของพาร์ทเนอร์', example: '1' })
+  @ApiResponse({ status: 200, description: 'สลับสถานะสำเร็จ', type: PartnerEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/partners/:id/toggle')
   async togglePartnerStatus(@Param('id') id: string): Promise<PartnerEntity | null> {
@@ -78,6 +159,24 @@ export class PartnerController {
   }
 
   // Admin: Reorder partners
+  @ApiOperation({ summary: 'จัดลำดับการแสดงผลพาร์ทเนอร์ใหม่ (Admin)' })
+  @ApiBearerAuth()
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        ids: {
+          type: 'array',
+          items: { type: 'number' },
+          description: 'รายการรหัสพาร์ทเนอร์เรียงตามลำดับใหม่',
+          example: [3, 1, 2],
+        },
+      },
+      required: ['ids'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'จัดลำดับสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/partners/reorder')
   async reorderPartners(@Body() body: { ids: number[] }): Promise<void> {

--- a/src/landing/partners/partner.entity.ts
+++ b/src/landing/partners/partner.entity.ts
@@ -5,39 +5,56 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 @Entity({ name: 'landing_partners' })
 export class PartnerEntity {
+  @ApiProperty({ description: 'รหัสของพาร์ทเนอร์', example: 1 })
   @PrimaryGeneratedColumn()
   id: number;
 
+  @ApiProperty({ description: 'ชื่อพาร์ทเนอร์', example: 'บริษัท ตัวอย่าง จำกัด' })
   @Column({ length: 200 })
   name: string;
 
+  @ApiPropertyOptional({ description: 'URL โลโก้พาร์ทเนอร์', example: 'https://example.com/logo.png' })
   @Column({ length: 500, nullable: true })
   logo_url: string;
 
+  @ApiPropertyOptional({ description: 'URL เว็บไซต์พาร์ทเนอร์', example: 'https://example.com' })
   @Column({ length: 500, nullable: true })
   website: string;
 
+  @ApiPropertyOptional({ description: 'คำอธิบายพาร์ทเนอร์', example: 'พาร์ทเนอร์ผู้จัดจำหน่ายยา' })
   @Column({ type: 'text', nullable: true })
   description: string;
 
+  @ApiPropertyOptional({ description: 'หมวดหมู่พาร์ทเนอร์', example: 'ผู้จัดจำหน่าย' })
   @Column({ length: 100, nullable: true })
   category: string;
 
+  @ApiPropertyOptional({
+    description: 'รายการรหัสเจ้าหนี้ (creditor codes) ที่เกี่ยวข้อง',
+    type: [String],
+    nullable: true,
+    example: ['C001', 'C002'],
+  })
   @Column({ type: 'simple-json', nullable: true })
   creditor_codes: string[] | null;
 
+  @ApiPropertyOptional({ description: 'ลำดับการแสดงผล', example: 0 })
   @Column({ default: 0 })
   display_order: number;
 
+  @ApiPropertyOptional({ description: 'สถานะเปิดใช้งาน', example: true })
   @Column({ default: true })
   is_active: boolean;
 
+  @ApiProperty({ description: 'วันเวลาที่สร้าง' })
   @CreateDateColumn()
   created_at: Date;
 
+  @ApiProperty({ description: 'วันเวลาที่แก้ไขล่าสุด' })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/src/landing/site-config/site-config.controller.ts
+++ b/src/landing/site-config/site-config.controller.ts
@@ -8,21 +8,35 @@ import {
   Param,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiParam,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { SiteConfigService } from './site-config.service';
 import { SiteConfigEntity, ConfigType } from './site-config.entity';
 
+@ApiTags('Landing - Site Config')
 @Controller('ecom')
 export class SiteConfigController {
   constructor(private readonly siteConfigService: SiteConfigService) {}
 
   // Public: Get all public configs
+  @ApiOperation({ summary: 'ดึง config ทั้งหมดที่เป็น public (ไม่ถูกซ่อน) (Public)' })
+  @ApiResponse({ status: 200, description: 'ออบเจกต์ของ config key-value ที่เป็น public' })
   @Get('landing/site-config')
   async getAllPublicConfigs(): Promise<Record<string, any>> {
     return this.siteConfigService.getAllPublicConfigs();
   }
 
   // Public: Get config by key
+  @ApiOperation({ summary: 'ดึงค่า config ตามคีย์ (Public)' })
+  @ApiParam({ name: 'key', description: 'คีย์ของ config', example: 'site_title' })
+  @ApiResponse({ status: 200, description: 'ค่าของ config ตามคีย์ที่ระบุ' })
   @Get('landing/site-config/:key')
   async getConfig(
     @Param('key') key: string,
@@ -32,6 +46,9 @@ export class SiteConfigController {
   }
 
   // Public: Get configs by category
+  @ApiOperation({ summary: 'ดึง config ทั้งหมดตามหมวดหมู่ (Public)' })
+  @ApiParam({ name: 'category', description: 'หมวดหมู่ของ config', example: 'general' })
+  @ApiResponse({ status: 200, description: 'ออบเจกต์ของ config key-value ตามหมวดหมู่' })
   @Get('landing/site-config/category/:category')
   async getConfigsByCategory(
     @Param('category') category: string,
@@ -40,6 +57,10 @@ export class SiteConfigController {
   }
 
   // Admin: Get all configs
+  @ApiOperation({ summary: 'ดึง config ทั้งหมด รวมที่ถูกซ่อน (Admin)' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, description: 'รายการ config ทั้งหมด', type: [SiteConfigEntity] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/site-config')
   async getAllConfigs(): Promise<SiteConfigEntity[]> {
@@ -47,6 +68,11 @@ export class SiteConfigController {
   }
 
   // Admin: Get config entity by key
+  @ApiOperation({ summary: 'ดึงข้อมูล config entity ตามคีย์ (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'key', description: 'คีย์ของ config', example: 'site_title' })
+  @ApiResponse({ status: 200, description: 'ข้อมูล config entity', type: SiteConfigEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/site-config/:key')
   async getConfigEntity(
@@ -56,6 +82,24 @@ export class SiteConfigController {
   }
 
   // Admin: Create config
+  @ApiOperation({ summary: 'สร้าง config ใหม่ (Admin)' })
+  @ApiBearerAuth()
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        config_key: { type: 'string', description: 'คีย์ของ config (unique)', example: 'site_title' },
+        config_value: { type: 'string', description: 'ค่าของ config', example: 'WangPharma E-commerce' },
+        config_type: { enum: Object.values(ConfigType), description: 'ประเภทของค่า config' },
+        description: { type: 'string', description: 'คำอธิบาย config' },
+        category: { type: 'string', description: 'หมวดหมู่ของ config' },
+        hidden: { type: 'boolean', description: 'ซ่อนจาก public หรือไม่' },
+      },
+      required: ['config_key', 'config_value'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้าง config สำเร็จ', type: SiteConfigEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('admin/landing/site-config')
   async createConfig(
@@ -65,6 +109,22 @@ export class SiteConfigController {
   }
 
   // Admin: Update config
+  @ApiOperation({ summary: 'แก้ไขค่า config ตามคีย์ (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'key', description: 'คีย์ของ config', example: 'site_title' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        value: { type: 'string', description: 'ค่าใหม่ของ config', example: 'WangPharma E-commerce' },
+        type: { enum: Object.values(ConfigType), description: 'ประเภทของค่า config' },
+        hidden: { type: 'boolean', description: 'ซ่อนจาก public หรือไม่' },
+      },
+      required: ['value', 'hidden'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'แก้ไข config สำเร็จ', type: SiteConfigEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/site-config/:key')
   async updateConfig(
@@ -80,6 +140,11 @@ export class SiteConfigController {
   }
 
   // Admin: Delete config
+  @ApiOperation({ summary: 'ลบ config ตามคีย์ (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'key', description: 'คีย์ของ config', example: 'site_title' })
+  @ApiResponse({ status: 200, description: 'ลบ config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('admin/landing/site-config/:key')
   async deleteConfig(@Param('key') key: string): Promise<void> {

--- a/src/landing/site-config/site-config.entity.ts
+++ b/src/landing/site-config/site-config.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export enum ConfigType {
   TEXT = 'text',
@@ -16,15 +17,23 @@ export enum ConfigType {
 
 @Entity({ name: 'landing_site_configs' })
 export class SiteConfigEntity {
+  @ApiProperty({ description: 'รหัสของ config', example: 1 })
   @PrimaryGeneratedColumn()
   id!: number;
 
+  @ApiProperty({ description: 'คีย์ของ config (unique)', example: 'site_title' })
   @Column({ length: 100, unique: true })
   config_key!: string;
 
+  @ApiProperty({ description: 'ค่าของ config', example: 'WangPharma E-commerce' })
   @Column({ type: 'text' })
   config_value!: string;
 
+  @ApiProperty({
+    description: 'ประเภทของค่า config',
+    enum: ConfigType,
+    example: ConfigType.TEXT,
+  })
   @Column({
     type: 'enum',
     enum: ConfigType,
@@ -32,18 +41,23 @@ export class SiteConfigEntity {
   })
   config_type!: ConfigType;
 
+  @ApiPropertyOptional({ description: 'คำอธิบาย config', example: 'ชื่อเว็บไซต์ที่แสดงบนหน้า Landing' })
   @Column({ length: 200, nullable: true })
   description!: string;
 
+  @ApiPropertyOptional({ description: 'หมวดหมู่ของ config', example: 'general' })
   @Column({ length: 100, nullable: true })
   category!: string;
 
+  @ApiPropertyOptional({ description: 'ซ่อนจาก public หรือไม่', example: false })
   @Column({ type: 'boolean', default: false })
   hidden!: boolean;
 
+  @ApiProperty({ description: 'วันเวลาที่สร้าง' })
   @CreateDateColumn()
   created_at!: Date;
 
+  @ApiProperty({ description: 'วันเวลาที่แก้ไขล่าสุด' })
   @UpdateDateColumn()
   updated_at!: Date;
 }

--- a/src/landing/testimonials/testimonial.controller.ts
+++ b/src/landing/testimonials/testimonial.controller.ts
@@ -8,21 +8,36 @@ import {
   Param,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiParam,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { TestimonialService } from './testimonial.service';
 import { TestimonialEntity } from './testimonial.entity';
 
+@ApiTags('Landing - Testimonials')
 @Controller('ecom')
 export class TestimonialController {
   constructor(private readonly testimonialService: TestimonialService) {}
 
   // Public: Get all active testimonials
+  @ApiOperation({ summary: 'ดึงรายการคำรับรองที่เปิดใช้งานทั้งหมด (Public)' })
+  @ApiResponse({ status: 200, description: 'รายการคำรับรอง', type: [TestimonialEntity] })
   @Get('landing/testimonials')
   async getActiveTestimonials(): Promise<TestimonialEntity[]> {
     return this.testimonialService.getActiveTestimonials();
   }
 
   // Admin: Get all testimonials
+  @ApiOperation({ summary: 'ดึงรายการคำรับรองทั้งหมด รวมที่ปิดใช้งาน (Admin)' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, description: 'รายการคำรับรองทั้งหมด', type: [TestimonialEntity] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/testimonials')
   async getAllTestimonials(): Promise<TestimonialEntity[]> {
@@ -30,6 +45,11 @@ export class TestimonialController {
   }
 
   // Admin: Get testimonial by ID
+  @ApiOperation({ summary: 'ดึงข้อมูลคำรับรองตามรหัส (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของคำรับรอง', example: '1' })
+  @ApiResponse({ status: 200, description: 'ข้อมูลคำรับรอง', type: TestimonialEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/landing/testimonials/:id')
   async getTestimonialById(@Param('id') id: string): Promise<TestimonialEntity | null> {
@@ -37,6 +57,26 @@ export class TestimonialController {
   }
 
   // Admin: Create testimonial
+  @ApiOperation({ summary: 'สร้างคำรับรองใหม่ (Admin)' })
+  @ApiBearerAuth()
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'ชื่อผู้ให้คำรับรอง', example: 'สมหญิง รักดี' },
+        company: { type: 'string', description: 'ชื่อบริษัท/ร้าน' },
+        position: { type: 'string', description: 'ตำแหน่งของผู้ให้คำรับรอง' },
+        content: { type: 'string', description: 'เนื้อหาคำรับรอง', example: 'ใช้งานง่ายและสะดวกมาก' },
+        rating: { type: 'number', description: 'คะแนนรีวิว (1-5)', example: 5 },
+        avatar_url: { type: 'string', description: 'URL รูปประจำตัว' },
+        display_order: { type: 'number', description: 'ลำดับการแสดงผล' },
+        is_active: { type: 'boolean', description: 'สถานะเปิดใช้งาน' },
+      },
+      required: ['name', 'content'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้างคำรับรองสำเร็จ', type: TestimonialEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('admin/landing/testimonials')
   async createTestimonial(
@@ -46,6 +86,26 @@ export class TestimonialController {
   }
 
   // Admin: Update testimonial
+  @ApiOperation({ summary: 'แก้ไขข้อมูลคำรับรอง (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของคำรับรอง', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'ชื่อผู้ให้คำรับรอง' },
+        company: { type: 'string', description: 'ชื่อบริษัท/ร้าน' },
+        position: { type: 'string', description: 'ตำแหน่งของผู้ให้คำรับรอง' },
+        content: { type: 'string', description: 'เนื้อหาคำรับรอง' },
+        rating: { type: 'number', description: 'คะแนนรีวิว (1-5)' },
+        avatar_url: { type: 'string', description: 'URL รูปประจำตัว' },
+        display_order: { type: 'number', description: 'ลำดับการแสดงผล' },
+        is_active: { type: 'boolean', description: 'สถานะเปิดใช้งาน' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'แก้ไขคำรับรองสำเร็จ', type: TestimonialEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/testimonials/:id')
   async updateTestimonial(
@@ -56,6 +116,11 @@ export class TestimonialController {
   }
 
   // Admin: Delete testimonial
+  @ApiOperation({ summary: 'ลบคำรับรอง (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของคำรับรอง', example: '1' })
+  @ApiResponse({ status: 200, description: 'ลบคำรับรองสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('admin/landing/testimonials/:id')
   async deleteTestimonial(@Param('id') id: string): Promise<void> {
@@ -63,6 +128,11 @@ export class TestimonialController {
   }
 
   // Admin: Toggle testimonial status
+  @ApiOperation({ summary: 'สลับสถานะเปิด/ปิดใช้งานคำรับรอง (Admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'รหัสของคำรับรอง', example: '1' })
+  @ApiResponse({ status: 200, description: 'สลับสถานะสำเร็จ', type: TestimonialEntity })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/testimonials/:id/toggle')
   async toggleTestimonialStatus(
@@ -72,6 +142,24 @@ export class TestimonialController {
   }
 
   // Admin: Reorder testimonials
+  @ApiOperation({ summary: 'จัดลำดับการแสดงผลคำรับรองใหม่ (Admin)' })
+  @ApiBearerAuth()
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        ids: {
+          type: 'array',
+          items: { type: 'number' },
+          description: 'รายการรหัสคำรับรองเรียงตามลำดับใหม่',
+          example: [3, 1, 2],
+        },
+      },
+      required: ['ids'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'จัดลำดับสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/landing/testimonials/reorder')
   async reorderTestimonials(@Body() body: { ids: number[] }): Promise<void> {

--- a/src/landing/testimonials/testimonial.entity.ts
+++ b/src/landing/testimonials/testimonial.entity.ts
@@ -5,39 +5,51 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 @Entity({ name: 'landing_testimonials' })
 export class TestimonialEntity {
+  @ApiProperty({ description: 'รหัสของคำรับรอง', example: 1 })
   @PrimaryGeneratedColumn()
   id: number;
 
+  @ApiProperty({ description: 'ชื่อผู้ให้คำรับรอง', example: 'สมหญิง รักดี' })
   @Column({ length: 100 })
   name: string;
 
+  @ApiPropertyOptional({ description: 'ชื่อบริษัท/ร้าน', example: 'ร้านยาสมหญิง' })
   @Column({ length: 100, nullable: true })
   company: string;
 
+  @ApiPropertyOptional({ description: 'ตำแหน่งของผู้ให้คำรับรอง', example: 'เภสัชกร' })
   @Column({ length: 100, nullable: true })
   position: string;
 
+  @ApiProperty({ description: 'เนื้อหาคำรับรอง', example: 'ใช้งานง่ายและสะดวกมาก' })
   @Column({ type: 'text' })
   content: string;
 
+  @ApiPropertyOptional({ description: 'คะแนนรีวิว (1-5)', example: 5 })
   @Column({ type: 'int', default: 5 })
   rating: number;
 
+  @ApiPropertyOptional({ description: 'URL รูปประจำตัว', example: 'https://example.com/avatar.png' })
   @Column({ length: 500, nullable: true })
   avatar_url: string;
 
+  @ApiPropertyOptional({ description: 'ลำดับการแสดงผล', example: 0 })
   @Column({ default: 0 })
   display_order: number;
 
+  @ApiPropertyOptional({ description: 'สถานะเปิดใช้งาน', example: true })
   @Column({ default: true })
   is_active: boolean;
 
+  @ApiProperty({ description: 'วันเวลาที่สร้าง' })
   @CreateDateColumn()
   created_at: Date;
 
+  @ApiProperty({ description: 'วันเวลาที่แก้ไขล่าสุด' })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/src/line-oa-monitor/line-oa-monitor.controller.ts
+++ b/src/line-oa-monitor/line-oa-monitor.controller.ts
@@ -1,11 +1,29 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { LineOaMonitorService, LineOaMonitorResponse } from './line-oa-monitor.service';
 
+@ApiTags('LINE OA Monitor')
 @Controller('ecom')
 export class LineOaMonitorController {
   constructor(private readonly lineOaMonitorService: LineOaMonitorService) {}
 
+  @ApiOperation({
+    summary:
+      'ดึงข้อมูลสรุปสถานะการลงทะเบียน LINE OA ของสมาชิกทั้งหมด (admin)',
+  })
+  @ApiBearerAuth()
+  @ApiResponse({
+    status: 200,
+    description:
+      'สรุปจำนวนสมาชิกทั้งหมด/ลงทะเบียนแล้ว/ยังไม่ลงทะเบียน พร้อมรายชื่อสมาชิก',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/line-oa-monitor')
   async getMonitorData(): Promise<LineOaMonitorResponse> {

--- a/src/line-register-meeting/dto/register-meeting.dto.ts
+++ b/src/line-register-meeting/dto/register-meeting.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AttendeeDto {
+  @ApiProperty({
+    example: 'สมชาย ใจดี',
+    description: 'Required; not empty; ชื่อผู้เข้าร่วม',
+  })
+  member_name: string;
+
+  @ApiProperty({
+    example: '0812345678',
+    description: 'Required; not empty; เบอร์โทรศัพท์',
+  })
+  phone: string;
+
+  @ApiProperty({
+    example: 'กรุงเทพมหานคร',
+    description: 'Required; not empty; จังหวัด',
+  })
+  province: string;
+
+  @ApiProperty({
+    example: 'U1234567890abcdef1234567890abcdef',
+    description: 'Required; not empty; LINE ID',
+  })
+  line_id: string;
+}
+
+export class RegisterMeetingDto {
+  @ApiProperty({
+    example: 'M00001',
+    description: 'Required; not empty; รหัสสมาชิก/ร้านค้า',
+  })
+  mem_code: string;
+
+  @ApiProperty({
+    example: 'ร้านยาสุขภาพดี',
+    description: 'Required; not empty; ชื่อร้านค้า',
+  })
+  store_name: string;
+
+  @ApiProperty({
+    type: [AttendeeDto],
+    description: 'Required; not empty; รายชื่อผู้เข้าร่วมประชุม',
+  })
+  attendees: AttendeeDto[];
+}

--- a/src/line-register-meeting/line-register-meeting.controller.ts
+++ b/src/line-register-meeting/line-register-meeting.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Res } from '@nestjs/common';
 import { Get, Post, Body } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { LineRegisterMeetingService } from './line-register-meeting.service';
-import { RegisterMeetingDto } from './dto/register-meeting.dto';
+import { RegisterMeetingDto } from 'src/common/dto-index';
 import { Response } from 'express';
 
 @ApiTags('LINE Register Meeting')

--- a/src/line-register-meeting/line-register-meeting.controller.ts
+++ b/src/line-register-meeting/line-register-meeting.controller.ts
@@ -1,14 +1,23 @@
 import { Controller, Res } from '@nestjs/common';
 import { Get, Post, Body } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { LineRegisterMeetingService } from './line-register-meeting.service';
 import { Response } from 'express';
 
+@ApiTags('LINE Register Meeting')
 @Controller('ecom/line-register-meeting')
 export class LineRegisterMeetingController {
   constructor(
     private readonly lineRegisterMeetingService: LineRegisterMeetingService,
   ) {}
 
+  @ApiOperation({
+    summary: 'ส่งออกรายชื่อสมาชิกที่ลงทะเบียนเข้าร่วมประชุมเป็นไฟล์ Excel',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'ไฟล์ Excel (.xlsx) รายชื่อสมาชิกที่ลงทะเบียนเข้าร่วมประชุม',
+  })
   @Get('export')
   async exportExcel(@Res() res: Response) {
     const buffer = await this.lineRegisterMeetingService.getAllMember();
@@ -22,6 +31,34 @@ export class LineRegisterMeetingController {
     res.end(buffer);
   }
 
+  @ApiOperation({ summary: 'ลงทะเบียนร้านค้าและผู้เข้าร่วมประชุมผ่าน LINE' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['mem_code', 'store_name', 'attendees'],
+      properties: {
+        mem_code: { type: 'string', description: 'รหัสสมาชิก/ร้านค้า' },
+        store_name: { type: 'string', description: 'ชื่อร้านค้า' },
+        attendees: {
+          type: 'array',
+          description: 'รายชื่อผู้เข้าร่วมประชุม',
+          items: {
+            type: 'object',
+            properties: {
+              member_name: { type: 'string', description: 'ชื่อผู้เข้าร่วม' },
+              phone: { type: 'string', description: 'เบอร์โทรศัพท์' },
+              province: { type: 'string', description: 'จังหวัด' },
+              line_id: { type: 'string', description: 'LINE ID' },
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'ลงทะเบียนเข้าร่วมประชุมสำเร็จ',
+  })
   @Post()
   registerMeeting(
     @Body()

--- a/src/line-register-meeting/line-register-meeting.controller.ts
+++ b/src/line-register-meeting/line-register-meeting.controller.ts
@@ -37,18 +37,43 @@ export class LineRegisterMeetingController {
       type: 'object',
       required: ['mem_code', 'store_name', 'attendees'],
       properties: {
-        mem_code: { type: 'string', description: 'รหัสสมาชิก/ร้านค้า' },
-        store_name: { type: 'string', description: 'ชื่อร้านค้า' },
+        mem_code: {
+          type: 'string',
+          example: 'M00001',
+          description: 'Required; not empty; รหัสสมาชิก/ร้านค้า',
+        },
+        store_name: {
+          type: 'string',
+          example: 'ร้านยาสุขภาพดี',
+          description: 'Required; not empty; ชื่อร้านค้า',
+        },
         attendees: {
           type: 'array',
-          description: 'รายชื่อผู้เข้าร่วมประชุม',
+          description: 'Required; not empty; รายชื่อผู้เข้าร่วมประชุม',
           items: {
             type: 'object',
+            required: ['member_name', 'phone', 'province', 'line_id'],
             properties: {
-              member_name: { type: 'string', description: 'ชื่อผู้เข้าร่วม' },
-              phone: { type: 'string', description: 'เบอร์โทรศัพท์' },
-              province: { type: 'string', description: 'จังหวัด' },
-              line_id: { type: 'string', description: 'LINE ID' },
+              member_name: {
+                type: 'string',
+                example: 'สมชาย ใจดี',
+                description: 'Required; not empty; ชื่อผู้เข้าร่วม',
+              },
+              phone: {
+                type: 'string',
+                example: '0812345678',
+                description: 'Required; not empty; เบอร์โทรศัพท์',
+              },
+              province: {
+                type: 'string',
+                example: 'กรุงเทพมหานคร',
+                description: 'Required; not empty; จังหวัด',
+              },
+              line_id: {
+                type: 'string',
+                example: 'U1234567890abcdef1234567890abcdef',
+                description: 'Required; not empty; LINE ID',
+              },
             },
           },
         },

--- a/src/line-register-meeting/line-register-meeting.controller.ts
+++ b/src/line-register-meeting/line-register-meeting.controller.ts
@@ -1,14 +1,24 @@
 import { Controller, Res } from '@nestjs/common';
 import { Get, Post, Body } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { LineRegisterMeetingService } from './line-register-meeting.service';
+import { RegisterMeetingDto } from './dto/register-meeting.dto';
 import { Response } from 'express';
 
+@ApiTags('LINE Register Meeting')
 @Controller('ecom/line-register-meeting')
 export class LineRegisterMeetingController {
   constructor(
     private readonly lineRegisterMeetingService: LineRegisterMeetingService,
   ) {}
 
+  @ApiOperation({
+    summary: 'ส่งออกรายชื่อสมาชิกที่ลงทะเบียนเข้าร่วมประชุมเป็นไฟล์ Excel',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'ไฟล์ Excel (.xlsx) รายชื่อสมาชิกที่ลงทะเบียนเข้าร่วมประชุม',
+  })
   @Get('export')
   async exportExcel(@Res() res: Response) {
     const buffer = await this.lineRegisterMeetingService.getAllMember();
@@ -22,20 +32,29 @@ export class LineRegisterMeetingController {
     res.end(buffer);
   }
 
-  @Post()
-  registerMeeting(
-    @Body()
-    data: {
-      mem_code: string;
-      store_name: string;
-      attendees: {
-        member_name: string;
-        phone: string;
-        province: string;
-        line_id: string;
-      }[];
+  @ApiOperation({ summary: 'ลงทะเบียนร้านค้าและผู้เข้าร่วมประชุมผ่าน LINE' })
+  @ApiBody({ type: RegisterMeetingDto })
+  @ApiResponse({
+    status: 201,
+    description: 'ลงทะเบียนเข้าร่วมประชุมสำเร็จ',
+    schema: {
+      example: {
+        id: 1,
+        mem_code: 'M00001',
+        store_name: 'ร้านยาสุขภาพดี',
+        attendees: [
+          {
+            member_name: 'สมชาย ใจดี',
+            phone: '0812345678',
+            province: 'กรุงเทพมหานคร',
+            line_id: 'U1234567890abcdef1234567890abcdef',
+          },
+        ],
+      },
     },
-  ) {
+  })
+  @Post()
+  registerMeeting(@Body() data: RegisterMeetingDto) {
     return this.lineRegisterMeetingService.registerMeeting(data);
   }
 }

--- a/src/lot/dto/add-lots.dto.ts
+++ b/src/lot/dto/add-lots.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AddLotItemDto {
+  @ApiProperty({ example: 'LOT2026A', description: 'Required; not empty' })
+  lot: string;
+
+  @ApiProperty({ example: '2026-01-01', description: 'Required; not empty' })
+  mfg: string;
+
+  @ApiProperty({ example: '2028-01-01', description: 'Required; not empty' })
+  exp: string;
+
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { ConfigService } from '@nestjs/config';
 import * as bodyParser from 'body-parser';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -15,6 +16,15 @@ async function bootstrap() {
   app.use(bodyParser.urlencoded({ limit: '50mb', extended: true }));
   app.setGlobalPrefix('api');
   app.enableCors();
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('Backend-Ecommerce API')
+    .setDescription('WangPharma Ecommerce backend API documentation')
+    .setVersion('1.0')
+    .addBearerAuth()
+    .build();
+  const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('api/docs', app, swaggerDocument);
 
   const enableKafka =
     configService.get<string>('ENABLE_KAFKA', 'true') === 'true';

--- a/src/modalmain/dto/save-modal-content.dto.ts
+++ b/src/modalmain/dto/save-modal-content.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SaveModalContentDto {
+  @ApiProperty({ example: 1, description: 'Required' })
+  id: number;
+
+  @ApiProperty({ example: 'ประกาศปิดระบบ', description: 'Required; not empty' })
+  title: string;
+
+  @ApiPropertyOptional({ example: '<p>เนื้อหา</p>', description: 'Optional; empty string allowed' })
+  content?: string;
+
+  @ApiProperty({ example: true, description: 'Required' })
+  show: boolean;
+}

--- a/src/new-arrivals/dto/new-arrival-item.dto.ts
+++ b/src/new-arrivals/dto/new-arrival-item.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class NewArrivalItemDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiProperty({ example: 'L2026001', description: 'Required; not empty' })
+  LOT: string;
+
+  @ApiProperty({ example: '2026-01-01', description: 'Required; format YYYY-MM-DD' })
+  MFG: string;
+
+  @ApiProperty({ example: '2028-01-01', description: 'Required; format YYYY-MM-DD' })
+  EXP: string;
+
+  @ApiProperty({ type: String, format: 'date-time', example: '2026-06-23T10:00:00.000Z', description: 'Required; ISO datetime' })
+  createdAt: Date;
+
+  @ApiProperty({ example: 100, description: 'Required' })
+  amount: number;
+
+  @ApiProperty({ example: 'กล่อง', description: 'Required; not empty' })
+  unit: string;
+}

--- a/src/product-keyword/dto/update-keysearch.dto.ts
+++ b/src/product-keyword/dto/update-keysearch.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateKeysearchDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiProperty({ example: 'พารา,แก้ปวด', description: 'Optional; empty string allowed' })
+  keysearch: string;
+
+  @ApiProperty({ example: 0, description: 'Optional' })
+  viewers: number;
+}

--- a/src/product-request/product-request.controller.ts
+++ b/src/product-request/product-request.controller.ts
@@ -15,6 +15,16 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -25,12 +35,49 @@ import {
 import { ProductRequestStatus } from './product-request.entity';
 import { JwtPayload } from '../app.controller';
 
+@ApiTags('Product Request')
 @Controller('ecom')
 export class ProductRequestController {
   constructor(private readonly service: ProductRequestService) {}
 
   // ==================== USER ====================
 
+  @ApiOperation({
+    summary: 'สร้างคำขอสินค้าใหม่ (แจ้งหาสินค้าที่ไม่พบในระบบ) พร้อมแนบรูปภาพ',
+  })
+  @ApiBearerAuth()
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['keyword', 'pro_name'],
+      properties: {
+        keyword: { type: 'string', description: 'คำค้นหาที่ผู้ใช้ใช้ค้นหาสินค้า' },
+        pro_name: { type: 'string', description: 'ชื่อสินค้าที่ต้องการ' },
+        note: { type: 'string', description: 'หมายเหตุเพิ่มเติม (ถ้ามี)' },
+        source_page: {
+          type: 'string',
+          description: 'หน้าที่ผู้ใช้ส่งคำขอมา (ถ้ามี)',
+        },
+        shown_products: {
+          type: 'string',
+          description: 'รายการสินค้าที่แสดงอยู่ในหน้านั้น (ถ้ามี)',
+        },
+        current_page: {
+          type: 'number',
+          description: 'หมายเลขหน้าปัจจุบัน (ถ้ามี)',
+        },
+        image: {
+          type: 'string',
+          format: 'binary',
+          description: 'ไฟล์รูปภาพสินค้า (ไม่เกิน 5MB, เฉพาะไฟล์ภาพ)',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้างคำขอสินค้าสำเร็จ' })
+  @ApiResponse({ status: 400, description: 'keyword หรือ pro_name ไม่ถูกต้อง/ไม่ใช่ไฟล์ภาพ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('product-request')
   @UseInterceptors(
@@ -78,6 +125,18 @@ export class ProductRequestController {
 
   // ==================== ADMIN ====================
 
+  @ApiOperation({ summary: 'ดึงรายการคำขอสินค้าทั้งหมดแบบแบ่งหน้า (admin)' })
+  @ApiBearerAuth()
+  @ApiQuery({ name: 'page', required: false, description: 'หมายเลขหน้า (default: 1)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'จำนวนต่อหน้า (default: 20)' })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ProductRequestStatus,
+    description: 'กรองตามสถานะคำขอสินค้า',
+  })
+  @ApiResponse({ status: 200, description: 'รายการคำขอสินค้าพร้อม pagination' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/product-request')
   getAll(
@@ -88,6 +147,24 @@ export class ProductRequestController {
     return this.service.getAll(page, limit, status);
   }
 
+  @ApiOperation({ summary: 'อัปเดตสถานะคำขอสินค้าตาม id (admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'id ของคำขอสินค้า' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['status'],
+      properties: {
+        status: {
+          type: 'string',
+          enum: Object.values(ProductRequestStatus),
+          description: 'สถานะใหม่ของคำขอสินค้า',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'อัปเดตสถานะคำขอสินค้าสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Patch('admin/product-request/:id/status')
   updateStatus(

--- a/src/product-request/product-request.controller.ts
+++ b/src/product-request/product-request.controller.ts
@@ -15,6 +15,16 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -25,12 +35,64 @@ import {
 import { ProductRequestStatus } from './product-request.entity';
 import { JwtPayload } from '../app.controller';
 
+@ApiTags('Product Request')
 @Controller('ecom')
 export class ProductRequestController {
   constructor(private readonly service: ProductRequestService) {}
 
   // ==================== USER ====================
 
+  @ApiOperation({
+    summary: 'สร้างคำขอสินค้าใหม่ (แจ้งหาสินค้าที่ไม่พบในระบบ) พร้อมแนบรูปภาพ',
+  })
+  @ApiBearerAuth()
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['keyword', 'pro_name'],
+      properties: {
+        keyword: {
+          type: 'string',
+          example: 'ยาแก้ปวดหัว',
+          description: 'Required; not empty; คำค้นหาที่ผู้ใช้ใช้ค้นหาสินค้า',
+        },
+        pro_name: {
+          type: 'string',
+          example: 'พาราเซตามอล 500mg',
+          description: 'Required; not empty; ชื่อสินค้าที่ต้องการ',
+        },
+        note: {
+          type: 'string',
+          example: 'ต้องการแบบซองเล็ก',
+          description: 'Optional; empty string allowed; หมายเหตุเพิ่มเติม (ถ้ามี)',
+        },
+        source_page: {
+          type: 'string',
+          example: '/products/search',
+          description: 'Optional; empty string allowed; หน้าที่ผู้ใช้ส่งคำขอมา (ถ้ามี)',
+        },
+        shown_products: {
+          type: 'string',
+          example: 'A001,A002,A003',
+          description: 'Optional; empty string allowed; รายการสินค้าที่แสดงอยู่ในหน้านั้น (ถ้ามี)',
+        },
+        current_page: {
+          type: 'number',
+          example: 1,
+          description: 'Optional; หมายเลขหน้าปัจจุบัน (ถ้ามี)',
+        },
+        image: {
+          type: 'string',
+          format: 'binary',
+          description: 'Optional; ไฟล์รูปภาพสินค้า (ไม่เกิน 5MB, เฉพาะไฟล์ภาพ)',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้างคำขอสินค้าสำเร็จ' })
+  @ApiResponse({ status: 400, description: 'keyword หรือ pro_name ไม่ถูกต้อง/ไม่ใช่ไฟล์ภาพ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('product-request')
   @UseInterceptors(
@@ -78,6 +140,19 @@ export class ProductRequestController {
 
   // ==================== ADMIN ====================
 
+  @ApiOperation({ summary: 'ดึงรายการคำขอสินค้าทั้งหมดแบบแบ่งหน้า (admin)' })
+  @ApiBearerAuth()
+  @ApiQuery({ name: 'page', required: false, example: '1', description: 'Optional; หมายเลขหน้า (default: 1)' })
+  @ApiQuery({ name: 'limit', required: false, example: '20', description: 'Optional; จำนวนต่อหน้า (default: 20)' })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ProductRequestStatus,
+    example: ProductRequestStatus.PENDING,
+    description: 'Optional; กรองตามสถานะคำขอสินค้า',
+  })
+  @ApiResponse({ status: 200, description: 'รายการคำขอสินค้าพร้อม pagination' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/product-request')
   getAll(
@@ -88,6 +163,25 @@ export class ProductRequestController {
     return this.service.getAll(page, limit, status);
   }
 
+  @ApiOperation({ summary: 'อัปเดตสถานะคำขอสินค้าตาม id (admin)' })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', description: 'id ของคำขอสินค้า', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['status'],
+      properties: {
+        status: {
+          type: 'string',
+          enum: Object.values(ProductRequestStatus),
+          example: ProductRequestStatus.RESOLVED,
+          description: 'Required; สถานะใหม่ของคำขอสินค้า',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'อัปเดตสถานะคำขอสินค้าสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Patch('admin/product-request/:id/status')
   updateStatus(

--- a/src/product-request/product-request.controller.ts
+++ b/src/product-request/product-request.controller.ts
@@ -52,25 +52,40 @@ export class ProductRequestController {
       type: 'object',
       required: ['keyword', 'pro_name'],
       properties: {
-        keyword: { type: 'string', description: 'คำค้นหาที่ผู้ใช้ใช้ค้นหาสินค้า' },
-        pro_name: { type: 'string', description: 'ชื่อสินค้าที่ต้องการ' },
-        note: { type: 'string', description: 'หมายเหตุเพิ่มเติม (ถ้ามี)' },
+        keyword: {
+          type: 'string',
+          example: 'ยาแก้ปวดหัว',
+          description: 'Required; not empty; คำค้นหาที่ผู้ใช้ใช้ค้นหาสินค้า',
+        },
+        pro_name: {
+          type: 'string',
+          example: 'พาราเซตามอล 500mg',
+          description: 'Required; not empty; ชื่อสินค้าที่ต้องการ',
+        },
+        note: {
+          type: 'string',
+          example: 'ต้องการแบบซองเล็ก',
+          description: 'Optional; empty string allowed; หมายเหตุเพิ่มเติม (ถ้ามี)',
+        },
         source_page: {
           type: 'string',
-          description: 'หน้าที่ผู้ใช้ส่งคำขอมา (ถ้ามี)',
+          example: '/products/search',
+          description: 'Optional; empty string allowed; หน้าที่ผู้ใช้ส่งคำขอมา (ถ้ามี)',
         },
         shown_products: {
           type: 'string',
-          description: 'รายการสินค้าที่แสดงอยู่ในหน้านั้น (ถ้ามี)',
+          example: 'A001,A002,A003',
+          description: 'Optional; empty string allowed; รายการสินค้าที่แสดงอยู่ในหน้านั้น (ถ้ามี)',
         },
         current_page: {
           type: 'number',
-          description: 'หมายเลขหน้าปัจจุบัน (ถ้ามี)',
+          example: 1,
+          description: 'Optional; หมายเลขหน้าปัจจุบัน (ถ้ามี)',
         },
         image: {
           type: 'string',
           format: 'binary',
-          description: 'ไฟล์รูปภาพสินค้า (ไม่เกิน 5MB, เฉพาะไฟล์ภาพ)',
+          description: 'Optional; ไฟล์รูปภาพสินค้า (ไม่เกิน 5MB, เฉพาะไฟล์ภาพ)',
         },
       },
     },
@@ -127,13 +142,14 @@ export class ProductRequestController {
 
   @ApiOperation({ summary: 'ดึงรายการคำขอสินค้าทั้งหมดแบบแบ่งหน้า (admin)' })
   @ApiBearerAuth()
-  @ApiQuery({ name: 'page', required: false, description: 'หมายเลขหน้า (default: 1)' })
-  @ApiQuery({ name: 'limit', required: false, description: 'จำนวนต่อหน้า (default: 20)' })
+  @ApiQuery({ name: 'page', required: false, example: '1', description: 'Optional; หมายเลขหน้า (default: 1)' })
+  @ApiQuery({ name: 'limit', required: false, example: '20', description: 'Optional; จำนวนต่อหน้า (default: 20)' })
   @ApiQuery({
     name: 'status',
     required: false,
     enum: ProductRequestStatus,
-    description: 'กรองตามสถานะคำขอสินค้า',
+    example: ProductRequestStatus.PENDING,
+    description: 'Optional; กรองตามสถานะคำขอสินค้า',
   })
   @ApiResponse({ status: 200, description: 'รายการคำขอสินค้าพร้อม pagination' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -149,7 +165,7 @@ export class ProductRequestController {
 
   @ApiOperation({ summary: 'อัปเดตสถานะคำขอสินค้าตาม id (admin)' })
   @ApiBearerAuth()
-  @ApiParam({ name: 'id', description: 'id ของคำขอสินค้า' })
+  @ApiParam({ name: 'id', description: 'id ของคำขอสินค้า', example: '1' })
   @ApiBody({
     schema: {
       type: 'object',
@@ -158,7 +174,8 @@ export class ProductRequestController {
         status: {
           type: 'string',
           enum: Object.values(ProductRequestStatus),
-          description: 'สถานะใหม่ของคำขอสินค้า',
+          example: ProductRequestStatus.RESOLVED,
+          description: 'Required; สถานะใหม่ของคำขอสินค้า',
         },
       },
     },

--- a/src/products/creditor.entity.ts
+++ b/src/products/creditor.entity.ts
@@ -15,7 +15,7 @@ export class CreditorEntity {
   @Column()
   creditor_name: string;
 
-  @Column({ nullable: true, default: null })
+  @Column({ type: 'varchar', nullable: true, default: null })
   creditor_address: string | null;
 
   @OneToMany(() => ProductEntity, (product) => product)

--- a/src/products/dto/add-creditor.dto.ts
+++ b/src/products/dto/add-creditor.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AddCreditorDto {
+  @ApiProperty({ example: 'C001', description: 'Required; not empty' })
+  creditor_code: string;
+
+  @ApiProperty({ example: 'บริษัท ตัวอย่าง จำกัด', description: 'Required; not empty' })
+  creditor_name: string;
+}

--- a/src/products/dto/back-office.dto.ts
+++ b/src/products/dto/back-office.dto.ts
@@ -1,0 +1,72 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BackOfficeProductRowDto {
+  @ApiProperty({ example: 'P00123', description: 'Required' })
+  pro_code: string;
+
+  @ApiProperty({ example: 'ยาพาราเซตามอล', description: 'Required' })
+  pro_name: string;
+
+  @ApiProperty({ example: 10, description: 'Required' })
+  priceA: number;
+
+  @ApiProperty({ example: 12, description: 'Required' })
+  priceB: number;
+
+  @ApiProperty({ example: 15, description: 'Required' })
+  priceC: number;
+
+  @ApiProperty({ example: 1, description: 'Required' })
+  ratio1: number;
+
+  @ApiProperty({ example: 10, description: 'Required' })
+  ratio2: number;
+
+  @ApiProperty({ example: 100, description: 'Required' })
+  ratio3: number;
+
+  @ApiProperty({ example: 'เม็ด', description: 'Required' })
+  unit1: string;
+
+  @ApiProperty({ example: 'แผง', description: 'Required' })
+  unit2: string;
+
+  @ApiProperty({ example: 'กล่อง', description: 'Required' })
+  unit3: string;
+
+  @ApiProperty({ example: 'S00123', description: 'Required' })
+  supplier: string;
+
+  @ApiProperty({ example: 5, description: 'Required' })
+  pro_lowest_stock: number;
+
+  @ApiProperty({ example: 100, description: 'Required' })
+  order_quantity: number;
+}
+
+export class UpdateProductFromBackOfficeDto {
+  @ApiProperty({
+    type: [BackOfficeProductRowDto],
+    description: 'Required; rows of product fields to update (pro_code, pro_name, prices, ratios, units, supplier, stock fields)',
+  })
+  group: BackOfficeProductRowDto[];
+
+  @ApiProperty({ example: 'back-office-2026-06.xlsx', description: 'Required; not empty' })
+  filename: string;
+}
+
+export class UpdateStockBackOfficeRowDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiProperty({ example: 100, description: 'Required' })
+  stock: number;
+}
+
+export class UpdateStockFromBackOfficeDto {
+  @ApiProperty({ type: [UpdateStockBackOfficeRowDto], description: 'Required' })
+  group: UpdateStockBackOfficeRowDto[];
+
+  @ApiProperty({ example: 'stock-2026-06.xlsx', description: 'Required; not empty' })
+  filename: string;
+}

--- a/src/products/dto/get-flashsale.dto.ts
+++ b/src/products/dto/get-flashsale.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class GetFlashSaleDto {
+  @ApiProperty({ example: 20, description: 'Required' })
+  limit: number;
+
+  @ApiPropertyOptional({
+    example: 'M00123',
+    description: 'Optional; overridden by JWT member code if present',
+  })
+  mem_code?: string;
+}

--- a/src/products/dto/get-product-detail.dto.ts
+++ b/src/products/dto/get-product-detail.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetProductDetailDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiProperty({ example: 'M00123', description: 'Required, but overridden by JWT member code' })
+  mem_code: string;
+}

--- a/src/products/dto/product-for-you.dto.ts
+++ b/src/products/dto/product-for-you.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProductForYouDto {
+  @ApiProperty({ example: '', description: 'Required; empty string allowed' })
+  keyword: string;
+
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+}

--- a/src/products/dto/search-category-products.dto.ts
+++ b/src/products/dto/search-category-products.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SearchCategoryProductsDto {
+  @ApiProperty({ example: '', description: 'Required field; empty string allowed (returns whole category)' })
+  keyword: string;
+
+  @ApiProperty({ example: 0, description: 'Required' })
+  offset: number;
+
+  @ApiProperty({ example: 5, description: 'Required' })
+  category: number;
+
+  @ApiProperty({ example: 'M00123', description: 'Required, but overridden by JWT member code' })
+  mem_code: string;
+
+  @ApiPropertyOptional({ example: 1, description: 'Optional' })
+  sort_by?: number;
+
+  @ApiProperty({ example: 20, description: 'Required' })
+  limit: number;
+}

--- a/src/products/dto/search-products.dto.ts
+++ b/src/products/dto/search-products.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SearchProductsDto {
+  @ApiProperty({ example: 'paracetamol', description: 'Required; empty string returns unfiltered results' })
+  keyword: string;
+
+  @ApiProperty({ example: 0, description: 'Required' })
+  offset: number;
+
+  @ApiProperty({ example: 'M00123', description: 'Required, but overridden by JWT member code' })
+  mem_code: string;
+
+  @ApiPropertyOptional({ example: 1, description: 'Optional' })
+  sort_by?: number;
+
+  @ApiProperty({ example: 20, description: 'Required' })
+  limit: number;
+
+  @ApiPropertyOptional({
+    type: [String],
+    example: ['C001', 'C002'],
+    description: 'Optional filter by creditor codes',
+  })
+  creditor_codes?: string[];
+}

--- a/src/products/dto/upload-po-item.dto.ts
+++ b/src/products/dto/upload-po-item.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UploadPoItemDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; product code, not empty' })
+  pro_code: string;
+
+  @ApiProperty({ example: 6, description: 'Required; month number 1-12' })
+  month: number;
+}

--- a/src/products/dto/upload-product-flashsale-item.dto.ts
+++ b/src/products/dto/upload-product-flashsale-item.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UploadProductFlashSaleItemDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  productCode: string;
+
+  @ApiProperty({ example: 50, description: 'Required' })
+  quantity: number;
+}

--- a/src/products/dto/upload-product-l16.dto.ts
+++ b/src/products/dto/upload-product-l16.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProductL16ItemDto {
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiProperty({
+    oneOf: [{ type: 'number' }, { type: 'string' }],
+    example: 1,
+    description: 'Required; 1 = L16-only, 0 = normal',
+  })
+  status: number | string;
+}
+
+export class UploadProductL16Dto {
+  @ApiProperty({ type: [ProductL16ItemDto], description: 'Required' })
+  data: ProductL16ItemDto[];
+
+  @ApiProperty({ example: 'l16-upload-2026-06.xlsx', description: 'Required; not empty' })
+  filename: string;
+}

--- a/src/promotion/dto/add-promotion-condition.dto.ts
+++ b/src/promotion/dto/add-promotion-condition.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AddPromotionConditionDto {
+  @ApiProperty({ example: 5, description: 'Required' })
+  tier_id: number;
+
+  @ApiProperty({ example: 'G001', description: 'Required; not empty' })
+  product_gcode: string;
+}

--- a/src/promotion/dto/add-promotion-reward.dto.ts
+++ b/src/promotion/dto/add-promotion-reward.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AddPromotionRewardDto {
+  @ApiProperty({ example: 5, description: 'Required' })
+  tier_id: number;
+
+  @ApiProperty({ example: 'G001', description: 'Required; not empty' })
+  product_gcode: string;
+
+  @ApiProperty({ example: 1, description: 'Required' })
+  qty: number;
+
+  @ApiProperty({ example: 'กล่อง', description: 'Required; not empty' })
+  unit: string;
+}

--- a/src/promotion/dto/add-promotion.dto.ts
+++ b/src/promotion/dto/add-promotion.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AddPromotionDto {
+  @ApiProperty({ type: 'string', format: 'binary', description: 'Required; promotion poster image' })
+  file: unknown;
+
+  @ApiProperty({ example: 'โปรโมชั่นซัมเมอร์', description: 'Required; not empty' })
+  promo_name: string;
+
+  @ApiPropertyOptional({ example: 'C001', description: 'Optional; empty string treated as no creditor' })
+  creditor_code: string;
+
+  @ApiProperty({ example: '2026-07-01T00:00:00Z', description: 'Required' })
+  start_date: Date;
+
+  @ApiProperty({ example: '2026-07-31T23:59:59Z', description: 'Required' })
+  end_date: Date;
+
+  @ApiProperty({ enum: ['true', 'false'], example: 'true', description: 'Required; string "true"/"false"' })
+  status: string;
+}

--- a/src/promotion/dto/add-tier.dto.ts
+++ b/src/promotion/dto/add-tier.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AddTierDto {
+  @ApiPropertyOptional({ type: 'string', format: 'binary', description: 'Optional; tier poster image' })
+  file?: unknown;
+
+  @ApiProperty({ example: 12, description: 'Required' })
+  promo_id: number;
+
+  @ApiProperty({ example: 'Gold', description: 'Required; not empty' })
+  tier_name: string;
+
+  @ApiProperty({ example: 1000, description: 'Required' })
+  min_amount: number;
+
+  @ApiPropertyOptional({ example: 'ซื้อครบ 1,000 บาท', description: 'Optional; empty string allowed' })
+  description?: string;
+
+  @ApiPropertyOptional({ example: 'รับส่วนลด 10%', description: 'Optional; empty string allowed' })
+  detail?: string;
+
+  @ApiPropertyOptional({
+    enum: ['true', 'false'],
+    example: 'false',
+    description: 'Optional; string "true"/"false"',
+  })
+  is_unit_based?: string;
+}

--- a/src/promotion/dto/delete-promotion-condition.dto.ts
+++ b/src/promotion/dto/delete-promotion-condition.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeletePromotionConditionDto {
+  @ApiProperty({ example: 7, description: 'Required' })
+  cond_id: number;
+}

--- a/src/promotion/dto/delete-promotion-reward.dto.ts
+++ b/src/promotion/dto/delete-promotion-reward.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeletePromotionRewardDto {
+  @ApiProperty({ example: 9, description: 'Required' })
+  reward_id: number;
+}

--- a/src/promotion/dto/delete-promotion.dto.ts
+++ b/src/promotion/dto/delete-promotion.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeletePromotionDto {
+  @ApiProperty({ example: 12, description: 'Required' })
+  promo_id: number;
+}

--- a/src/promotion/dto/delete-tier.dto.ts
+++ b/src/promotion/dto/delete-tier.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteTierDto {
+  @ApiProperty({ example: 5, description: 'Required' })
+  tier_id: number;
+}

--- a/src/promotion/dto/duplicate-promotion.dto.ts
+++ b/src/promotion/dto/duplicate-promotion.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DuplicatePromotionDto {
+  @ApiProperty({ example: 12, description: 'Required' })
+  promo_id: number;
+
+  @ApiProperty({ example: '2026-08-01T00:00:00Z', description: 'Required' })
+  start_date: Date;
+
+  @ApiProperty({ example: '2026-08-31T23:59:59Z', description: 'Required' })
+  end_date: Date;
+}

--- a/src/promotion/dto/edit-promotion-reward.dto.ts
+++ b/src/promotion/dto/edit-promotion-reward.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class EditPromotionRewardDto {
+  @ApiProperty({ example: 9, description: 'Required' })
+  reward_id: number;
+
+  @ApiProperty({ example: 2, description: 'Required' })
+  qty: number;
+
+  @ApiProperty({ example: 'กล่อง', description: 'Required; not empty' })
+  unit: string;
+}

--- a/src/promotion/dto/edit-tier.dto.ts
+++ b/src/promotion/dto/edit-tier.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class EditTierDto {
+  @ApiProperty({ example: 5, description: 'Required' })
+  tier_id: number;
+
+  @ApiPropertyOptional({ example: 'Gold', description: 'Optional; empty string allowed' })
+  tier_name?: string;
+
+  @ApiPropertyOptional({ example: 1000, description: 'Optional' })
+  min_amount?: number;
+
+  @ApiPropertyOptional({ example: 'ซื้อครบ 1,000 บาท', description: 'Optional; empty string allowed' })
+  description?: string;
+
+  @ApiPropertyOptional({ example: 'รับส่วนลด 10%', description: 'Optional; empty string allowed' })
+  detail?: string;
+}

--- a/src/promotion/dto/generate-code-promotion.dto.ts
+++ b/src/promotion/dto/generate-code-promotion.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GenerateCodePromotionDto {
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+}

--- a/src/promotion/dto/get-product-by-creditor.dto.ts
+++ b/src/promotion/dto/get-product-by-creditor.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetProductByCreditorDto {
+  @ApiProperty({ example: 'C001', description: 'Required; not empty' })
+  creditor_code: string;
+}

--- a/src/promotion/dto/get-product-tier.dto.ts
+++ b/src/promotion/dto/get-product-tier.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class GetProductTierDto {
+  @ApiProperty({ example: 5, description: 'Required' })
+  tier_id: number;
+
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+
+  @ApiPropertyOptional({ example: 1, description: 'Optional' })
+  sort_by?: number;
+}

--- a/src/promotion/dto/update-promo-poster.dto.ts
+++ b/src/promotion/dto/update-promo-poster.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdatePromoPosterDto {
+  @ApiProperty({ type: 'string', format: 'binary', description: 'Required' })
+  file: unknown;
+
+  @ApiProperty({ example: '12', description: 'Required; not empty' })
+  promo_id: string;
+}

--- a/src/promotion/dto/update-promotion-status.dto.ts
+++ b/src/promotion/dto/update-promotion-status.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdatePromotionStatusDto {
+  @ApiProperty({ example: 12, description: 'Required' })
+  promo_id: number;
+
+  @ApiProperty({ example: true, description: 'Required' })
+  status: boolean;
+}

--- a/src/promotion/dto/update-promotion.dto.ts
+++ b/src/promotion/dto/update-promotion.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdatePromotionDto {
+  @ApiProperty({ example: 12, description: 'Required' })
+  promo_id: number;
+
+  @ApiPropertyOptional({ example: 'โปรโมชั่นซัมเมอร์', description: 'Optional; empty string allowed' })
+  promo_name?: string;
+
+  @ApiPropertyOptional({ example: '2026-08-01T00:00:00Z', description: 'Optional' })
+  start_date?: Date;
+
+  @ApiPropertyOptional({ example: '2026-08-31T23:59:59Z', description: 'Optional' })
+  end_date?: Date;
+
+  @ApiPropertyOptional({ example: true, description: 'Optional' })
+  status?: boolean;
+}

--- a/src/promotion/dto/use-code-for-check-reward.dto.ts
+++ b/src/promotion/dto/use-code-for-check-reward.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UseCodeForCheckRewardDto {
+  @ApiProperty({ example: 'PROMO2026', description: 'Required; not empty' })
+  code_text: string;
+}

--- a/src/rating/rating.controller.ts
+++ b/src/rating/rating.controller.ts
@@ -52,7 +52,8 @@ export class RatingController {
     name: 'type',
     required: false,
     enum: ['positive', 'negative'],
-    description: 'กรองประเภทตัวเลือก: positive หรือ negative',
+    example: 'positive',
+    description: 'Optional; กรองประเภทตัวเลือก: positive หรือ negative',
   })
   @ApiResponse({ status: 200, description: 'รายการตัวเลือก select config ที่เปิดใช้งาน' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -72,7 +73,7 @@ export class RatingController {
   }
 
   @ApiOperation({ summary: 'ตรวจสอบว่าออเดอร์ (sh_running) นี้มีการรีวิวแล้วหรือยัง' })
-  @ApiParam({ name: 'sh_running', description: 'เลขที่ออเดอร์/บิล' })
+  @ApiParam({ name: 'sh_running', description: 'เลขที่ออเดอร์/บิล', example: 'SH00001234' })
   @ApiResponse({ status: 200, description: 'ข้อมูลรีวิวของออเดอร์นี้ (ถ้ามี)' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -86,19 +87,37 @@ export class RatingController {
     schema: {
       type: 'object',
       properties: {
-        sh_running: { type: 'string', description: 'เลขที่ออเดอร์/บิล' },
-        mem_code: { type: 'string', description: 'รหัสสมาชิก (optional)' },
-        rating_point: { type: 'number', description: 'คะแนนที่ให้' },
-        comment: { type: 'string', description: 'ความเห็นเพิ่มเติม (optional)' },
+        sh_running: {
+          type: 'string',
+          example: 'SH00001234',
+          description: 'Required; not empty; เลขที่ออเดอร์/บิล',
+        },
+        mem_code: {
+          type: 'string',
+          example: 'M00001',
+          description: 'Optional; empty string allowed; รหัสสมาชิก',
+        },
+        rating_point: {
+          type: 'number',
+          example: 5,
+          description: 'Required; คะแนนที่ให้',
+        },
+        comment: {
+          type: 'string',
+          example: 'สินค้าดี จัดส่งรวดเร็ว',
+          description: 'Optional; empty string allowed; ความเห็นเพิ่มเติม',
+        },
         positive_select: {
           type: 'array',
           items: { type: 'string' },
-          description: 'ตัวเลือกด้านบวกที่เลือก (optional)',
+          example: ['จัดส่งเร็ว', 'สินค้าตรงปก'],
+          description: 'Optional; ตัวเลือกด้านบวกที่เลือก',
         },
         negative_select: {
           type: 'array',
           items: { type: 'string' },
-          description: 'ตัวเลือกด้านลบที่เลือก (optional)',
+          example: [],
+          description: 'Optional; ตัวเลือกด้านลบที่เลือก',
         },
       },
       required: ['sh_running', 'rating_point'],
@@ -119,19 +138,37 @@ export class RatingController {
       items: {
         type: 'object',
         properties: {
-          sh_running: { type: 'string', description: 'เลขที่ออเดอร์/บิล' },
-          mem_code: { type: 'string', description: 'รหัสสมาชิก (optional)' },
-          rating_point: { type: 'number', description: 'คะแนนที่ให้' },
-          comment: { type: 'string', description: 'ความเห็นเพิ่มเติม (optional)' },
+          sh_running: {
+            type: 'string',
+            example: 'SH00001234',
+            description: 'Required; not empty; เลขที่ออเดอร์/บิล',
+          },
+          mem_code: {
+            type: 'string',
+            example: 'M00001',
+            description: 'Optional; empty string allowed; รหัสสมาชิก',
+          },
+          rating_point: {
+            type: 'number',
+            example: 5,
+            description: 'Required; คะแนนที่ให้',
+          },
+          comment: {
+            type: 'string',
+            example: 'สินค้าดี จัดส่งรวดเร็ว',
+            description: 'Optional; empty string allowed; ความเห็นเพิ่มเติม',
+          },
           positive_select: {
             type: 'array',
             items: { type: 'string' },
-            description: 'ตัวเลือกด้านบวกที่เลือก (optional)',
+            example: ['จัดส่งเร็ว', 'สินค้าตรงปก'],
+            description: 'Optional; ตัวเลือกด้านบวกที่เลือก',
           },
           negative_select: {
             type: 'array',
             items: { type: 'string' },
-            description: 'ตัวเลือกด้านลบที่เลือก (optional)',
+            example: [],
+            description: 'Optional; ตัวเลือกด้านลบที่เลือก',
           },
         },
         required: ['sh_running', 'rating_point'],
@@ -147,7 +184,7 @@ export class RatingController {
   }
 
   @ApiOperation({ summary: 'อัปโหลดรูปภาพประกอบรีวิว (สูงสุด 10 ไฟล์ ไฟล์ละไม่เกิน 5MB)' })
-  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)' })
+  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)', example: '1' })
   @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: {
@@ -156,7 +193,7 @@ export class RatingController {
         files: {
           type: 'array',
           items: { type: 'string', format: 'binary' },
-          description: 'ไฟล์รูปภาพ (สูงสุด 10 ไฟล์)',
+          description: 'Optional; ไฟล์รูปภาพ (สูงสุด 10 ไฟล์)',
         },
       },
     },
@@ -188,15 +225,23 @@ export class RatingController {
   }
 
   @ApiOperation({ summary: 'ส่งคำตอบแบบสอบถาม (questionnaire) สำหรับรีวิวหนึ่งรายการ' })
-  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)' })
+  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)', example: '1' })
   @ApiBody({
     schema: {
       type: 'array',
       items: {
         type: 'object',
         properties: {
-          question_id: { type: 'number', description: 'รหัสคำถาม' },
-          rating_point: { type: 'number', description: 'คะแนนที่ให้สำหรับคำถามนี้' },
+          question_id: {
+            type: 'number',
+            example: 1,
+            description: 'Required; รหัสคำถาม',
+          },
+          rating_point: {
+            type: 'number',
+            example: 5,
+            description: 'Required; คะแนนที่ให้สำหรับคำถามนี้',
+          },
         },
         required: ['question_id', 'rating_point'],
       },
@@ -243,10 +288,10 @@ export class RatingController {
   }
 
   @ApiOperation({ summary: 'ดึงรายการรีวิวทั้งหมดแบบ pagination พร้อมกรองตามช่วงคะแนน' })
-  @ApiQuery({ name: 'page', required: false, description: 'หน้าที่ต้องการ (default 1)' })
-  @ApiQuery({ name: 'limit', required: false, description: 'จำนวนรายการต่อหน้า (default 20)' })
-  @ApiQuery({ name: 'minPoint', required: false, description: 'คะแนนต่ำสุดที่ใช้กรอง' })
-  @ApiQuery({ name: 'maxPoint', required: false, description: 'คะแนนสูงสุดที่ใช้กรอง' })
+  @ApiQuery({ name: 'page', required: false, example: '1', description: 'Optional; หน้าที่ต้องการ (default 1)' })
+  @ApiQuery({ name: 'limit', required: false, example: '20', description: 'Optional; จำนวนรายการต่อหน้า (default 20)' })
+  @ApiQuery({ name: 'minPoint', required: false, example: '1', description: 'Optional; คะแนนต่ำสุดที่ใช้กรอง' })
+  @ApiQuery({ name: 'maxPoint', required: false, example: '5', description: 'Optional; คะแนนสูงสุดที่ใช้กรอง' })
   @ApiResponse({ status: 200, description: 'รายการรีวิวพร้อม pagination' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -266,7 +311,7 @@ export class RatingController {
   }
 
   @ApiOperation({ summary: 'ดึงรายละเอียดรีวิวรายการเดียวตาม id (admin)' })
-  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)' })
+  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)', example: '1' })
   @ApiResponse({ status: 200, description: 'รายละเอียดรีวิว' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -280,9 +325,22 @@ export class RatingController {
     schema: {
       type: 'object',
       properties: {
-        choice: { type: 'string', description: 'ข้อความตัวเลือก' },
-        type: { type: 'string', enum: ['positive', 'negative'], description: 'ประเภทตัวเลือก' },
-        status: { type: 'boolean', description: 'สถานะเปิดใช้งาน (optional)' },
+        choice: {
+          type: 'string',
+          example: 'จัดส่งเร็ว',
+          description: 'Required; not empty; ข้อความตัวเลือก',
+        },
+        type: {
+          type: 'string',
+          enum: ['positive', 'negative'],
+          example: 'positive',
+          description: 'Required; ประเภทตัวเลือก',
+        },
+        status: {
+          type: 'boolean',
+          example: true,
+          description: 'Optional; สถานะเปิดใช้งาน',
+        },
       },
       required: ['choice', 'type'],
     },
@@ -296,14 +354,27 @@ export class RatingController {
   }
 
   @ApiOperation({ summary: 'แก้ไข select config ตาม id (admin)' })
-  @ApiParam({ name: 'id', description: 'รหัส select config' })
+  @ApiParam({ name: 'id', description: 'รหัส select config', example: '1' })
   @ApiBody({
     schema: {
       type: 'object',
       properties: {
-        choice: { type: 'string', description: 'ข้อความตัวเลือก (optional)' },
-        type: { type: 'string', enum: ['positive', 'negative'], description: 'ประเภทตัวเลือก (optional)' },
-        status: { type: 'boolean', description: 'สถานะเปิดใช้งาน (optional)' },
+        choice: {
+          type: 'string',
+          example: 'จัดส่งเร็ว',
+          description: 'Optional; empty string allowed; ข้อความตัวเลือก',
+        },
+        type: {
+          type: 'string',
+          enum: ['positive', 'negative'],
+          example: 'positive',
+          description: 'Optional; ประเภทตัวเลือก',
+        },
+        status: {
+          type: 'boolean',
+          example: true,
+          description: 'Optional; สถานะเปิดใช้งาน',
+        },
       },
     },
   })
@@ -319,7 +390,7 @@ export class RatingController {
   }
 
   @ApiOperation({ summary: 'ลบ select config ตาม id (admin)' })
-  @ApiParam({ name: 'id', description: 'รหัส select config' })
+  @ApiParam({ name: 'id', description: 'รหัส select config', example: '1' })
   @ApiResponse({ status: 200, description: 'ลบ select config สำเร็จ' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
@@ -333,8 +404,16 @@ export class RatingController {
     schema: {
       type: 'object',
       properties: {
-        question: { type: 'string', description: 'ข้อความคำถาม' },
-        status: { type: 'boolean', description: 'สถานะเปิดใช้งาน (optional)' },
+        question: {
+          type: 'string',
+          example: 'พนักงานบริการดีหรือไม่',
+          description: 'Required; not empty; ข้อความคำถาม',
+        },
+        status: {
+          type: 'boolean',
+          example: true,
+          description: 'Optional; สถานะเปิดใช้งาน',
+        },
       },
       required: ['question'],
     },
@@ -348,13 +427,21 @@ export class RatingController {
   }
 
   @ApiOperation({ summary: 'แก้ไข questionnaire config ตาม id (admin)' })
-  @ApiParam({ name: 'id', description: 'รหัส questionnaire config' })
+  @ApiParam({ name: 'id', description: 'รหัส questionnaire config', example: '1' })
   @ApiBody({
     schema: {
       type: 'object',
       properties: {
-        question: { type: 'string', description: 'ข้อความคำถาม (optional)' },
-        status: { type: 'boolean', description: 'สถานะเปิดใช้งาน (optional)' },
+        question: {
+          type: 'string',
+          example: 'พนักงานบริการดีหรือไม่',
+          description: 'Optional; empty string allowed; ข้อความคำถาม',
+        },
+        status: {
+          type: 'boolean',
+          example: true,
+          description: 'Optional; สถานะเปิดใช้งาน',
+        },
       },
     },
   })
@@ -370,7 +457,7 @@ export class RatingController {
   }
 
   @ApiOperation({ summary: 'ลบ questionnaire config ตาม id (admin)' })
-  @ApiParam({ name: 'id', description: 'รหัส questionnaire config' })
+  @ApiParam({ name: 'id', description: 'รหัส questionnaire config', example: '1' })
   @ApiResponse({ status: 200, description: 'ลบ questionnaire config สำเร็จ' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)

--- a/src/rating/rating.controller.ts
+++ b/src/rating/rating.controller.ts
@@ -16,6 +16,16 @@ import {
 } from '@nestjs/common';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import {
   RatingService,
@@ -29,42 +39,167 @@ import {
 } from './rating.service';
 import { ReviewSelectType } from './review-config-select.entity';
 
+@ApiTags('Rating')
+@ApiBearerAuth()
 @Controller('ecom')
 export class RatingController {
   constructor(private readonly ratingService: RatingService) {}
 
   // ==================== USER ====================
 
+  @ApiOperation({ summary: 'ดึงตัวเลือก select config (positive/negative) ที่เปิดใช้งานอยู่' })
+  @ApiQuery({
+    name: 'type',
+    required: false,
+    enum: ['positive', 'negative'],
+    example: 'positive',
+    description: 'Optional; กรองประเภทตัวเลือก: positive หรือ negative',
+  })
+  @ApiResponse({ status: 200, description: 'รายการตัวเลือก select config ที่เปิดใช้งาน' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('rating/config/select')
   getActiveSelectOptions(@Query('type') type?: ReviewSelectType) {
     return this.ratingService.getActiveSelectOptions(type);
   }
 
+  @ApiOperation({ summary: 'ดึงคำถามแบบสอบถาม (questionnaire) ที่เปิดใช้งานอยู่' })
+  @ApiResponse({ status: 200, description: 'รายการคำถามแบบสอบถามที่เปิดใช้งาน' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('rating/config/questionnaire')
   getActiveQuestions() {
     return this.ratingService.getActiveQuestions();
   }
 
+  @ApiOperation({ summary: 'ตรวจสอบว่าออเดอร์ (sh_running) นี้มีการรีวิวแล้วหรือยัง' })
+  @ApiParam({ name: 'sh_running', description: 'เลขที่ออเดอร์/บิล', example: 'SH00001234' })
+  @ApiResponse({ status: 200, description: 'ข้อมูลรีวิวของออเดอร์นี้ (ถ้ามี)' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('rating/check/:sh_running')
   getRatingBySh(@Param('sh_running') sh_running: string) {
     return this.ratingService.getRatingBySh(sh_running);
   }
 
+  @ApiOperation({ summary: 'ส่งคำรีวิว/ให้คะแนนสำหรับออเดอร์หนึ่งรายการ' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        sh_running: {
+          type: 'string',
+          example: 'SH00001234',
+          description: 'Required; not empty; เลขที่ออเดอร์/บิล',
+        },
+        mem_code: {
+          type: 'string',
+          example: 'M00001',
+          description: 'Optional; empty string allowed; รหัสสมาชิก',
+        },
+        rating_point: {
+          type: 'number',
+          example: 5,
+          description: 'Required; คะแนนที่ให้',
+        },
+        comment: {
+          type: 'string',
+          example: 'สินค้าดี จัดส่งรวดเร็ว',
+          description: 'Optional; empty string allowed; ความเห็นเพิ่มเติม',
+        },
+        positive_select: {
+          type: 'array',
+          items: { type: 'string' },
+          example: ['จัดส่งเร็ว', 'สินค้าตรงปก'],
+          description: 'Optional; ตัวเลือกด้านบวกที่เลือก',
+        },
+        negative_select: {
+          type: 'array',
+          items: { type: 'string' },
+          example: [],
+          description: 'Optional; ตัวเลือกด้านลบที่เลือก',
+        },
+      },
+      required: ['sh_running', 'rating_point'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้างรีวิวสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('rating')
   submitRating(@Body() data: CreateRatingDto) {
     return this.ratingService.submitRating(data);
   }
 
+  @ApiOperation({ summary: 'ส่งคำรีวิว/ให้คะแนนหลายออเดอร์พร้อมกัน (batch)' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          sh_running: {
+            type: 'string',
+            example: 'SH00001234',
+            description: 'Required; not empty; เลขที่ออเดอร์/บิล',
+          },
+          mem_code: {
+            type: 'string',
+            example: 'M00001',
+            description: 'Optional; empty string allowed; รหัสสมาชิก',
+          },
+          rating_point: {
+            type: 'number',
+            example: 5,
+            description: 'Required; คะแนนที่ให้',
+          },
+          comment: {
+            type: 'string',
+            example: 'สินค้าดี จัดส่งรวดเร็ว',
+            description: 'Optional; empty string allowed; ความเห็นเพิ่มเติม',
+          },
+          positive_select: {
+            type: 'array',
+            items: { type: 'string' },
+            example: ['จัดส่งเร็ว', 'สินค้าตรงปก'],
+            description: 'Optional; ตัวเลือกด้านบวกที่เลือก',
+          },
+          negative_select: {
+            type: 'array',
+            items: { type: 'string' },
+            example: [],
+            description: 'Optional; ตัวเลือกด้านลบที่เลือก',
+          },
+        },
+        required: ['sh_running', 'rating_point'],
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้างรีวิวแบบ batch สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('rating/batch')
   submitBatchRating(@Body() items: BatchRatingItemDto[]) {
     return this.ratingService.submitBatchRating(items);
   }
 
+  @ApiOperation({ summary: 'อัปโหลดรูปภาพประกอบรีวิว (สูงสุด 10 ไฟล์ ไฟล์ละไม่เกิน 5MB)' })
+  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)', example: '1' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        files: {
+          type: 'array',
+          items: { type: 'string', format: 'binary' },
+          description: 'Optional; ไฟล์รูปภาพ (สูงสุด 10 ไฟล์)',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'อัปโหลดรูปภาพสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('rating/:id/images')
   @UseInterceptors(
@@ -89,6 +224,31 @@ export class RatingController {
     return this.ratingService.uploadReviewImages(id, files);
   }
 
+  @ApiOperation({ summary: 'ส่งคำตอบแบบสอบถาม (questionnaire) สำหรับรีวิวหนึ่งรายการ' })
+  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          question_id: {
+            type: 'number',
+            example: 1,
+            description: 'Required; รหัสคำถาม',
+          },
+          rating_point: {
+            type: 'number',
+            example: 5,
+            description: 'Required; คะแนนที่ให้สำหรับคำถามนี้',
+          },
+        },
+        required: ['question_id', 'rating_point'],
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'ส่งคำตอบแบบสอบถามสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('rating/:id/questionnaire')
   submitQuestionnaire(
@@ -100,24 +260,40 @@ export class RatingController {
 
   // ==================== ADMIN ====================
 
+  @ApiOperation({ summary: 'ดึงสถิติสรุปของรีวิวทั้งหมด (ค่าเฉลี่ย, การกระจายคะแนน)' })
+  @ApiResponse({ status: 200, description: 'สถิติสรุปของรีวิว' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/rating/stats')
   getRatingStats() {
     return this.ratingService.getRatingStats();
   }
 
+  @ApiOperation({ summary: 'ดึง select config ทั้งหมด (admin) ทั้งที่เปิดและปิดใช้งาน' })
+  @ApiResponse({ status: 200, description: 'รายการ select config ทั้งหมด' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/rating/config/select')
   getAllSelectConfigs() {
     return this.ratingService.getAllSelectConfigs();
   }
 
+  @ApiOperation({ summary: 'ดึง questionnaire config ทั้งหมด (admin) ทั้งที่เปิดและปิดใช้งาน' })
+  @ApiResponse({ status: 200, description: 'รายการ questionnaire config ทั้งหมด' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/rating/config/questionnaire')
   getAllQuestionnaireConfigs() {
     return this.ratingService.getAllQuestionnaireConfigs();
   }
 
+  @ApiOperation({ summary: 'ดึงรายการรีวิวทั้งหมดแบบ pagination พร้อมกรองตามช่วงคะแนน' })
+  @ApiQuery({ name: 'page', required: false, example: '1', description: 'Optional; หน้าที่ต้องการ (default 1)' })
+  @ApiQuery({ name: 'limit', required: false, example: '20', description: 'Optional; จำนวนรายการต่อหน้า (default 20)' })
+  @ApiQuery({ name: 'minPoint', required: false, example: '1', description: 'Optional; คะแนนต่ำสุดที่ใช้กรอง' })
+  @ApiQuery({ name: 'maxPoint', required: false, example: '5', description: 'Optional; คะแนนสูงสุดที่ใช้กรอง' })
+  @ApiResponse({ status: 200, description: 'รายการรีวิวพร้อม pagination' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/rating')
   getAllRatings(
@@ -134,18 +310,76 @@ export class RatingController {
     );
   }
 
+  @ApiOperation({ summary: 'ดึงรายละเอียดรีวิวรายการเดียวตาม id (admin)' })
+  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)', example: '1' })
+  @ApiResponse({ status: 200, description: 'รายละเอียดรีวิว' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/rating/:id')
   getRatingById(@Param('id', ParseIntPipe) id: number) {
     return this.ratingService.getRatingById(id);
   }
 
+  @ApiOperation({ summary: 'สร้าง select config ใหม่ (positive/negative choice) (admin)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        choice: {
+          type: 'string',
+          example: 'จัดส่งเร็ว',
+          description: 'Required; not empty; ข้อความตัวเลือก',
+        },
+        type: {
+          type: 'string',
+          enum: ['positive', 'negative'],
+          example: 'positive',
+          description: 'Required; ประเภทตัวเลือก',
+        },
+        status: {
+          type: 'boolean',
+          example: true,
+          description: 'Optional; สถานะเปิดใช้งาน',
+        },
+      },
+      required: ['choice', 'type'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้าง select config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('admin/rating/config/select')
   createSelectConfig(@Body() data: CreateSelectConfigDto) {
     return this.ratingService.createSelectConfig(data);
   }
 
+  @ApiOperation({ summary: 'แก้ไข select config ตาม id (admin)' })
+  @ApiParam({ name: 'id', description: 'รหัส select config', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        choice: {
+          type: 'string',
+          example: 'จัดส่งเร็ว',
+          description: 'Optional; empty string allowed; ข้อความตัวเลือก',
+        },
+        type: {
+          type: 'string',
+          enum: ['positive', 'negative'],
+          example: 'positive',
+          description: 'Optional; ประเภทตัวเลือก',
+        },
+        status: {
+          type: 'boolean',
+          example: true,
+          description: 'Optional; สถานะเปิดใช้งาน',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'แก้ไข select config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/rating/config/select/:id')
   updateSelectConfig(
@@ -155,18 +389,64 @@ export class RatingController {
     return this.ratingService.updateSelectConfig(id, data);
   }
 
+  @ApiOperation({ summary: 'ลบ select config ตาม id (admin)' })
+  @ApiParam({ name: 'id', description: 'รหัส select config', example: '1' })
+  @ApiResponse({ status: 200, description: 'ลบ select config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('admin/rating/config/select/:id')
   deleteSelectConfig(@Param('id', ParseIntPipe) id: number) {
     return this.ratingService.deleteSelectConfig(id);
   }
 
+  @ApiOperation({ summary: 'สร้าง questionnaire config (คำถามแบบสอบถาม) ใหม่ (admin)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        question: {
+          type: 'string',
+          example: 'พนักงานบริการดีหรือไม่',
+          description: 'Required; not empty; ข้อความคำถาม',
+        },
+        status: {
+          type: 'boolean',
+          example: true,
+          description: 'Optional; สถานะเปิดใช้งาน',
+        },
+      },
+      required: ['question'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้าง questionnaire config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('admin/rating/config/questionnaire')
   createQuestionnaireConfig(@Body() data: CreateQuestionnaireConfigDto) {
     return this.ratingService.createQuestionnaireConfig(data);
   }
 
+  @ApiOperation({ summary: 'แก้ไข questionnaire config ตาม id (admin)' })
+  @ApiParam({ name: 'id', description: 'รหัส questionnaire config', example: '1' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        question: {
+          type: 'string',
+          example: 'พนักงานบริการดีหรือไม่',
+          description: 'Optional; empty string allowed; ข้อความคำถาม',
+        },
+        status: {
+          type: 'boolean',
+          example: true,
+          description: 'Optional; สถานะเปิดใช้งาน',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'แก้ไข questionnaire config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/rating/config/questionnaire/:id')
   updateQuestionnaireConfig(
@@ -176,6 +456,10 @@ export class RatingController {
     return this.ratingService.updateQuestionnaireConfig(id, data);
   }
 
+  @ApiOperation({ summary: 'ลบ questionnaire config ตาม id (admin)' })
+  @ApiParam({ name: 'id', description: 'รหัส questionnaire config', example: '1' })
+  @ApiResponse({ status: 200, description: 'ลบ questionnaire config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('admin/rating/config/questionnaire/:id')
   deleteQuestionnaireConfig(@Param('id', ParseIntPipe) id: number) {

--- a/src/rating/rating.controller.ts
+++ b/src/rating/rating.controller.ts
@@ -16,6 +16,16 @@ import {
 } from '@nestjs/common';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import {
   RatingService,
@@ -29,42 +39,130 @@ import {
 } from './rating.service';
 import { ReviewSelectType } from './review-config-select.entity';
 
+@ApiTags('Rating')
+@ApiBearerAuth()
 @Controller('ecom')
 export class RatingController {
   constructor(private readonly ratingService: RatingService) {}
 
   // ==================== USER ====================
 
+  @ApiOperation({ summary: 'ดึงตัวเลือก select config (positive/negative) ที่เปิดใช้งานอยู่' })
+  @ApiQuery({
+    name: 'type',
+    required: false,
+    enum: ['positive', 'negative'],
+    description: 'กรองประเภทตัวเลือก: positive หรือ negative',
+  })
+  @ApiResponse({ status: 200, description: 'รายการตัวเลือก select config ที่เปิดใช้งาน' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('rating/config/select')
   getActiveSelectOptions(@Query('type') type?: ReviewSelectType) {
     return this.ratingService.getActiveSelectOptions(type);
   }
 
+  @ApiOperation({ summary: 'ดึงคำถามแบบสอบถาม (questionnaire) ที่เปิดใช้งานอยู่' })
+  @ApiResponse({ status: 200, description: 'รายการคำถามแบบสอบถามที่เปิดใช้งาน' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('rating/config/questionnaire')
   getActiveQuestions() {
     return this.ratingService.getActiveQuestions();
   }
 
+  @ApiOperation({ summary: 'ตรวจสอบว่าออเดอร์ (sh_running) นี้มีการรีวิวแล้วหรือยัง' })
+  @ApiParam({ name: 'sh_running', description: 'เลขที่ออเดอร์/บิล' })
+  @ApiResponse({ status: 200, description: 'ข้อมูลรีวิวของออเดอร์นี้ (ถ้ามี)' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('rating/check/:sh_running')
   getRatingBySh(@Param('sh_running') sh_running: string) {
     return this.ratingService.getRatingBySh(sh_running);
   }
 
+  @ApiOperation({ summary: 'ส่งคำรีวิว/ให้คะแนนสำหรับออเดอร์หนึ่งรายการ' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        sh_running: { type: 'string', description: 'เลขที่ออเดอร์/บิล' },
+        mem_code: { type: 'string', description: 'รหัสสมาชิก (optional)' },
+        rating_point: { type: 'number', description: 'คะแนนที่ให้' },
+        comment: { type: 'string', description: 'ความเห็นเพิ่มเติม (optional)' },
+        positive_select: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'ตัวเลือกด้านบวกที่เลือก (optional)',
+        },
+        negative_select: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'ตัวเลือกด้านลบที่เลือก (optional)',
+        },
+      },
+      required: ['sh_running', 'rating_point'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้างรีวิวสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('rating')
   submitRating(@Body() data: CreateRatingDto) {
     return this.ratingService.submitRating(data);
   }
 
+  @ApiOperation({ summary: 'ส่งคำรีวิว/ให้คะแนนหลายออเดอร์พร้อมกัน (batch)' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          sh_running: { type: 'string', description: 'เลขที่ออเดอร์/บิล' },
+          mem_code: { type: 'string', description: 'รหัสสมาชิก (optional)' },
+          rating_point: { type: 'number', description: 'คะแนนที่ให้' },
+          comment: { type: 'string', description: 'ความเห็นเพิ่มเติม (optional)' },
+          positive_select: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'ตัวเลือกด้านบวกที่เลือก (optional)',
+          },
+          negative_select: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'ตัวเลือกด้านลบที่เลือก (optional)',
+          },
+        },
+        required: ['sh_running', 'rating_point'],
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้างรีวิวแบบ batch สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('rating/batch')
   submitBatchRating(@Body() items: BatchRatingItemDto[]) {
     return this.ratingService.submitBatchRating(items);
   }
 
+  @ApiOperation({ summary: 'อัปโหลดรูปภาพประกอบรีวิว (สูงสุด 10 ไฟล์ ไฟล์ละไม่เกิน 5MB)' })
+  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        files: {
+          type: 'array',
+          items: { type: 'string', format: 'binary' },
+          description: 'ไฟล์รูปภาพ (สูงสุด 10 ไฟล์)',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'อัปโหลดรูปภาพสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('rating/:id/images')
   @UseInterceptors(
@@ -89,6 +187,23 @@ export class RatingController {
     return this.ratingService.uploadReviewImages(id, files);
   }
 
+  @ApiOperation({ summary: 'ส่งคำตอบแบบสอบถาม (questionnaire) สำหรับรีวิวหนึ่งรายการ' })
+  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)' })
+  @ApiBody({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          question_id: { type: 'number', description: 'รหัสคำถาม' },
+          rating_point: { type: 'number', description: 'คะแนนที่ให้สำหรับคำถามนี้' },
+        },
+        required: ['question_id', 'rating_point'],
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'ส่งคำตอบแบบสอบถามสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('rating/:id/questionnaire')
   submitQuestionnaire(
@@ -100,24 +215,40 @@ export class RatingController {
 
   // ==================== ADMIN ====================
 
+  @ApiOperation({ summary: 'ดึงสถิติสรุปของรีวิวทั้งหมด (ค่าเฉลี่ย, การกระจายคะแนน)' })
+  @ApiResponse({ status: 200, description: 'สถิติสรุปของรีวิว' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/rating/stats')
   getRatingStats() {
     return this.ratingService.getRatingStats();
   }
 
+  @ApiOperation({ summary: 'ดึง select config ทั้งหมด (admin) ทั้งที่เปิดและปิดใช้งาน' })
+  @ApiResponse({ status: 200, description: 'รายการ select config ทั้งหมด' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/rating/config/select')
   getAllSelectConfigs() {
     return this.ratingService.getAllSelectConfigs();
   }
 
+  @ApiOperation({ summary: 'ดึง questionnaire config ทั้งหมด (admin) ทั้งที่เปิดและปิดใช้งาน' })
+  @ApiResponse({ status: 200, description: 'รายการ questionnaire config ทั้งหมด' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/rating/config/questionnaire')
   getAllQuestionnaireConfigs() {
     return this.ratingService.getAllQuestionnaireConfigs();
   }
 
+  @ApiOperation({ summary: 'ดึงรายการรีวิวทั้งหมดแบบ pagination พร้อมกรองตามช่วงคะแนน' })
+  @ApiQuery({ name: 'page', required: false, description: 'หน้าที่ต้องการ (default 1)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'จำนวนรายการต่อหน้า (default 20)' })
+  @ApiQuery({ name: 'minPoint', required: false, description: 'คะแนนต่ำสุดที่ใช้กรอง' })
+  @ApiQuery({ name: 'maxPoint', required: false, description: 'คะแนนสูงสุดที่ใช้กรอง' })
+  @ApiResponse({ status: 200, description: 'รายการรีวิวพร้อม pagination' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/rating')
   getAllRatings(
@@ -134,18 +265,50 @@ export class RatingController {
     );
   }
 
+  @ApiOperation({ summary: 'ดึงรายละเอียดรีวิวรายการเดียวตาม id (admin)' })
+  @ApiParam({ name: 'id', description: 'รหัสรีวิว (rating id)' })
+  @ApiResponse({ status: 200, description: 'รายละเอียดรีวิว' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('admin/rating/:id')
   getRatingById(@Param('id', ParseIntPipe) id: number) {
     return this.ratingService.getRatingById(id);
   }
 
+  @ApiOperation({ summary: 'สร้าง select config ใหม่ (positive/negative choice) (admin)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        choice: { type: 'string', description: 'ข้อความตัวเลือก' },
+        type: { type: 'string', enum: ['positive', 'negative'], description: 'ประเภทตัวเลือก' },
+        status: { type: 'boolean', description: 'สถานะเปิดใช้งาน (optional)' },
+      },
+      required: ['choice', 'type'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้าง select config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('admin/rating/config/select')
   createSelectConfig(@Body() data: CreateSelectConfigDto) {
     return this.ratingService.createSelectConfig(data);
   }
 
+  @ApiOperation({ summary: 'แก้ไข select config ตาม id (admin)' })
+  @ApiParam({ name: 'id', description: 'รหัส select config' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        choice: { type: 'string', description: 'ข้อความตัวเลือก (optional)' },
+        type: { type: 'string', enum: ['positive', 'negative'], description: 'ประเภทตัวเลือก (optional)' },
+        status: { type: 'boolean', description: 'สถานะเปิดใช้งาน (optional)' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'แก้ไข select config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/rating/config/select/:id')
   updateSelectConfig(
@@ -155,18 +318,48 @@ export class RatingController {
     return this.ratingService.updateSelectConfig(id, data);
   }
 
+  @ApiOperation({ summary: 'ลบ select config ตาม id (admin)' })
+  @ApiParam({ name: 'id', description: 'รหัส select config' })
+  @ApiResponse({ status: 200, description: 'ลบ select config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('admin/rating/config/select/:id')
   deleteSelectConfig(@Param('id', ParseIntPipe) id: number) {
     return this.ratingService.deleteSelectConfig(id);
   }
 
+  @ApiOperation({ summary: 'สร้าง questionnaire config (คำถามแบบสอบถาม) ใหม่ (admin)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        question: { type: 'string', description: 'ข้อความคำถาม' },
+        status: { type: 'boolean', description: 'สถานะเปิดใช้งาน (optional)' },
+      },
+      required: ['question'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'สร้าง questionnaire config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('admin/rating/config/questionnaire')
   createQuestionnaireConfig(@Body() data: CreateQuestionnaireConfigDto) {
     return this.ratingService.createQuestionnaireConfig(data);
   }
 
+  @ApiOperation({ summary: 'แก้ไข questionnaire config ตาม id (admin)' })
+  @ApiParam({ name: 'id', description: 'รหัส questionnaire config' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        question: { type: 'string', description: 'ข้อความคำถาม (optional)' },
+        status: { type: 'boolean', description: 'สถานะเปิดใช้งาน (optional)' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'แก้ไข questionnaire config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Put('admin/rating/config/questionnaire/:id')
   updateQuestionnaireConfig(
@@ -176,6 +369,10 @@ export class RatingController {
     return this.ratingService.updateQuestionnaireConfig(id, data);
   }
 
+  @ApiOperation({ summary: 'ลบ questionnaire config ตาม id (admin)' })
+  @ApiParam({ name: 'id', description: 'รหัส questionnaire config' })
+  @ApiResponse({ status: 200, description: 'ลบ questionnaire config สำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Delete('admin/rating/config/questionnaire/:id')
   deleteQuestionnaireConfig(@Param('id', ParseIntPipe) id: number) {

--- a/src/review-request/review-request.controller.ts
+++ b/src/review-request/review-request.controller.ts
@@ -1,28 +1,52 @@
 import { Body, Controller, Get, Param, Patch, UseGuards } from '@nestjs/common';
 import { IsArray, IsNotEmpty, IsString } from 'class-validator';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiProperty,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ReviewRequestService } from './review-request.service';
 
 class CompleteReviewDto {
+  @ApiProperty({ description: 'รหัสสมาชิก (mem_code)', example: 'M00001' })
   @IsString()
   @IsNotEmpty()
   mem_code!: string;
 
+  @ApiProperty({
+    description: 'รายการเลขที่ออเดอร์/บิล (sh_running) ที่ทำการรีวิวเสร็จสิ้นแล้ว',
+    type: [String],
+  })
   @IsArray()
   @IsString({ each: true })
   sh_running!: string[];
 }
 
+@ApiTags('Review Request')
+@ApiBearerAuth()
 @Controller('ecom/review-request')
 export class ReviewRequestController {
   constructor(private readonly service: ReviewRequestService) {}
 
+  @ApiOperation({ summary: 'ดึงรายการคำขอรีวิวที่ยังไม่เสร็จสิ้นของสมาชิก' })
+  @ApiParam({ name: 'mem_code', description: 'รหัสสมาชิก (mem_code)' })
+  @ApiResponse({ status: 200, description: 'รายการคำขอรีวิวที่ยังค้างอยู่' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Get('pending/:mem_code')
   getPending(@Param('mem_code') memCode: string) {
     return this.service.getPending(memCode);
   }
 
+  @ApiOperation({ summary: 'ทำเครื่องหมายคำขอรีวิวว่าเสร็จสิ้นแล้วสำหรับออเดอร์ที่ระบุ' })
+  @ApiBody({ type: CompleteReviewDto })
+  @ApiResponse({ status: 200, description: 'ทำเครื่องหมายเสร็จสิ้นสำเร็จ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Patch('complete')
   async complete(@Body() dto: CompleteReviewDto) {

--- a/src/sessions/dto/sessions.dto.ts
+++ b/src/sessions/dto/sessions.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateSessionDto {
+  @ApiProperty({ example: 'a1b2c3d4e5', description: 'Required; not empty' })
+  session_token: string;
+
+  @ApiPropertyOptional({ example: '203.0.113.10', description: 'Optional; empty string allowed' })
+  ip_address?: string;
+
+  @ApiPropertyOptional({ example: 'Mozilla/5.0', description: 'Optional; empty string allowed' })
+  user_agent?: string;
+
+  @ApiPropertyOptional({ example: 'mobile', description: 'Optional; empty string allowed' })
+  device_type?: string;
+}
+
+export class LogoutSessionDto {
+  @ApiProperty({ example: 'a1b2c3d4e5', description: 'Required; not empty' })
+  session_token: string;
+}
+
+export class MemCodeDto {
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+}

--- a/src/shopping-cart/dto/add-product-cart.dto.ts
+++ b/src/shopping-cart/dto/add-product-cart.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AddProductCartDto {
+  @ApiProperty({ example: 'M00123', description: 'Required, but overridden by JWT member code' })
+  mem_code: string;
+
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiProperty({ example: 'กล่อง', description: 'Required; not empty' })
+  pro_unit: string;
+
+  @ApiProperty({ example: 2, description: 'Required' })
+  amount: number;
+
+  @ApiProperty({ example: '', description: 'Required; pass empty string if not a flash-sale item' })
+  flashsale_end: string;
+
+  @ApiPropertyOptional({ type: 'string', example: '1', description: 'Optional' })
+  cartVersion?: string | number;
+
+  @ApiPropertyOptional({ example: '1.0.0', description: 'Optional' })
+  clientVersion?: string;
+
+  @ApiPropertyOptional({ example: '', description: 'Optional; empty string allowed' })
+  company_day_source?: string;
+}

--- a/src/shopping-cart/dto/check-product-cart-all.dto.ts
+++ b/src/shopping-cart/dto/check-product-cart-all.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CheckProductCartAllDto {
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+
+  @ApiProperty({ enum: ['check', 'uncheck'], example: 'check', description: 'Required; not empty' })
+  type: string;
+
+  @ApiPropertyOptional({ example: '1.0.0', description: 'Optional' })
+  clientVersion?: string;
+}

--- a/src/shopping-cart/dto/check-product-cart.dto.ts
+++ b/src/shopping-cart/dto/check-product-cart.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CheckProductCartDto {
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiProperty({ enum: ['check', 'uncheck'], example: 'check', description: 'Required; not empty' })
+  type: string;
+
+  @ApiPropertyOptional({ example: '1.0.0', description: 'Optional' })
+  clientVersion?: string;
+}

--- a/src/shopping-cart/dto/delete-product-cart.dto.ts
+++ b/src/shopping-cart/dto/delete-product-cart.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class DeleteProductCartDto {
+  @ApiProperty({ example: 'M00123', description: 'Required; not empty' })
+  mem_code: string;
+
+  @ApiProperty({ example: 'P00123', description: 'Required; not empty' })
+  pro_code: string;
+
+  @ApiPropertyOptional({ example: '1.0.0', description: 'Optional' })
+  clientVersion?: string;
+}

--- a/src/shopping-order/dto/submit-order.dto.ts
+++ b/src/shopping-order/dto/submit-order.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListFreeItemDto {
+  @ApiProperty({ example: 'P00123' })
+  pro_code: string;
+
+  @ApiProperty({ example: 1 })
+  amount: number;
+
+  @ApiProperty({ example: 'กล่อง' })
+  pro_unit1: string;
+
+  @ApiProperty({ example: 10 })
+  pro_point: number;
+
+  @ApiProperty({ enum: ['1', '2', '3'], example: '1' })
+  unit_enum: '1' | '2' | '3';
+}
+
+export class SubmitOrderDto {
+  @ApiPropertyOptional({ example: 'E001', description: 'Optional; empty string allowed' })
+  emp_code?: string;
+
+  @ApiProperty({ example: 'M00123', description: 'Required, but overridden by JWT member code' })
+  mem_code: string;
+
+  @ApiProperty({ example: 1500.5, description: 'Required' })
+  total_price: number;
+
+  @ApiProperty({
+    type: [ListFreeItemDto],
+    nullable: true,
+    description: 'Required; pass null if no point-redeemed free items',
+  })
+  listFree: [ListFreeItemDto] | null;
+
+  @ApiProperty({ example: 'A', description: 'Required; not empty' })
+  priceOption: string;
+
+  @ApiProperty({ example: 'cash', description: 'Required; not empty' })
+  paymentOptions: string;
+
+  @ApiProperty({ example: 'standard', description: 'Required; not empty' })
+  shippingOptions: string;
+
+  @ApiProperty({ example: '123 ถ.สุขุมวิท กรุงเทพฯ', description: 'Required; not empty' })
+  addressed: string;
+}

--- a/src/users/dto/update-user-data.dto.ts
+++ b/src/users/dto/update-user-data.dto.ts
@@ -1,0 +1,93 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateUserDataDto {
+  @ApiProperty({
+    example: 'M00001',
+    description: 'Required; not empty; รหัสสมาชิกใช้ระบุตัวผู้ใช้ที่จะอัปเดต',
+  })
+  mem_code: string;
+
+  @ApiPropertyOptional({ example: 'pharmacy01', description: 'Optional; empty string allowed' })
+  mem_username?: string;
+
+  @ApiPropertyOptional({ example: 'ร้านยาสุขภาพดี', description: 'Optional; empty string allowed' })
+  mem_nameSite?: string;
+
+  @ApiPropertyOptional({ example: 'ภ.12345', description: 'Optional; empty string allowed' })
+  mem_license?: string;
+
+  @ApiPropertyOptional({ example: '0812345678', description: 'Optional; empty string allowed' })
+  mem_phone?: string;
+
+  @ApiPropertyOptional({ example: 'pharmacy01@example.com', description: 'Optional; empty string allowed' })
+  mem_email?: string;
+
+  @ApiPropertyOptional({ example: '1234567890123', description: 'Optional; empty string allowed' })
+  mem_taxid?: string;
+
+  @ApiPropertyOptional({ example: '123 หมู่ 4', description: 'Optional; empty string allowed' })
+  mem_address?: string;
+
+  @ApiPropertyOptional({ example: 'หมู่บ้านสุขใจ', description: 'Optional; empty string allowed' })
+  mem_village?: string;
+
+  @ApiPropertyOptional({ example: 'ซอย 5', description: 'Optional; empty string allowed' })
+  mem_alley?: string;
+
+  @ApiPropertyOptional({ example: 'ถนนสุขุมวิท', description: 'Optional; empty string allowed' })
+  mem_road?: string;
+
+  @ApiPropertyOptional({ example: 'กรุงเทพมหานคร', description: 'Optional; empty string allowed' })
+  mem_province?: string;
+
+  @ApiPropertyOptional({ example: 'วัฒนา', description: 'Optional; empty string allowed' })
+  mem_amphur?: string;
+
+  @ApiPropertyOptional({ example: 'คลองเตยเหนือ', description: 'Optional; empty string allowed' })
+  mem_tumbon?: string;
+
+  @ApiPropertyOptional({ example: '10110', description: 'Optional; empty string allowed' })
+  mem_post?: string;
+
+  @ApiPropertyOptional({ example: 'company', description: 'Optional; empty string allowed' })
+  mem_invoice_type?: string;
+
+  @ApiPropertyOptional({
+    example: 'U1234567890abcdef1234567890abcdef',
+    description: 'Optional; empty string allowed',
+  })
+  line_id?: string;
+
+  @ApiPropertyOptional({ example: 'https://wangpharma.com', description: 'Optional; empty string allowed' })
+  website?: string;
+
+  @ApiPropertyOptional({
+    example: 'https://facebook.com/wangpharma',
+    description: 'Optional; empty string allowed',
+  })
+  facebook?: string;
+
+  @ApiPropertyOptional({ example: 'นาย', description: 'Optional; empty string allowed' })
+  owner_title?: string;
+
+  @ApiPropertyOptional({ example: 'สมชาย ใจดี', description: 'Optional; empty string allowed' })
+  owner_name?: string;
+
+  @ApiPropertyOptional({ example: '0812345678', description: 'Optional; empty string allowed' })
+  owner_tel?: string;
+
+  @ApiPropertyOptional({ example: 'owner@example.com', description: 'Optional; empty string allowed' })
+  owner_email?: string;
+
+  @ApiPropertyOptional({ example: 'ภญ.', description: 'Optional; empty string allowed' })
+  pharmacist_title?: string;
+
+  @ApiPropertyOptional({ example: 'สมหญิง ขยันดี', description: 'Optional; empty string allowed' })
+  pharmacist_name?: string;
+
+  @ApiPropertyOptional({ example: '0823456789', description: 'Optional; empty string allowed' })
+  pharmacist_tel?: string;
+
+  @ApiPropertyOptional({ example: 'pharmacist@example.com', description: 'Optional; empty string allowed' })
+  pharmacist_email?: string;
+}

--- a/src/users/dto/upload-image-user.dto.ts
+++ b/src/users/dto/upload-image-user.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UploadImageUserDto {
+  @ApiProperty({ type: 'string', format: 'binary', description: 'Required' })
+  file: unknown;
+
+  @ApiProperty({ example: 'M00123', description: 'Required' })
+  mem_code: string;
+
+  @ApiProperty({ example: 'profile', description: 'Required; image category/usage tag' })
+  type: string;
+
+  @ApiProperty({
+    example: 'https://cdn.wangpharma.com/users/old.jpg',
+    description: 'Required; pass empty string if there is no previous image to remove',
+  })
+  old_url: string;
+}

--- a/src/wangday/dto/import-wangday.dto.ts
+++ b/src/wangday/dto/import-wangday.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ImportWangdayDto {
+  @ApiProperty({
+    type: [Object],
+    description:
+      'Required; rows from Excel with Thai column keys (วันที่, เลขที่ใบกำกับ, รหัสลูกค้า, ยอดเงินสุทธิ)',
+  })
+  data: Record<string, unknown>[];
+
+  @ApiProperty({ example: true, description: 'Required' })
+  isLastChunk: boolean;
+
+  @ApiProperty({ example: false, description: 'Required' })
+  isFirstChunk: boolean;
+
+  @ApiProperty({ example: 'wangday-2026-06.xlsx', description: 'Required; not empty' })
+  fileName: string;
+}

--- a/src/watermark-audit/watermark-audit.controller.ts
+++ b/src/watermark-audit/watermark-audit.controller.ts
@@ -35,7 +35,11 @@ export class WatermarkAuditController {
     schema: {
       type: 'object',
       properties: {
-        page: { type: 'string', description: 'ชื่อ/path ของหน้าที่ขอ watermark token' },
+        page: {
+          type: 'string',
+          example: '/products/A001',
+          description: 'Required; not empty; ชื่อ/path ของหน้าที่ขอ watermark token',
+        },
       },
       required: ['page'],
     },
@@ -71,7 +75,12 @@ export class WatermarkAuditController {
   @ApiOperation({
     summary: 'ค้นหาข้อมูลที่มาของ watermark token ที่หลุดออกไป (ใคร/เมื่อไหร่/หน้าไหน) — เฉพาะ admin',
   })
-  @ApiQuery({ name: 'token', required: true, description: 'watermark token ที่ต้องการตรวจสอบ' })
+  @ApiQuery({
+    name: 'token',
+    required: true,
+    example: 'wmk_3f9c1a2b4e5d6f7890abcdef12345678',
+    description: 'Required; not empty; watermark token ที่ต้องการตรวจสอบ',
+  })
   @ApiResponse({ status: 200, description: 'ข้อมูลผู้ออก token, เวลา, และหน้าที่เกี่ยวข้อง' })
   @ApiResponse({ status: 400, description: 'token จำเป็นต้องระบุ' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })

--- a/src/watermark-audit/watermark-audit.controller.ts
+++ b/src/watermark-audit/watermark-audit.controller.ts
@@ -10,14 +10,43 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { Request } from 'express';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { JwtPayload } from '../app.controller';
 import { WatermarkAuditService } from './watermark-audit.service';
 
+@ApiTags('Watermark Audit')
+@ApiBearerAuth()
 @Controller('ecom')
 export class WatermarkAuditController {
   constructor(private readonly service: WatermarkAuditService) {}
 
+  @ApiOperation({
+    summary: 'ออก watermark token สำหรับหน้าที่ระบุ เพื่อใช้ติดตามแหล่งที่มาของข้อมูลที่หลุดออกไป',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        page: {
+          type: 'string',
+          example: '/products/A001',
+          description: 'Required; not empty; ชื่อ/path ของหน้าที่ขอ watermark token',
+        },
+      },
+      required: ['page'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'ออก watermark token สำเร็จ' })
+  @ApiResponse({ status: 400, description: 'page จำเป็นต้องระบุ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('watermark/token')
   issueToken(
@@ -43,6 +72,19 @@ export class WatermarkAuditController {
   }
 
   // Admin: resolve a leaked watermark token -> who/when/which page.
+  @ApiOperation({
+    summary: 'ค้นหาข้อมูลที่มาของ watermark token ที่หลุดออกไป (ใคร/เมื่อไหร่/หน้าไหน) — เฉพาะ admin',
+  })
+  @ApiQuery({
+    name: 'token',
+    required: true,
+    example: 'wmk_3f9c1a2b4e5d6f7890abcdef12345678',
+    description: 'Required; not empty; watermark token ที่ต้องการตรวจสอบ',
+  })
+  @ApiResponse({ status: 200, description: 'ข้อมูลผู้ออก token, เวลา, และหน้าที่เกี่ยวข้อง' })
+  @ApiResponse({ status: 400, description: 'token จำเป็นต้องระบุ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @UseGuards(JwtAuthGuard)
   @Get('watermark/lookup')
   lookup(

--- a/src/watermark-audit/watermark-audit.controller.ts
+++ b/src/watermark-audit/watermark-audit.controller.ts
@@ -10,14 +10,39 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { Request } from 'express';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { JwtPayload } from '../app.controller';
 import { WatermarkAuditService } from './watermark-audit.service';
 
+@ApiTags('Watermark Audit')
+@ApiBearerAuth()
 @Controller('ecom')
 export class WatermarkAuditController {
   constructor(private readonly service: WatermarkAuditService) {}
 
+  @ApiOperation({
+    summary: 'ออก watermark token สำหรับหน้าที่ระบุ เพื่อใช้ติดตามแหล่งที่มาของข้อมูลที่หลุดออกไป',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        page: { type: 'string', description: 'ชื่อ/path ของหน้าที่ขอ watermark token' },
+      },
+      required: ['page'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'ออก watermark token สำเร็จ' })
+  @ApiResponse({ status: 400, description: 'page จำเป็นต้องระบุ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @UseGuards(JwtAuthGuard)
   @Post('watermark/token')
   issueToken(
@@ -43,6 +68,14 @@ export class WatermarkAuditController {
   }
 
   // Admin: resolve a leaked watermark token -> who/when/which page.
+  @ApiOperation({
+    summary: 'ค้นหาข้อมูลที่มาของ watermark token ที่หลุดออกไป (ใคร/เมื่อไหร่/หน้าไหน) — เฉพาะ admin',
+  })
+  @ApiQuery({ name: 'token', required: true, description: 'watermark token ที่ต้องการตรวจสอบ' })
+  @ApiResponse({ status: 200, description: 'ข้อมูลผู้ออก token, เวลา, และหน้าที่เกี่ยวข้อง' })
+  @ApiResponse({ status: 400, description: 'token จำเป็นต้องระบุ' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @UseGuards(JwtAuthGuard)
   @Get('watermark/lookup')
   lookup(


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- ECWC-351

### 📌 ประเภทของ PR
- [ ] ✨ Feature ใหม่
- [ ] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [x] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
เพิ่ม Swagger/OpenAPI documentation แบบละเอียด (`example`, `description` ระบุ required/optional, `required` array) ให้ทุก endpoint ในโปรเจกต์ เพื่อให้ frontend/QA/ทีมอื่นเข้าใจ API ได้ง่ายขึ้นโดยไม่ต้องอ่าน source code

(แทนที่ PR #210 ซึ่งถูกปิดไปโดยอัตโนมัติตอน rename branch จาก `worktree-swagger-docs` เป็น `feature/ECWC-351`)

### 🛠️ แก้ปัญหานั้นอย่างไร
- Setup `@nestjs/swagger` (`DocumentBuilder`/`SwaggerModule`) ใน `main.ts` เปิดที่ `/api/docs`
- Annotate ทุก endpoint ใน `app.controller.ts` (278 endpoints) ด้วย `@ApiBody`/`@ApiParam`/`@ApiQuery` แบบมี `example` + `description` (required/optional/empty string allowed)
- Annotate controller ที่เหลือทั้งหมด: `app-version`, `auth`, `happy-hour` (รวม DTO), `line-oa-monitor`, `line-register-meeting`, `product-request`, `rating`, `watermark-audit`
- สำหรับ controller ที่ใช้ DTO class (`@ApiBody({ type: XxxDto })`) แก้ที่ `@ApiProperty()`/`@ApiPropertyOptional()` ใน DTO file โดยตรง

### 🧪 วิธี Test
1. รัน `npm run start:dev`
2. เปิด `http://localhost:<PORT>/api/docs`
3. ตรวจดูว่าทุก endpoint มี example/description ครบ และกด "Try it out" ทดสอบยิง request ได้จริง (endpoint ที่ต้อง login ใช้ปุ่ม Authorize ใส่ JWT token จาก `POST /api/ecom/login`)

### 🔑 Environment Variables ใหม่
- ไม่มี