### PR TITLE
feat: add seed-e2e script for Playwright CI environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js -d ./src/data-source.ts",
     "migration:generate": "npm run typeorm -- migration:generate",
     "migration:run": "npm run typeorm -- migration:run",
-    "migration:revert": "npm run typeorm -- migration:revert"
+    "migration:revert": "npm run typeorm -- migration:revert",
+    "seed:e2e": "ts-node -r tsconfig-paths/register scripts/seed-e2e.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.876.0",

--- a/scripts/seed-e2e.ts
+++ b/scripts/seed-e2e.ts
@@ -1,0 +1,80 @@
+/**
+ * Seed ข้อมูลขั้นต่ำที่ Playwright E2E suite ของ Ecommerce-Frontend ต้องใช้
+ * (tests/e2e/utils/auth.ts, tests/e2e/happy-hour-manage.spec.ts) — รันเฉพาะตอนเตรียม
+ * environment สำหรับ CI/E2E เท่านั้น ไม่ใช่ seed สำหรับ production
+ *
+ * idempotent: รันซ้ำได้ ถ้ามีข้อมูลอยู่แล้วจะ skip ไม่ทับของเดิม
+ */
+import { AppDataSource } from '../src/data-source';
+import { UserEntity } from '../src/users/users.entity';
+import { ProductEntity } from '../src/products/products.entity';
+import * as bcrypt from 'bcrypt';
+
+const SALT_ROUNDS = 10;
+
+// ตรงกับ E2E_ADMIN_USERNAME / E2E_ADMIN_PASSWORD ที่ Ecommerce-Frontend ใช้ login ผ่าน loginAsAdmin()
+const ADMIN_CODE = process.env.E2E_SEED_ADMIN_CODE ?? '0539';
+const ADMIN_PASSWORD = process.env.E2E_SEED_ADMIN_PASSWORD ?? '0539';
+
+// pro_code 92020405 ตรงกับที่ tests/e2e/happy-hour-manage.spec.ts เลือกเป็นของแถมโดยตรง
+// ส่วนตัวอื่นมีคำว่า "โลตัส" ให้ debounce search ของ Lotus Card picker เจอผลลัพธ์
+const SEED_PRODUCTS: Partial<ProductEntity>[] = [
+  { pro_code: '92020405', pro_name: 'บัตรโลตัส100บ/ใบ' },
+  { pro_code: 'E2E-LOTUS-050', pro_name: 'บัตรโลตัส50บ/ใบ' },
+  { pro_code: 'E2E-LOTUS-200', pro_name: 'บัตรโลตัส200บ/ใบ' },
+];
+
+async function seedAdminUser(dataSource: typeof AppDataSource) {
+  const userRepo = dataSource.getRepository(UserEntity);
+  const existing = await userRepo.findOne({
+    where: { mem_username: ADMIN_CODE },
+  });
+  if (existing) {
+    console.log(`seed-e2e: admin user "${ADMIN_CODE}" มีอยู่แล้ว — skip`);
+    return;
+  }
+
+  await userRepo.save(
+    userRepo.create({
+      mem_code: ADMIN_CODE,
+      mem_username: ADMIN_CODE,
+      mem_password: await bcrypt.hash(ADMIN_PASSWORD, SALT_ROUNDS),
+      mem_nameSite: 'E2E Test Admin',
+      permision_admin: true,
+      role: 'Admin',
+    }),
+  );
+  console.log(`seed-e2e: สร้าง admin user "${ADMIN_CODE}" แล้ว`);
+}
+
+async function seedProducts(dataSource: typeof AppDataSource) {
+  const productRepo = dataSource.getRepository(ProductEntity);
+
+  for (const product of SEED_PRODUCTS) {
+    const existing = await productRepo.findOne({
+      where: { pro_code: product.pro_code },
+    });
+    if (existing) {
+      console.log(`seed-e2e: product "${product.pro_code}" มีอยู่แล้ว — skip`);
+      continue;
+    }
+    await productRepo.save(productRepo.create(product));
+    console.log(`seed-e2e: สร้าง product "${product.pro_code}" แล้ว`);
+  }
+}
+
+async function main() {
+  await AppDataSource.initialize();
+  try {
+    await seedAdminUser(AppDataSource);
+    await seedProducts(AppDataSource);
+    console.log('seed-e2e: เสร็จสิ้น');
+  } finally {
+    await AppDataSource.destroy();
+  }
+}
+
+main().catch((error) => {
+  console.error('seed-e2e: ล้มเหลว', error);
+  process.exit(1);
+});

