### PR TITLE
🧠 learn-from-reviews: proposed knowledge updates

### DIFF
--- a/.ai/conventions.md
+++ b/.ai/conventions.md
@@ -15,3 +15,15 @@ if (!Number.isInteger(page) || page < 1) throw new BadRequestException('current_
 ```
 **Source:** PR#148 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/148
 **Added:** 2026-05-19  **Confidence:** medium (single occurrence)
+
+### C-002  Always include migration files in the same PR as entity/schema changes
+**Why:** PR#176 — new tables (`happy_hour_slot_reward`) and columns (`start_date`, `end_date`) were added to entities but no migration file was included in the diff. With `synchronize: false` in production this leaves the DB schema inconsistent until a migration is written and run separately. Reviewers flagged it as a must-fix before merge.
+**Example:**
+```
+# When you add/change an entity column, generate and commit the migration in the same branch:
+npm run migration:generate -- src/migrations/AddHappyHourSlotReward
+git add src/migrations/
+# then include it in the same PR as the entity change
+```
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-07-06  **Confidence:** medium (single occurrence)

--- a/.ai/gotchas.md
+++ b/.ai/gotchas.md
@@ -10,3 +10,34 @@ Format per entry: `### G-NNN <statement>` then **Why:** / **Example:** / **Sourc
 **Why:** PR#143 P2 — getHotdealFromproCode (src/hotdeal/hotdeal.service.ts:660-667) converts the freebie's pro2_amount/pro2_unit using the MAIN product's unit ratio. If product2 (the freebie) uses different units, the freebie data returned by the API is wrong. Either don't convert here, or use product2's own unit ratio.
 **Source:** PR#143 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/143
 **Added:** 2026-05-19
+
+### G-002  Never modify an existing Entity column definition without a corresponding migration — TypeORM sync will DROP the column and recreate it
+**Why:** PR#205 — a PR modified `creditor.entity.ts` column definitions directly. Reviewer flagged: "ห้ามแก้ Entity เนื่องจาก Column จะโดน Drop ทิ้ง และสร้างใหม่". Even with `synchronize: false` in production, any dev/staging environment with synchronize enabled will silently drop the column and recreate it, destroying data. Always write a migration instead of touching column decorators on existing columns.
+**Example:**
+```ts
+// ✗ no — changing @Column() options on an existing column without a migration
+@Column({ type: 'varchar', length: 500 })  // was length: 255
+creditor_address: string;
+
+// ✓ keep the entity matching the DB and write a migration:
+// npm run migration:generate -- src/migrations/AlterCreditorAddressLength
+```
+**Source:** PR#205 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/205
+**Added:** 2026-07-06  **Confidence:** high
+
+### G-003  Fixing an N+1 query in one method does not fix it everywhere — audit all methods in the same service for the same pattern
+**Why:** PR#176 — the PR description claimed to fix N+1 queries, and `enrichSlotWithProducts()` was indeed fixed (batch IN query). But `simulate()` in the same file still had `Promise.all(slot.rewards.map(async (r) => this.productRepo.findOne(...)))` — one query per reward. Reviewers catch the missed instance during review; it should be found before PR is opened.
+**Example:**
+```ts
+// ✗ still N+1 — one findOne per reward inside Promise.all
+const products = await Promise.all(
+  rewards.map(r => this.productRepo.findOne({ where: { pro_code: r.pro_code } }))
+);
+
+// ✓ batch fetch all at once
+const codes = rewards.map(r => r.pro_code);
+const products = await this.productRepo.find({ where: { pro_code: In(codes) } });
+```
+**Location:** src/happy-hour/happy-hour.service.ts — `simulate()` method
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-07-06  **Confidence:** medium (single occurrence)

--- a/.ai/ledger.json
+++ b/.ai/ledger.json
@@ -1,6 +1,6 @@
 {
   "repo": "wangpharma-org/Backend-Ecommerce",
-  "last_run": "2026-05-19",
+  "last_run": "2026-07-06",
   "approvers": [
     "62theories"
   ],
@@ -12,14 +12,16 @@
       "status": "proposed",
       "source_prs": [
         121,
-        137
+        137,
+        178
       ],
       "reviewers": [
-        "MossOcelot"
+        "MossOcelot",
+        "Sasit-Nine"
       ],
       "confidence": "high",
       "first_seen": "2026-05-19",
-      "last_seen": "2026-05-19",
+      "last_seen": "2026-05-25",
       "approved_by": null,
       "approved_at": null,
       "promoted_from": "preference"
@@ -89,6 +91,114 @@
       "confidence": "low",
       "first_seen": "2026-05-19",
       "last_seen": "2026-05-19",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "G-002",
+      "kind": "gotcha",
+      "file": ".ai/gotchas.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        205
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "high",
+      "first_seen": "2026-07-06",
+      "last_seen": "2026-07-06",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "R-003",
+      "kind": "rule",
+      "file": ".ai/rules.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "high",
+      "first_seen": "2026-07-06",
+      "last_seen": "2026-07-06",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "C-002",
+      "kind": "convention",
+      "file": ".ai/conventions.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "medium",
+      "first_seen": "2026-07-06",
+      "last_seen": "2026-07-06",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "G-003",
+      "kind": "gotcha",
+      "file": ".ai/gotchas.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "medium",
+      "first_seen": "2026-07-06",
+      "last_seen": "2026-07-06",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "Q-002",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-07-06",
+      "last_seen": "2026-07-06",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "Q-003",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-07-06",
+      "last_seen": "2026-07-06",
       "approved_by": null,
       "approved_at": null
     }

--- a/.ai/quarantine.md
+++ b/.ai/quarantine.md
@@ -11,3 +11,23 @@ Format per entry: `### Q-NNN <statement>` then **Why:** / **Example:** / **Sourc
 **Promote to convention when:** seen again in ≥1 more PR by another reviewer.
 **Source:** PR#123 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/123
 **Added:** 2026-05-19  **Status:** quarantined (not team-agreed)
+
+### Q-002  Use object-style `select` in TypeORM queries (`{ field: true }`) rather than array-style (`['field']`)
+**Why:** PR#176 — `findSmallestUnit` used `select: ['pro_unit1', 'pro_unit2', ...]`. Reviewer noted the object style is preferred in TypeORM v0.3+. Single reviewer, single PR — not yet team-agreed.
+**Example:**
+```ts
+// array style (works but older pattern)
+select: ['pro_unit1', 'pro_unit2', 'pro_unit3']
+
+// object style (preferred in TypeORM v0.3+)
+select: { pro_unit1: true, pro_unit2: true, pro_unit3: true }
+```
+**Promote to convention when:** seen flagged in ≥1 more PR by another reviewer.
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-07-06  **Status:** quarantined (not team-agreed)
+
+### Q-003  Service-specific endpoints belong in their domain controller, not in AppController
+**Why:** PR#176 — `/ecom/check-happy-hour-reward` was added to `AppController` alongside `HappyHourService`. Reviewer suggested it belongs in `HappyHourController` or `ShoppingOrderController` to avoid coupling AppController to domain services. Single reviewer, single PR.
+**Promote to convention when:** seen flagged again or adopted as a project-wide structural decision.
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-07-06  **Status:** quarantined (not team-agreed)

--- a/.ai/rules.md
+++ b/.ai/rules.md
@@ -37,3 +37,19 @@ this.logger.error('failed to fetch products', err)
 ```
 **Source:** ECWC-282 session 2026-05-30
 **Added:** 2026-05-30
+
+### R-003  Every endpoint that mutates or reads user/order data must be protected with `@UseGuards(JwtAuthGuard)`; never leave mutation endpoints unauthenticated
+**Why:** PR#176 — the new `/ecom/check-happy-hour-reward` endpoint was merged without `@UseGuards(JwtAuthGuard)`, allowing any unauthenticated caller to POST and alter freebie quantities on orders. Reviewer flagged it as critical before merge.
+**Example:**
+```ts
+// ✗ no — any caller can hit this
+@Post('/ecom/check-happy-hour-reward')
+async checkHappyHourReward(@Body() body: { sh_running: string }) { ... }
+
+// ✓ guard every non-public endpoint
+@UseGuards(JwtAuthGuard)
+@Post('/ecom/check-happy-hour-reward')
+async checkHappyHourReward(@Body() body: { sh_running: string }) { ... }
+```
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-07-06  **Confidence:** high (security-critical)


### PR DESCRIPTION
## Auto-distilled knowledge proposals — propose-only, do NOT merge without review

This PR was generated automatically by the `learn-from-reviews` scheduled routine. It distilled review feedback from **43 merged PRs** since `2026-05-19` into the team knowledge base under `.ai/`.

**All items are `status: "proposed"` with `approved_by: null`.** Nothing here is authoritative until @62theories (CODEOWNER and team lead) reviews, approves, and the PR is merged. On merge, a human should flip approved items to `status: "agreed"` and set `approved_by`.

---

## New proposals

| ID | Kind | Statement | Source | Confidence |
|----|------|-----------|--------|------------|
| R-003 | rule | Every mutation endpoint must have `@UseGuards(JwtAuthGuard)` | PR#176 @Sasit-Nine | high (security-critical) |
| C-002 | convention | Migration files must ship in the same PR as entity/schema changes | PR#176 @Sasit-Nine | medium |
| G-002 | gotcha | Modifying Entity column definitions without a migration causes TypeORM sync to DROP + recreate columns | PR#205 @Sasit-Nine | high |
| G-003 | gotcha | Fixing N+1 in one method doesn't fix it everywhere — audit the whole service | PR#176 @Sasit-Nine | medium |
| Q-002 | preference → quarantine | Prefer object-style `select` in TypeORM queries (`{ field: true }`) | PR#176 @Sasit-Nine | low |
| Q-003 | preference → quarantine | Domain endpoints belong in domain controller, not `AppController` | PR#176 @Sasit-Nine | low |

## Ledger-only updates

- **R-001** (`no console.log`): added PR#178 to `source_prs`; updated `last_seen` to 2026-05-25. Sasit-Nine flagged `console.log` three more times in `shopping-cart.service.ts` — this rule continues to be violated.

---

## What to review

1. **R-003** — security rule. The `/ecom/check-happy-hour-reward` endpoint shipped without `@UseGuards(JwtAuthGuard)` in PR#176, allowing unauthenticated order mutation. If the team agrees this is a hard must-have, this becomes enforceable via code review checklist or lint.
2. **C-002** — reinforces existing CLAUDE.md migration guidance with the specific practice: migration must be in the same PR, not a follow-up.
3. **G-002** — TypeORM's synchronize behavior when entity columns are edited without migrations. Relevant to any dev environment that runs `synchronize: true`.
4. **G-003** — the N+1 fix in PR#176 patched `enrichSlotWithProducts()` but missed `simulate()` in the same file.
5. **Q-002, Q-003** — quarantined preferences from a single reviewer/PR. Promote to conventions if the team agrees or they recur.

## Instructions for approver (@62theories)

- Review the diff under `.ai/`
- Approve this PR to signal team agreement
- After merge, update any approved items in `ledger.json` to `"status": "agreed"`, `"approved_by": "<your login>"`, `"approved_at": "<date>"`
- Discard any items you disagree with by editing the files before merging

---

🤖 Auto-generated by the `learn-from-reviews` scheduled routine — propose-only. The skill never merges or approves its own output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVi6urpEa61roedFpmm7ZL)_