### PR TITLE
ECWC-350 / Creditor Listener & Upsert (+ ECWC-354 fix creditor_address varchar)

### DIFF
--- a/src/products/creditor.entity.ts
+++ b/src/products/creditor.entity.ts
@@ -15,7 +15,7 @@ export class CreditorEntity {
   @Column()
   creditor_name: string;
 
-  @Column({ nullable: true, default: null })
+  @Column({ type: 'varchar', nullable: true, default: null })
   creditor_address: string | null;
 
   @OneToMany(() => ProductEntity, (product) => product)

--- a/src/products/creditor.entity.ts
+++ b/src/products/creditor.entity.ts
@@ -15,8 +15,8 @@ export class CreditorEntity {
   @Column()
   creditor_name: string;
 
-  @Column({ nullable: true, default: null })
-  creditor_address: string;
+  @Column({ type: 'varchar', length: 255, nullable: true, default: null })
+  creditor_address: string | null;
 
   @OneToMany(() => ProductEntity, (product) => product)
   product: ProductEntity;

--- a/src/products/creditor.entity.ts
+++ b/src/products/creditor.entity.ts
@@ -15,7 +15,7 @@ export class CreditorEntity {
   @Column()
   creditor_name: string;
 
-  @Column({ type: 'varchar', length: 255, nullable: true, default: null })
+  @Column({ nullable: true, default: null })
   creditor_address: string | null;
 
   @OneToMany(() => ProductEntity, (product) => product)

--- a/src/products/creditor.listener.ts
+++ b/src/products/creditor.listener.ts
@@ -1,0 +1,36 @@
+import { Controller, Logger } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
+import { ProductsService } from './products.service';
+
+interface CreditorEcomPayload {
+  creditor_code: string;
+  creditor_name?: string;
+  creditor_address?: string | null;
+}
+
+@Controller()
+export class CreditorListener {
+  private readonly logger = new Logger(CreditorListener.name);
+
+  constructor(private readonly productsService: ProductsService) {}
+
+  @MessagePattern('creditor_created_ecom')
+  async handleCreated(@Payload() message: CreditorEcomPayload) {
+    try {
+      this.logger.log('Received message in creditor listener (created):', message);
+      await this.productsService.upsertCreditor(message);
+    } catch (error) {
+      this.logger.error('Kafka creditor_created_ecom error', String(error));
+    }
+  }
+
+  @MessagePattern('creditor_update_ecom')
+  async handleUpdated(@Payload() message: CreditorEcomPayload) {
+    try {
+      this.logger.log('Received message in creditor listener (updated):', message);
+      await this.productsService.upsertCreditor(message);
+    } catch (error) {
+      this.logger.error('Kafka creditor_update_ecom error', String(error));
+    }
+  }
+}

--- a/src/products/product.listener.ts
+++ b/src/products/product.listener.ts
@@ -82,6 +82,21 @@ export class ProductListner {
     }
   }
 
+  @MessagePattern('product_stock_update')
+  async updateStock(
+    @Payload() message: { product_code: string; product_stock: number },
+  ) {
+    try {
+      this.logger.log('Received message in product stock listener:', message);
+      await this.productServerce.updateStockFromKafka(message);
+    } catch (error) {
+      this.logger.error(
+        'Kafka Received message in product stock listener',
+        String(error),
+      );
+    }
+  }
+
   @MessagePattern('product_created_detail_ecom')
   async addProductDetail(@Payload() message: ProductPharmaEntity) {
     try {

--- a/src/products/product.listener.ts
+++ b/src/products/product.listener.ts
@@ -82,21 +82,6 @@ export class ProductListner {
     }
   }
 
-  @MessagePattern('product_stock_update')
-  async updateStock(
-    @Payload() message: { product_code: string; product_stock: number },
-  ) {
-    try {
-      this.logger.log('Received message in product stock listener:', message);
-      await this.productServerce.updateStockFromKafka(message);
-    } catch (error) {
-      this.logger.error(
-        'Kafka Received message in product stock listener',
-        String(error),
-      );
-    }
-  }
-
   @MessagePattern('product_created_detail_ecom')
   async addProductDetail(@Payload() message: ProductPharmaEntity) {
     try {

--- a/src/products/products.module.ts
+++ b/src/products/products.module.ts
@@ -6,6 +6,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ProductEntity } from './products.entity';
 import { ProductPharmaEntity } from './product-pharma.entity';
 import { ProductListner } from './product.listener';
+import { CreditorListener } from './creditor.listener';
 import { CreditorEntity } from './creditor.entity';
 import { LogFileEntity } from 'src/backend/logFile.entity';
 import { BackendModule } from 'src/backend/backend.module';
@@ -35,7 +36,7 @@ import { ProductUnitEntity } from './product-unit.entity';
     forwardRef(() => ShoppingCartModule),
   ],
   providers: [ProductsService],
-  controllers: [ProductListner],
+  controllers: [ProductListner, CreditorListener],
   exports: [ProductsService],
 })
 export class ProductsModule {}

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -697,22 +697,6 @@ export class ProductsService {
     }
   }
 
