### PR TITLE
ECWC-364 / แก้ Event Loop ใน Ecommerce

### DIFF
--- a/src/hotdeal/hotdeal.service.ts
+++ b/src/hotdeal/hotdeal.service.ts
@@ -1114,13 +1114,16 @@ export class HotdealService {
       ]),
     ] as string[];
 
+    // ดึง units ของทุก code ในครั้งเดียว แล้ว transform จาก map — กัน N+1
+    const unitsMap = await this.productService.getUnitsMapByProCodes(uniqueCodes);
     const transformedMap = new Map<string, { pro_unit1: string; pro_unit2: string; pro_unit3: string }>();
-    await Promise.all(
-      uniqueCodes.map(async (code) => {
-        const t = await this.productService.transformProductWithUnits({ pro_code: code } as ProductEntity);
-        transformedMap.set(code, t);
-      }),
-    );
+    for (const code of uniqueCodes) {
+      const t = await this.productService.transformProductWithUnits(
+        { pro_code: code } as ProductEntity,
+        unitsMap.get(code) ?? [],
+      );
+      transformedMap.set(code, t);
+    }
 
     const resolveUnit = (transformed: { pro_unit1: string; pro_unit2: string; pro_unit3: string } | undefined, level: number, fallback: string) => {
       if (!transformed) return fallback;

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -132,6 +132,7 @@ export class ProductsService {
 
   async transformProductWithUnits<T extends { pro_code: string }>(
     product: T,
+    units?: { level: number; unit_name: string; ratio: number }[],
   ): Promise<
     T & {
       pro_unit1: string;
@@ -142,21 +143,56 @@ export class ProductsService {
       pro_ratio3: number;
     }
   > {
-    const units = await this.productUnitRepo.find({
-      where: { product: { pro_code: product.pro_code } },
-      select: ['level', 'unit_name', 'ratio'],
-      order: { level: 'ASC' },
-    });
+    // ถ้า caller ส่ง units มาแล้ว (prefetch แบบ batch) ไม่ query ซ้ำ กัน N+1
+    const resolvedUnits =
+      units ??
+      (await this.productUnitRepo.find({
+        where: { product: { pro_code: product.pro_code } },
+        select: ['level', 'unit_name', 'ratio'],
+        order: { level: 'ASC' },
+      }));
 
     return {
       ...product,
-      pro_unit1: this.convertEnumToUnitName(1, units),
-      pro_unit2: this.convertEnumToUnitName(2, units),
-      pro_unit3: this.convertEnumToUnitName(3, units),
-      pro_ratio1: this.getRatioFromUnits(1, units),
-      pro_ratio2: this.getRatioFromUnits(2, units),
-      pro_ratio3: this.getRatioFromUnits(3, units),
+      pro_unit1: this.convertEnumToUnitName(1, resolvedUnits),
+      pro_unit2: this.convertEnumToUnitName(2, resolvedUnits),
+      pro_unit3: this.convertEnumToUnitName(3, resolvedUnits),
+      pro_ratio1: this.getRatioFromUnits(1, resolvedUnits),
+      pro_ratio2: this.getRatioFromUnits(2, resolvedUnits),
+      pro_ratio3: this.getRatioFromUnits(3, resolvedUnits),
     };
+  }
+
+  // ดึง units ของหลาย pro_code ในครั้งเดียว แล้ว group เป็น map — กัน N+1 ตอน transform หลายตัว
+  async getUnitsMapByProCodes(
+    proCodes: string[],
+  ): Promise<
+    Map<string, { level: number; unit_name: string; ratio: number }[]>
+  > {
+    const map = new Map<
+      string,
+      { level: number; unit_name: string; ratio: number }[]
+    >();
+    if (proCodes.length === 0) {
+      return map;
+    }
+
+    const allUnits = await this.productUnitRepo.find({
+      where: { pro_code: In(proCodes) },
+      select: { pro_code: true, level: true, unit_name: true, ratio: true },
+      order: { level: 'ASC' },
+    });
+
+    for (const unit of allUnits) {
+      const list = map.get(unit.pro_code);
+      if (list) {
+        list.push(unit);
+      } else {
+        map.set(unit.pro_code, [unit]);
+      }
+    }
+
+    return map;
   }
 
   private async isL16Member(

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -2698,6 +2698,8 @@ export class ProductsService {
         `${process.env.OLD_WEBSITE_URL}/API/appV3/search_auto.php`,
         {
           params: { search },
+          // เว็บเก่าเคยค้างนานถึง 16 นาที → กัน event loop congestion
+          timeout: 10000,
         },
       );
 
@@ -2758,6 +2760,8 @@ export class ProductsService {
         `${process.env.OLD_WEBSITE_URL}/API/appV3/search_enter.php`,
         {
           params: { search },
+          // เว็บเก่าเคยค้างนานถึง 16 นาที → กัน event loop congestion
+          timeout: 10000,
         },
       );
 

--- a/src/shopping-cart/shopping-cart.service.ts
+++ b/src/shopping-cart/shopping-cart.service.ts
@@ -218,6 +218,15 @@ interface HotdealSyncContext {
   hotdeals: HotdealEntity[];
 }
 
+// prefetch แบบ batch สำหรับ getProductCart — กัน N+1 ในการคำนวณแต้ม/ของแถม
+interface HotdealPointsContext {
+  allHotdeals: Awaited<ReturnType<HotdealService['getHotdealByProCode']>>;
+  freebiesByMain: Map<string, ShoppingCartEntity[]>;
+  mainInCartByMain: Map<string, ShoppingCartEntity[]>;
+  unitsMap: Map<string, { level: number; unit_name: string; ratio: number }[]>;
+  usedPointsMap?: Map<string, number>;
+}
+
 // Define a DTO for the return type
 export interface CartSummary {
   cart: any[];
@@ -353,6 +362,7 @@ export class ShoppingCartService {
 
   private async transformProductWithUnits<T extends { pro_code: string }>(
     product: T,
+    units?: { level: number; unit_name: string; ratio: number }[],
   ): Promise<
     T & {
       pro_unit1: string;
@@ -363,18 +373,20 @@ export class ShoppingCartService {
       pro_ratio3: number;
     }
   > {
-    return await this.productsService.transformProductWithUnits(product);
+    return await this.productsService.transformProductWithUnits(product, units);
   }
 
   private async calculateSmallestUnitWithTransformed(
     orderItems: Array<{ unit: string; quantity: number; pro_code: string }>,
     pro_code: string,
+    unitsMap?: Map<string, { level: number; unit_name: string; ratio: number }[]>,
   ): Promise<number> {
     let total = 0;
     try {
-      const transformedProduct = await this.transformProductWithUnits({
-        pro_code,
-      });
+      const transformedProduct = await this.transformProductWithUnits(
+        { pro_code },
+        unitsMap?.get(pro_code),
+      );
 
       const units = [
         {
@@ -1739,30 +1751,92 @@ export class ShoppingCartService {
         ...raw.find((r) => r.pro_code === pro_code),
       }));
 
-      const transformedProductsMap = new Map<string, any>();
-      for (const product of uniqueProducts) {
-        const transformed = await this.transformProductWithUnits(product);
-        transformedProductsMap.set(product.pro_code, transformed);
+      // Prefetch แบบ batch (freebies + main-in-cart) กัน N+1 ในการคำนวณแต้ม/ของแถม
+      const [freebiesAll, mainInCartAll] = await Promise.all([
+        this.shoppingCartRepo.find({
+          where: {
+            mem_code,
+            hotdeal_promain: In(allProCodes),
+            hotdeal_free: true,
+            spc_checked: true,
+          },
+          relations: { product: true },
+        }),
+        this.shoppingCartRepo.find({
+          where: {
+            mem_code,
+            pro_code: In(allProCodes),
+            hotdeal_free: false,
+            spc_checked: true,
+          },
+          relations: { product: { units: true } },
+        }),
+      ]);
+
+      const freebiesByMain = new Map<string, ShoppingCartEntity[]>();
+      for (const freebie of freebiesAll) {
+        const mainCode = freebie.hotdeal_promain ?? '';
+        const list = freebiesByMain.get(mainCode);
+        if (list) list.push(freebie);
+        else freebiesByMain.set(mainCode, [freebie]);
       }
-      // คำนวณ used points สำหรับแต่ละสินค้า
-      const usedPointsPromises = allProCodes.map((proCode) =>
-        this.calculateUsedHotdealPoints(mem_code, proCode),
-      );
-      const usedPointsResults = await Promise.all(usedPointsPromises);
-      const usedPointsMap = new Map(
-        allProCodes.map((proCode, index) => [
-          proCode,
-          usedPointsResults[index],
+
+      const mainInCartByMain = new Map<string, ShoppingCartEntity[]>();
+      for (const item of mainInCartAll) {
+        const list = mainInCartByMain.get(item.pro_code);
+        if (list) list.push(item);
+        else mainInCartByMain.set(item.pro_code, [item]);
+      }
+
+      // units ของสินค้าหลัก + สินค้าของแถม ดึงครั้งเดียว
+      const unitsMap = await this.productsService.getUnitsMapByProCodes([
+        ...new Set([
+          ...allProCodes,
+          ...freebiesAll.map((freebie) => freebie.pro_code),
         ]),
+      ]);
+
+      const hotdealPointsContext: HotdealPointsContext = {
+        allHotdeals,
+        freebiesByMain,
+        mainInCartByMain,
+        unitsMap,
+      };
+
+      // Transform units ของทุก product (ใช้ unitsMap ไม่ query ใน loop)
+      const transformedProductsMap = new Map<string, TransformedProductCart>();
+      for (const product of uniqueProducts) {
+        const transformed = await this.transformProductWithUnits(
+          product,
+          unitsMap.get(product.pro_code) ?? [],
+        );
+        transformedProductsMap.set(
+          product.pro_code,
+          transformed as unknown as TransformedProductCart,
+        );
+      }
+
+      // คำนวณ used points สำหรับแต่ละสินค้า (อ่านจาก context ที่ prefetch แล้ว)
+      const usedPointsResults = await Promise.all(
+        allProCodes.map((proCode) =>
+          this.calculateUsedHotdealPoints(
+            mem_code,
+            proCode,
+            hotdealPointsContext,
+          ),
+        ),
       );
+      const usedPointsMap = new Map(
+        allProCodes.map((proCode, index) => [proCode, usedPointsResults[index]]),
+      );
+      // getHotdealPointsInfo reuse ค่านี้ ไม่คำนวณ used points ซ้ำ
+      hotdealPointsContext.usedPointsMap = usedPointsMap;
 
       // คำนวณ hotdeal points info แบบละเอียด (แต้มที่เหลือหลังหักของแถม)
-      const hotdealPointsInfoPromises = allProCodes.map(async (proCode) => {
-        // getHotdealPointsInfo คืนค่า remainingPoints (แต้มที่เหลือ)
-        return this.getHotdealPointsInfo(mem_code, proCode);
-      });
       const hotdealPointsInfoResults = await Promise.all(
-        hotdealPointsInfoPromises,
+        allProCodes.map((proCode) =>
+          this.getHotdealPointsInfo(mem_code, proCode, hotdealPointsContext),
+        ),
       );
       const hotdealPointsInfoMap = new Map(
         allProCodes.map((proCode, index) => [
@@ -2881,25 +2955,30 @@ export class ShoppingCartService {
   async calculateUsedHotdealPoints(
     mem_code: string,
     pro_code: string,
+    ctx?: HotdealPointsContext,
   ): Promise<number> {
     try {
       // ดึงรายการของแถม (hotdeal_free = true) ที่เกิดจากสินค้าหลัก pro_code
-      const freebies = await this.shoppingCartRepo.find({
-        where: {
-          mem_code,
-          hotdeal_promain: pro_code,
-          hotdeal_free: true,
-          spc_checked: true,
-        },
-        relations: { product: true },
-      });
+      // มี ctx (มาจาก getProductCart) → อ่านจาก map ที่ prefetch ไว้ กัน N+1
+      const freebies = ctx
+        ? (ctx.freebiesByMain.get(pro_code) ?? [])
+        : await this.shoppingCartRepo.find({
+            where: {
+              mem_code,
+              hotdeal_promain: pro_code,
+              hotdeal_free: true,
+              spc_checked: true,
+            },
+            relations: { product: true },
+          });
       if (freebies.length === 0) {
         return 0;
       }
 
-      // ดึงข้อมูล hotdeal สำหรับสินค้าหลัก
-      const hotdeals: HotdealEntity[] | null =
-        await this.hotdealService.getHotdealByProCode([pro_code]);
+      // ดึงข้อมูล hotdeal สำหรับสินค้าหลัก — reuse allHotdeals ที่ batch มาแล้วถ้ามี ctx
+      const hotdeals = ctx
+        ? ctx.allHotdeals.filter((hd) => hd.product?.pro_code === pro_code)
+        : await this.hotdealService.getHotdealByProCode([pro_code]);
       if (!hotdeals || hotdeals.length === 0) {
         return 0;
       }
@@ -2913,6 +2992,7 @@ export class ShoppingCartService {
         if (freebie.product) {
           const transformedProduct = await this.transformProductWithUnits(
             freebie.product,
+            ctx?.unitsMap.get(freebie.pro_code),
           );
           freebieUnitName = this.convertEnumToUnitName(
             freebie.spc_unit_enum,
@@ -2949,6 +3029,7 @@ export class ShoppingCartService {
             await this.calculateSmallestUnitWithTransformed(
               requiredItems,
               pro_code,
+              ctx?.unitsMap,
             );
 
           // คำนวณแต้มรวมที่ใช้ = จำนวนของแถม × แต้มต่อหน่วย
@@ -2967,27 +3048,31 @@ export class ShoppingCartService {
   async getHotdealPointsInfo(
     mem_code: string,
     pro_code: string,
+    ctx?: HotdealPointsContext,
   ): Promise<number> {
     try {
-      // คำนวณแต้มทั้งหมดที่มีในตะกร้า
-      const mainProductsInCart = await this.shoppingCartRepo.find({
-        where: {
-          mem_code,
-          pro_code,
-          hotdeal_free: false,
-          spc_checked: true,
-        },
-        relations: { product: { units: true } },
-      });
+      // คำนวณแต้มทั้งหมดที่มีในตะกร้า — อ่านจาก map ที่ prefetch ไว้ถ้ามี ctx
+      const mainProductsInCart = ctx
+        ? (ctx.mainInCartByMain.get(pro_code) ?? [])
+        : await this.shoppingCartRepo.find({
+            where: {
+              mem_code,
+              pro_code,
+              hotdeal_free: false,
+              spc_checked: true,
+            },
+            relations: { product: { units: true } },
+          });
 
       if (mainProductsInCart.length === 0) {
         return 0;
       }
 
       // แปลง spc_unit_enum เป็น unit name สำหรับการคำนวณ
-      const transformedProduct = await this.transformProductWithUnits({
-        pro_code,
-      });
+      const transformedProduct = await this.transformProductWithUnits(
+        { pro_code },
+        ctx?.unitsMap.get(pro_code),
+      );
       const cartItemsWithUnitNames = mainProductsInCart.map((item) => {
         const unitName = this.convertEnumToUnitName(
           item.spc_unit_enum,
@@ -3005,11 +3090,12 @@ export class ShoppingCartService {
       const totalPoints = await this.calculateSmallestUnitWithTransformed(
         cartItemsWithUnitNames,
         pro_code,
+        ctx?.unitsMap,
       );
-      const usedPoints = await this.calculateUsedHotdealPoints(
-        mem_code,
-        pro_code,
-      );
+      // reuse usedPointsMap ที่คำนวณไว้แล้วใน getProductCart ไม่คำนวณซ้ำ
+      const usedPoints = ctx
+        ? (ctx.usedPointsMap?.get(pro_code) ?? 0)
+        : await this.calculateUsedHotdealPoints(mem_code, pro_code);
       const remainingPoints = Math.max(0, totalPoints - usedPoints);
 
       return remainingPoints;


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- https://nitipongjin-13063.atlassian.net/browse/ECWC-364

### 📌 ประเภทของ PR
- [ ] ✨ Feature ใหม่
- [x] 🐛 แก้ Bug
- [x] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
Pod `ecommerce-backend` หน่วงสะสมหลัง restart จน event loop congestion (p99 หลาย endpoint แตะ 100–300s ทั้งที่ DB จริงใช้เวลาไม่ถึง 1%) มี 2 ต้นตอ:

1. **External API ไม่มี timeout** — `searchExternalProducts` / `searchEnterProducts` เรียก API เว็บเก่า (`search_auto.php`, `search_enter.php`) ด้วย `axios.get` ที่ไม่ตั้ง timeout → axios รอไม่จำกัด บาง request ค้างนานถึง **995 วินาที** (จาก SigNoz trace) กิน socket + pending callback ค้าง → event loop congestion ลามทุก endpoint
2. **N+1 ใน `getProductCart`** — ยิง query **~673 ครั้ง/การดึงตะกร้า 1 ครั้ง** จาก `transformProductWithUnits` ใน loop, `calculateUsedHotdealPoints`/`getHotdealPointsInfo` query ต่อ `pro_code`, และ `getHotdealByProCode` ถูกเรียกซ้ำทีละตัว (add-cart ที่ฝัง getProductCart พุ่งเป็น 1073 query)

### 🛠️ แก้ปัญหานั้นอย่างไร
**1. Timeout ให้ external API (แก้ event loop congestion)**
- เพิ่ม `timeout: 10000` (10s) ให้ `axios.get` ทั้ง 2 จุด → เว็บเก่าช้า/ล่มจะ throw ใน 10s เข้า `catch` คืน `[]` เร็ว ไม่ทำให้ทั้ง request ค้าง (คงพฤติกรรม error เดิม)

**2. Batch query ใน `getProductCart` (แก้ N+1)**
- `transformProductWithUnits` รับ optional `units` param + เพิ่ม `getUnitsMapByProCodes` → ดึง units ของทุก pro_code ครั้งเดียวด้วย `In([...])`
- prefetch freebies + main-in-cart แบบ batch แล้ว group เป็น `Map`
- `calculateUsedHotdealPoints` / `getHotdealPointsInfo` / `calculateSmallestUnitWithTransformed` รับ context ที่ prefetch ไว้ (fallback query DB เมื่อไม่มี context → caller อื่น/test ไม่กระทบ)
- `getHotdealPointsInfo` reuse `usedPointsMap` ไม่คำนวณ used points ซ้ำ
- `getHotdealByProCode` batch units ครั้งเดียวแทน transform ทีละตัวใน loop

> Logic การคำนวณแต้ม/ของแถม/transform **ไม่เปลี่ยน** — เปลี่ยนแค่ "แหล่งข้อมูล" (อ่านจาก map แทน query ต่อรายการ)

### 🧪 วิธี Test
**Golden before/after diff บน DB จริง (docker)** — รัน `getProductCart` code เดิม (HEAD) vs ใหม่ บน DB ก้อนเดียวกัน (snapshot/restore `shopping_cart` ให้เริ่มจาก state เดียวกัน) แล้วเทียบ JSON ทุก byte:
- **12 members** ครอบคลุมทุกเคสยาก: hotdeal freebie (77000, 32011, 08031, 10127, 84332, 05008), สมาชิก L16 (32011, 00442, 85007, 00357), cart ใหญ่ + recommended (03089=193, 10406=133, 01085=91)
- ✅ ผล: **byte-identical ทั้ง 1,009,324 bytes** — ทุก field (`pointHotdeal`, `hotdealPointsInfo`, `totalSmallestUnit`, `recommend`, `lots`, `shopping_cart`, `hotdeal`, units/ratios) ตรงกันเป๊ะ, 0 error
- ⚡ ความเร็ว: 77000 `869ms→188ms` (4.6x), 03089 `630ms→67ms` (9.4x), 10406 `318ms→29ms` (11x), อื่นๆ ~5–7x
- `tsc --noEmit` ผ่าน

### 🔑 Environment Variables ใหม่
- ไม่มี
