### PR TITLE
ECWC-361 / Bug ไม่สามารถเพิ่มสินค้าเข้าร่วมรายการใน Company Day ได้

### DIFF
--- a/src/promotion/promotion.service.ts
+++ b/src/promotion/promotion.service.ts
@@ -1,5 +1,6 @@
 import { ShoppingCartService } from 'src/shopping-cart/shopping-cart.service';
 import {
+  BadRequestException,
   HttpException,
   Injectable,
   InternalServerErrorException,
@@ -795,25 +796,17 @@ export class PromotionService {
 
   async createCondition(data: { tier_id: number; product_gcode: string }) {
     try {
-      const tireIsUnit = await this.promotionConditionRepo
-        .createQueryBuilder('condition')
-        .leftJoin('condition.tier', 'tier')
-        .leftJoin('condition.product', 'product')
-        .where('product.pro_code = :pro_code', {
-          pro_code: data.product_gcode,
-        })
-        .andWhere('tier.is_unit = :is_unit', { is_unit: true })
-        .getMany();
-
-      if (tireIsUnit.length > 0)
-        throw new NotFoundException(
-          'Some promotion tire is unit based, cannot add product condition to this tire',
-        );
-
       const tier = await this.promotionTierRepo.findOne({
         where: { tier_id: data.tier_id },
         relations: ['promotion'],
       });
+      if (!tier) throw new NotFoundException(`Tier not found: ${data.tier_id}`);
+
+      // เช็คเฉพาะ tier ปลายทางที่จะเพิ่มเข้าไป ไม่ใช่ทั้งระบบจาก product
+      if (tier.is_unit)
+        throw new BadRequestException(
+          'Some promotion tire is unit based, cannot add product condition to this tire',
+        );
 
       const findTierisProduct = await this.promotionTierRepo
         .createQueryBuilder('tier')
@@ -825,7 +818,7 @@ export class PromotionService {
         .getMany();
 
       if (findTierisProduct.length > 0)
-        throw new NotFoundException(
+        throw new BadRequestException(
           'Cannot set all products for this tier because there are other tiers with the same minimum amount that are not active',
         );
 


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- https://nitipongjin-13063.atlassian.net/browse/ECWC-361

### 📌 ประเภทของ PR
- [ ] ✨ Feature ใหม่
- [x] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
แก้ bug ที่ endpoint `POST /api/ecom/promotion/condition/add` ตอบ `404` และไม่สามารถเพิ่มสินค้าเข้าร่วมรายการ (product condition) ใน Company Day ได้

สาเหตุจริงจาก log pod `e-commerce-backend`:
```
NotFoundException: Some promotion tire is unit based, cannot add product condition to this tire
  at PromotionService.createCondition (promotion.service.js:602)
```
เป็น `NotFoundException` ที่ถูก throw จาก business logic เอง ไม่ใช่ route หาย

### 🛠️ แก้ปัญหานั้นอย่างไร
- **แก้ logic หลัก** — `createCondition` เดิม query `promotion_condition` ทั้งระบบด้วย `product_gcode` + `tier.is_unit = true` โดยไม่ filter `tier_id` ปลายทางเลย ทำให้ถ้าสินค้านั้นเคยผูกกับ unit-based tier ที่ไหนก็ตามในระบบ จะถูก reject ทันที แม้ tier ที่กำลังจะเพิ่มจริงไม่ใช่ unit based → เปลี่ยนเป็นเช็ค `tier.is_unit` ที่ tier ปลายทาง (`data.tier_id`) ตรงๆ โดยใช้ `findOne(tier)` ที่ query อยู่แล้ว + เพิ่ม null check
- **แก้ status code** — เปลี่ยน `NotFoundException` (404) → `BadRequestException` (400) ทั้ง 2 จุด เพราะเป็น validation error ฝั่ง frontend จะได้แยกออกจาก route not found
- ลด query ลง 1 ตัว (ตัด query แบบ global ที่ไม่จำเป็นออก)

### 🧪 วิธี Test
1. สร้าง promotion ที่มี tier แบบ **ไม่ใช่** unit based (`is_unit = false`)
2. เรียก `POST /api/ecom/promotion/condition/add` ด้วย `tier_id` ของ tier นั้น + `product_gcode` ของสินค้าที่เคยอยู่ใน unit-based tier อื่น
3. คาดหวัง: เพิ่มสำเร็จ (เดิมจะได้ 404)
4. ลองเพิ่ม condition ใส่ tier ที่เป็น unit based จริง → คาดหวัง `400 Bad Request` พร้อมข้อความเดิม

### 🔑 Environment Variables ใหม่
- ไม่มี