-  async updateStockFromKafka(message: {
-    product_code: string;
-    product_stock: number;
-  }) {
-    try {
-      // pro_stock เป็น int — ปัดเศษกัน decimal จากต้นทางถูก MySQL ตัดทิ้งเงียบ ๆ
-      await this.productRepo.update(
-        { pro_code: message.product_code },
-        { pro_stock: Math.round(Number(message.product_stock) || 0) },
-      );
-    } catch (error) {
-      this.logger.error('Error updating product stock', String(error));
-      throw error;
-    }
-  }
-
   async createProduct(
     product: ProductEntity & {
       pro_unit1?: string;

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -193,6 +193,42 @@ export class ProductsService {
     }
   }
 
+  // sync creditor (supplier) master จาก agentservice ผ่าน Kafka — upsert ตาม creditor_code
+  async upsertCreditor(data: {
+    creditor_code: string;
+    creditor_name?: string;
+    creditor_address?: string | null;
+  }) {
+    try {
+      const existing = await this.creditorRepo.findOne({
+        where: { creditor_code: data.creditor_code },
+      });
+      if (existing) {
+        await this.creditorRepo.update(
+          { creditor_code: data.creditor_code },
+          {
+            ...(data.creditor_name !== undefined && {
+              creditor_name: data.creditor_name,
+            }),
+            ...(data.creditor_address !== undefined && {
+              creditor_address: data.creditor_address ?? null,
+            }),
+          },
+        );
+      } else {
+        const newCreditor = this.creditorRepo.create({
+          creditor_code: data.creditor_code,
+          creditor_name: data.creditor_name ?? '',
+          creditor_address: data.creditor_address ?? null,
+        });
+        await this.creditorRepo.save(newCreditor);
+      }
+    } catch (error) {
+      this.logger.error('Error upserting creditor:', String(error));
+      throw error;
+    }
+  }
+
   async getProductByCreditor(creditor_code: string) {
     try {
       const qb = this.productRepo.createQueryBuilder('product');
@@ -658,6 +694,22 @@ export class ProductsService {
     } catch (error) {
       this.logger.error('Error updating product promotion month', error);
       throw new Error('Error updating product promotion month');
+    }
+  }
+
+  async updateStockFromKafka(message: {
+    product_code: string;
+    product_stock: number;
+  }) {
+    try {
+      // pro_stock เป็น int — ปัดเศษกัน decimal จากต้นทางถูก MySQL ตัดทิ้งเงียบ ๆ
+      await this.productRepo.update(
+        { pro_code: message.product_code },
+        { pro_stock: Math.round(Number(message.product_stock) || 0) },
+      );
+    } catch (error) {
+      this.logger.error('Error updating product stock', String(error));
+      throw error;
     }
   }
 


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- https://nitipongjin-13063.atlassian.net/browse/ECWC-350
- https://nitipongjin-13063.atlassian.net/browse/ECWC-354

### 📌 ประเภทของ PR
- [x] ✨ Feature ใหม่
- [x] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
แยกเฉพาะฟีเจอร์ Creditor Listener & Upsert (ECWC-350) + การ fix type ของ column creditor_address (ECWC-354) ออกมาขึ้น `main` แยกจาก release 1.42.0 ที่ยังรวมฟีเจอร์อื่นอยู่

- รับข้อมูล creditor (supplier) master จาก agentservice ผ่าน Kafka เพื่อ sync เข้ามาในระบบ ecommerce
- ECWC-354: ระบุ `type: 'varchar'` ให้ column `creditor_address` เพื่อให้ schema นิยามชัดเจนและรองรับค่า null

### 🛠️ แก้ปัญหานั้นอย่างไร
- เพิ่ม `CreditorListener` (Kafka consumer) ฟัง topic `creditor_created_ecom` และ `creditor_update_ecom` แล้วเรียก `upsertCreditor`
- เพิ่ม method `upsertCreditor` ใน `ProductsService` — upsert ตาม `creditor_code` (update ถ้ามีอยู่ / create ถ้ายังไม่มี)
- ลงทะเบียน `CreditorListener` ใน `ProductsModule` controllers
- ปรับ `CreditorEntity.creditor_address` เป็น `type: 'varchar'` + `string | null`

### 🧪 วิธี Test
1. ส่ง message เข้า Kafka topic `creditor_created_ecom` ด้วย payload `{ creditor_code, creditor_name, creditor_address }` → ตรวจว่ามี record ใหม่ในตาราง creditor
2. ส่งซ้ำด้วย `creditor_code` เดิมแต่เปลี่ยน name/address → ตรวจว่า record ถูก update ไม่ใช่สร้างใหม่
3. ส่ง `creditor_address` เป็น null → ตรวจว่าไม่ error และค่าเป็น null

### 🔑 Environment Variables ใหม่
- ไม่มี
