### PR TITLE
ECWC-381 / แก้ให้การ update session กลับมาใช้งานได้ปกติ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,13 @@ pids
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
+# Load test — ข้อมูลจาก prod dump + token จริง ห้าม commit
+loadtest/seed-tokens.json
+loadtest/seed-jwt.txt
+loadtest/*.sql
+loadtest/result-*.json
+loadtest/*.docx
+
 # Claude Code — personal Stop-hook scratch (learn-from-reviews complement)
 .claude/*.local.md
 .claude/.learning-seen.json

--- a/loadtest/lock-stats.js
+++ b/loadtest/lock-stats.js
@@ -1,0 +1,25 @@
+// ดู InnoDB lock stats — รันก่อน/หลังยิง k6 แล้วเทียบ delta
+// รันจาก root: node loadtest/lock-stats.js
+const mysql = require('mysql2/promise');
+require('dotenv').config();
+
+async function main() {
+  const db = await mysql.createConnection({
+    host: process.env.DB_HOST || '127.0.0.1',
+    port: Number(process.env.DB_PORT) || 3311,
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME || 'ecommerce-db',
+  });
+
+  const [rows] = await db.query("SHOW GLOBAL STATUS LIKE 'Innodb_row_lock%'");
+  console.log(new Date().toISOString());
+  console.table(rows.map((r) => ({ metric: r.Variable_name, value: r.Value })));
+
+  await db.end();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/loadtest/reset-stats.js
+++ b/loadtest/reset-stats.js
@@ -1,0 +1,53 @@
+// เคลียร์ตัวนับ Innodb_row_lock_* — ตัวนับเป็นค่าสะสมระดับ engine ล้างด้วย SQL ไม่ได้
+// ต้อง restart MySQL เท่านั้น: script นี้ restart container → รอจนพร้อม → ยืนยันค่าเป็น 0
+// รันจาก root: node loadtest/reset-stats.js
+const { execSync } = require('child_process');
+const mysql = require('mysql2/promise');
+require('dotenv').config();
+
+const CONTAINER = process.env.LOADTEST_DB_CONTAINER || 'ecommerce-db';
+
+function connect() {
+  return mysql.createConnection({
+    host: process.env.DB_HOST || '127.0.0.1',
+    port: Number(process.env.DB_PORT) || 3311,
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME || 'ecommerce-db',
+    connectTimeout: 3000,
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  console.log(`restarting container: ${CONTAINER} ...`);
+  execSync(`docker restart ${CONTAINER}`, { stdio: 'inherit' });
+
+  // รอจน MySQL รับ connection ได้ (ปกติ 5-15 วิ)
+  process.stdout.write('waiting for MySQL ');
+  let db;
+  for (let i = 0; i < 60; i++) {
+    try {
+      db = await connect();
+      await db.query('SELECT 1');
+      break;
+    } catch {
+      process.stdout.write('.');
+      await sleep(1000);
+    }
+  }
+  console.log('');
+  if (!db) throw new Error('MySQL ไม่ตอบภายใน 60 วินาที');
+
+  const [rows] = await db.query("SHOW GLOBAL STATUS LIKE 'Innodb_row_lock%'");
+  console.table(rows.map((r) => ({ metric: r.Variable_name, value: r.Value })));
+  await db.end();
+
+  console.log('พร้อมเทสแล้ว — อย่าลืม restart backend ถ้า connection pool ตาย');
+}
+
+main().catch((e) => {
+  console.error(e.message);
+  process.exit(1);
+});

--- a/loadtest/sample-tokens.js
+++ b/loadtest/sample-tokens.js
@@ -1,0 +1,58 @@
+// สุ่ม session_token จริงจากตาราง user-sessions + gen JWT สำหรับผ่าน JwtAuthGuard
+// รันจาก root: node loadtest/sample-tokens.js
+const mysql = require('mysql2/promise');
+const jwt = require('jsonwebtoken');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
+
+const SAMPLE = 2000;
+
+async function main() {
+  const db = await mysql.createConnection({
+    host: process.env.DB_HOST || '127.0.0.1',
+    port: Number(process.env.DB_PORT) || 3311,
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME || 'ecommerce-db',
+  });
+
+  const [[{ total }]] = await db.query(
+    'SELECT COUNT(*) AS total FROM `user-sessions`',
+  );
+  const [[{ active }]] = await db.query(
+    'SELECT COUNT(*) AS active FROM `user-sessions` WHERE is_active = 1',
+  );
+  console.log(`user-sessions: ${total} rows (active: ${active})`);
+  if (active < SAMPLE) {
+    throw new Error(`active session ไม่พอ (ต้องการ ${SAMPLE}) — เช็คว่า import dump แล้ว`);
+  }
+
+  const [rows] = await db.query(
+    'SELECT session_token FROM `user-sessions` WHERE is_active = 1 ORDER BY RAND() LIMIT ?',
+    [SAMPLE],
+  );
+
+  // expiresIn ยาวกว่าของจริง (15m) กัน token หมดอายุกลางเทส
+  // backend local ใช้ 'fallback-secret' เพราะ constants.ts อ่าน env ก่อน ConfigModule โหลด .env
+  const secret = process.env.LOADTEST_JWT_SECRET || 'fallback-secret';
+  const token = jwt.sign(
+    { username: 'loadtest', name: 'loadtest', mem_code: 'M999999' },
+    secret,
+    { expiresIn: '12h' },
+  );
+
+  fs.writeFileSync(
+    path.join(__dirname, 'seed-tokens.json'),
+    JSON.stringify(rows),
+  );
+  fs.writeFileSync(path.join(__dirname, 'seed-jwt.txt'), token);
+  console.log(`เขียน loadtest/seed-tokens.json (${rows.length} tokens) + seed-jwt.txt แล้ว`);
+
+  await db.end();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/loadtest/update-activity.js
+++ b/loadtest/update-activity.js
@@ -15,10 +15,10 @@ export const options = {
   scenarios: {
     update_activity: {
       executor: 'constant-arrival-rate',
-      rate: Number(__ENV.RATE) || 4, 
-      timeUnit: '3s',
+      rate: Number(__ENV.RATE) || 30, 
+      timeUnit: '1s',
       duration: __ENV.DURATION || '3m',
-      preAllocatedVUs: 25,
+      preAllocatedVUs: 50,
       maxVUs: 1000,
     },
   },

--- a/loadtest/update-activity.js
+++ b/loadtest/update-activity.js
@@ -1,0 +1,42 @@
+// Load test: PUT /ecom/session/update-activity/:session_token
+// รัน:  k6 run loadtest/update-activity.js --summary-export=loadtest/result-before.json
+// ปรับ rate/duration:  k6 run -e RATE=200 -e DURATION=5m loadtest/update-activity.js
+import http from 'k6/http';
+import { check } from 'k6';
+import { SharedArray } from 'k6/data';
+
+const tokens = new SharedArray('tokens', function () {
+  return JSON.parse(open('./seed-tokens.json'));
+});
+const JWT = open('./seed-jwt.txt').trim();
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+
+export const options = {
+  scenarios: {
+    update_activity: {
+      executor: 'constant-arrival-rate',
+      rate: Number(__ENV.RATE) || 4, 
+      timeUnit: '3s',
+      duration: __ENV.DURATION || '3m',
+      preAllocatedVUs: 25,
+      maxVUs: 1000,
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+export default function () {
+  const t = tokens[Math.floor(Math.random() * tokens.length)];
+  const res = http.put(
+    `${BASE_URL}/api/ecom/session/update-activity/${t.session_token}`,
+    null,
+    {
+      headers: { Authorization: `Bearer ${JWT}` },
+      timeout: '30s',
+    },
+  );
+  check(res, { 'status 200': (r) => r.status === 200 });
+}

--- a/src/migrations/1783752217191-add-token-hash-index-to-user-sessions.ts
+++ b/src/migrations/1783752217191-add-token-hash-index-to-user-sessions.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTokenHashIndexToUserSessions1783752217191 implements MigrationInterface {
+  name = 'AddTokenHashIndexToUserSessions1783752217191';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`user-sessions\` ADD \`token_hash\` varchar(64) NULL`,
+    );
+    // backfill ด้วย SHA2 ฝั่ง MySQL — ได้ hex lowercase ตรงกับ crypto.createHash('sha256').digest('hex')
+    await queryRunner.query(
+      `UPDATE \`user-sessions\` SET \`token_hash\` = SHA2(\`session_token\`, 256) WHERE \`token_hash\` IS NULL`,
+    );
+    // ไม่ใช้ unique index เพราะข้อมูลเดิมมี session_token ซ้ำ (ดู ECWC-381)
+    await queryRunner.query(
+      `CREATE INDEX \`idx_user_sessions_token_hash\` ON \`user-sessions\` (\`token_hash\`)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX \`idx_user_sessions_mem_active\` ON \`user-sessions\` (\`mem_code\`, \`is_active\`)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX \`idx_user_sessions_mem_active\` ON \`user-sessions\``,
+    );
+    await queryRunner.query(
+      `DROP INDEX \`idx_user_sessions_token_hash\` ON \`user-sessions\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`user-sessions\` DROP COLUMN \`token_hash\``,
+    );
+  }
+}

--- a/src/sessions/sessions.entity.ts
+++ b/src/sessions/sessions.entity.ts
@@ -6,10 +6,12 @@ import {
   JoinColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  Index,
 } from 'typeorm';
 import { UserEntity } from '../users/users.entity';
 
 @Entity({ name: 'user-sessions' })
+@Index('idx_user_sessions_mem_active', ['mem_code', 'is_active'])
 export class UserSessionsEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -19,6 +21,11 @@ export class UserSessionsEntity {
 
   @Column({ type: 'varchar', length: 1024 })
   session_token: string;
+
+  // SHA-256 ของ session_token — ใช้เป็นเงื่อนไขค้นหาแทน session_token ที่ยาวเกินจะทำ index ได้
+  @Index('idx_user_sessions_token_hash')
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  token_hash: string | null;
 
   @Column({ type: 'varchar', length: 45, nullable: true })
   ip_address: string;

--- a/src/sessions/sessions.service.ts
+++ b/src/sessions/sessions.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { UserSessionsEntity } from './sessions.entity';
 import { Cron } from '@nestjs/schedule';
 import * as dayjs from 'dayjs';
+import { createHash } from 'crypto';
 import { ExpireSessionResponse } from '../auth/auth.service';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 
@@ -17,6 +18,11 @@ export class SessionsService {
     private readonly featureFlagsService: FeatureFlagsService,
   ) {}
 
+  // ค้นหาด้วย hash แทน session_token ตรงๆ — คอลัมน์เดิมยาว 1024 ทำ index เต็มไม่ได้ (ECWC-381)
+  private hashToken(sessionToken: string): string {
+    return createHash('sha256').update(sessionToken).digest('hex');
+  }
+
   async createSession(
     memCode: string,
     sessionToken: string,
@@ -27,6 +33,7 @@ export class SessionsService {
     const session = this.sessionsRepository.create({
       mem_code: memCode,
       session_token: sessionToken,
+      token_hash: this.hashToken(sessionToken),
       ip_address: ipAddress,
       user_agent: userAgent,
       device_type: deviceType,
@@ -43,7 +50,7 @@ export class SessionsService {
   ): Promise<UserSessionsEntity | null> {
     return await this.sessionsRepository.findOne({
       where: {
-        session_token: sessionToken,
+        token_hash: this.hashToken(sessionToken),
         is_active: true,
       },
       relations: ['user'],
@@ -71,14 +78,14 @@ export class SessionsService {
     }
 
     await this.sessionsRepository.update(
-      { session_token: sessionToken, is_active: true },
+      { token_hash: this.hashToken(sessionToken), is_active: true },
       { last_activity: new Date() },
     );
   }
 
   async logoutSession(sessionToken: string): Promise<void> {
     await this.sessionsRepository.update(
-      { session_token: sessionToken },
+      { token_hash: this.hashToken(sessionToken) },
       {
         is_active: false,
         logout_at: new Date(),


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- https://nitipongjin-13063.atlassian.net/browse/ECWC-381

### 📌 ประเภทของ PR
- [ ] ✨ Feature ใหม่
- [ ] 🐛 แก้ Bug
- [x] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร

แก้ปัญหาการอัปเดต session (`last_activity`) ทำให้ทั้งระบบหน่วง จนต้องปิด feature flag `session_update_last_activity` ไว้ (hotfix ECWC-368)

**Root cause:** ตาราง `user-sessions` ไม่มี index บน `session_token` (varchar 1024 — ยาวเกิน limit ของ InnoDB index) ทุก UPDATE จึง full scan ~300k แถว และ InnoDB lock ทุกแถวที่ scan ผ่าน → UPDATE ทำงานได้ทีละตัว คิวสะสมจน connection pool เต็ม ระบบหน่วงทั้งระบบ — พิสูจน์ด้วย load test: capacity เดิมอยู่แค่ ~0.3-0.5 req/s

### 🛠️ แก้ปัญหานั้นอย่างไร

- เพิ่มคอลัมน์ `token_hash` varchar(64) เก็บ SHA-256 ของ `session_token` + index `idx_user_sessions_token_hash` — ความยาวคงที่ 64 ตัวอักษร ทำ index ได้เต็ม
- Migration backfill ข้อมูลเดิมทั้งหมดด้วย `SHA2(session_token, 256)` ฝั่ง MySQL (hex ตรงกับ `crypto.createHash('sha256').digest('hex')` ฝั่ง Node)
- เพิ่ม composite index `idx_user_sessions_mem_active` (mem_code, is_active) รองรับ logout-all / logout-recent / count
- `SessionsService` เปลี่ยน WHERE ทุกจุด (create/find/update-activity/logout) จาก `session_token` → `token_hash` ผ่าน private method `hashToken()` — ตัว `session_token` เดิมยังเก็บครบ ไม่กระทบ consumer อื่น
- ใช้ index ธรรมดา (ไม่ unique) เพราะข้อมูลเดิมมี token ซ้ำ 5,663 แถว — dedupe เป็นงานต่อเนื่องแยกต่างหาก
- แถม: k6 load test scripts ใน `loadtest/` สำหรับทดสอบซ้ำได้

### 🧪 วิธี Test

Load test ด้วย k6 บนข้อมูลจริงจาก production (~300k แถว) เงื่อนไขเดียวกันก่อน-หลัง:

| ตัวชี้วัด (30 req/s) | Before | After |
|---|---|---|
| อัตราสำเร็จ | 20% (ล่มใน 33 วิ) | **100%** (5,401 req ครบ 3 นาที) |
| Latency p95 | 30,000 ms (timeout) | **66.62 ms** |
| InnoDB lock waits | 1,016 ครั้ง สูงสุด 50.8 วิ | **1 ครั้ง 26 ms** |

- `EXPLAIN` ยืนยัน UPDATE ใช้ index อ่าน 1 แถว (เดิม ~300k)
- Verify hash ฝั่ง MySQL ตรงกับฝั่ง Node ทุกแถว, backfill ครบไม่มี NULL
- `npm run build` + lint ผ่าน

**ขั้นตอน deploy:** รัน `npm run migration:run` ก่อน start code ใหม่ (backfill ใช้เวลาช่วงสั้นๆ ควรทำช่วง traffic ต่ำ) → หลัง deploy รัน backfill ซ้ำปิดช่องว่าง: `UPDATE \`user-sessions\` SET token_hash = SHA2(session_token,256) WHERE token_hash IS NULL` → เปิด flag `session_update_last_activity` แล้วเฝ้าดู `Innodb_row_lock_time`

### 🔑 Environment Variables ใหม่
- ไม่มี