--- a/scripts/seed-e2e.ts
+++ b/scripts/seed-e2e.ts
@@ -8,6 +8,7 @@
 import { DataSource } from 'typeorm';
 import { UserEntity } from '../src/users/users.entity';
 import { ProductEntity } from '../src/products/products.entity';
+import { Modalmain } from '../src/modalmain/modalmain.entity';
 import * as bcrypt from 'bcrypt';
 
 const SALT_ROUNDS = 10;
@@ -77,11 +78,33 @@ async function seedProducts(dataSource: DataSource) {
   }
 }
 
+// ModalContentService.saveModalContent() ทำแค่ repository.update({id}, ...) ไม่เคย insert
+// แถวใหม่เลย ถ้า table modalmain ว่างเปล่า (database สดใหม่) save จะ no-op เงียบๆตลอดไป
+// (ไม่มี error แต่ก็ไม่เคยมีแถวให้ GET เจอ) ต้อง seed แถวเริ่มต้นไว้ก่อนให้ update มี row ให้แก้จริง
+async function seedModalContent(dataSource: DataSource) {
+  const modalRepo = dataSource.getRepository(Modalmain);
+  const existing = await modalRepo.find();
+  if (existing.length > 0) {
+    console.log('seed-e2e: modalmain มีข้อมูลอยู่แล้ว — skip');
+    return;
+  }
+
+  await modalRepo.save(
+    modalRepo.create({
+      title: 'Happy Hour',
+      content: 'ทดสอบ',
+      show: false,
+    }),
+  );
+  console.log('seed-e2e: สร้าง modalmain แถวเริ่มต้นแล้ว');
+}
+
 async function main() {
   await SeedDataSource.initialize();
   try {
     await seedAdminUser(SeedDataSource);
     await seedProducts(SeedDataSource);
+    await seedModalContent(SeedDataSource);
     console.log('seed-e2e: เสร็จสิ้น');
   } finally {
     await SeedDataSource.destroy();

--- a/scripts/seed-e2e.ts
+++ b/scripts/seed-e2e.ts
@@ -5,12 +5,26 @@
  *
  * idempotent: รันซ้ำได้ ถ้ามีข้อมูลอยู่แล้วจะ skip ไม่ทับของเดิม
  */
-import { AppDataSource } from '../src/data-source';
+import { DataSource } from 'typeorm';
 import { UserEntity } from '../src/users/users.entity';
 import { ProductEntity } from '../src/products/products.entity';
 import * as bcrypt from 'bcrypt';
 
 const SALT_ROUNDS = 10;
+
+// สร้าง DataSource ของตัวเองแยกจาก src/data-source.ts (อันนั้น synchronize: false เสมอ
+// เพราะใช้ร่วมกับ migration CLI) — seed script นี้ตั้ง synchronize: true เพื่อสร้าง schema
+// เองตรงนี้เลย ไม่ต้องพึ่ง timing ว่า backend process (อีก connection แยกกัน) sync ไปก่อนหรือยัง
+const SeedDataSource = new DataSource({
+  type: 'mysql',
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT),
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  entities: [__dirname + '/../src/**/*.entity{.ts,.js}'],
+  synchronize: true,
+});
 
 // ตรงกับ E2E_ADMIN_USERNAME / E2E_ADMIN_PASSWORD ที่ Ecommerce-Frontend ใช้ login ผ่าน loginAsAdmin()
 const ADMIN_CODE = process.env.E2E_SEED_ADMIN_CODE ?? '0539';
@@ -24,7 +38,7 @@ const SEED_PRODUCTS: Partial<ProductEntity>[] = [
   { pro_code: 'E2E-LOTUS-200', pro_name: 'บัตรโลตัส200บ/ใบ' },
 ];
 
-async function seedAdminUser(dataSource: typeof AppDataSource) {
+async function seedAdminUser(dataSource: DataSource) {
   const userRepo = dataSource.getRepository(UserEntity);
   const existing = await userRepo.findOne({
     where: { mem_username: ADMIN_CODE },
@@ -47,7 +61,7 @@ async function seedAdminUser(dataSource: typeof AppDataSource) {
   console.log(`seed-e2e: สร้าง admin user "${ADMIN_CODE}" แล้ว`);
 }
 
-async function seedProducts(dataSource: typeof AppDataSource) {
+async function seedProducts(dataSource: DataSource) {
   const productRepo = dataSource.getRepository(ProductEntity);
 
   for (const product of SEED_PRODUCTS) {
@@ -64,13 +78,13 @@ async function seedProducts(dataSource: typeof AppDataSource) {
 }
 
 async function main() {
-  await AppDataSource.initialize();
+  await SeedDataSource.initialize();
   try {
-    await seedAdminUser(AppDataSource);
-    await seedProducts(AppDataSource);
+    await seedAdminUser(SeedDataSource);
+    await seedProducts(SeedDataSource);
     console.log('seed-e2e: เสร็จสิ้น');
   } finally {
-    await AppDataSource.destroy();
+    await SeedDataSource.destroy();
   }
 }
 


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- ECWC-352

### 📌 ประเภทของ PR
- [x] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
Ecommerce-Frontend กำลังตั้ง CI ให้รัน Playwright E2E suite (Happy Hour Management) ตอนเปิด PR เข้า develop โดยให้ backend นี้รันขึ้นมาสดๆใน CI job เดียวกัน (MySQL ใหม่ + `SYNCHRONIZE=true`) ซึ่ง DB จะไม่มีข้อมูลใดๆเลย ทำให้ test ที่ต้อง login ด้วย admin account และค้นหาสินค้า "โลตัส" ไม่ผ่านตั้งแต่ก้าวแรก

### 🛠️ แก้ปัญหานั้นอย่างไร
เพิ่ม `scripts/seed-e2e.ts` + npm script `seed:e2e` ที่ insert ข้อมูลขั้นต่ำที่ Playwright suite ต้องใช้:
- admin user (`mem_username`/`mem_code` = `0539`, password hash ด้วย bcrypt, `permision_admin: true`, `role: Admin`)
- สินค้า `pro_code` `92020405` ("บัตรโลตัส100บ/ใบ") และสินค้าอื่นที่มีคำว่า "โลตัส" ในชื่ออีก 2 รายการ สำหรับเทส product picker

Script เป็น idempotent (เช็คก่อนว่ามีอยู่แล้วหรือไม่ ถ้ามีจะ skip ไม่ insert ซ้ำ) ไม่ได้ไปแก้ schema/migration ใดๆ ใช้แค่ TypeORM repository ของ entity ที่มีอยู่แล้ว (`UserEntity`, `ProductEntity`)

### 🧪 วิธี Test
1. ตั้ง `.env` ให้ชี้ไปที่ DB ทดสอบ (ห้ามชี้ไป production)
2. รัน `npm run seed:e2e`
3. เช็คว่ามี user `0539` ใน table `users` และมี product `92020405` ใน table `product` — รันซ้ำอีกรอบต้องไม่ error และไม่สร้างซ้ำ (เห็น log "มีอยู่แล้ว — skip")

### 🔑 Environment Variables ใหม่
- `E2E_SEED_ADMIN_CODE` (optional, default `0539`) — รหัส admin ที่จะ seed
- `E2E_SEED_ADMIN_PASSWORD` (optional, default `0539`) — password ของ admin ที่จะ seed

---
หมายเหตุ: PR #216 (อันเดิม) ถูกปิดไปเพราะเปลี่ยนชื่อ branch จาก `feature/e2e-ci-seed-script` เป็น `feature/ECWC-352`