### PR TITLE
🧠 learn-from-reviews: proposed knowledge updates

### DIFF
--- a/.ai/conventions.md
+++ b/.ai/conventions.md
@@ -15,3 +15,14 @@ if (!Number.isInteger(page) || page < 1) throw new BadRequestException('current_
 ```
 **Source:** PR#148 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/148
 **Added:** 2026-05-19  **Confidence:** medium (single occurrence)
+
+### C-002  A PR that adds, removes, or renames schema elements must include the TypeORM migration file in the same PR
+**Why:** PR#176 — added `happy_hour_slot_reward` table and new columns but shipped no migration file. With `SYNCHRONIZE=false` in production the schema change never lands, making the feature broken on deploy.
+**Example:**
+```bash
+# After adding or changing an @Entity column, generate and commit the migration:
+npm run migration:generate -- src/migrations/AddHappyHourSlotReward
+# Then include src/migrations/<timestamp>-AddHappyHourSlotReward.ts in the same PR
+```
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-07-20  **Confidence:** medium (single occurrence)

--- a/.ai/gotchas.md
+++ b/.ai/gotchas.md
@@ -10,3 +10,19 @@ Format per entry: `### G-NNN <statement>` then **Why:** / **Example:** / **Sourc
 **Why:** PR#143 P2 — getHotdealFromproCode (src/hotdeal/hotdeal.service.ts:660-667) converts the freebie's pro2_amount/pro2_unit using the MAIN product's unit ratio. If product2 (the freebie) uses different units, the freebie data returned by the API is wrong. Either don't convert here, or use product2's own unit ratio.
 **Source:** PR#143 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/143
 **Added:** 2026-05-19
+
+### G-002  Changing a TypeORM `@Column` definition in an Entity causes DROP + recreate (or silent schema divergence)
+**Why:** PR#205 — reviewer blocked an entity edit with "ห้ามแก้ Entity เนื่องจาก Column จะโดน Drop ทิ้ง และสร้างใหม่". With `synchronize: true`, TypeORM drops the old column and recreates it, destroying data. With `synchronize: false` (our production setting) the change is silently ignored and the live schema diverges from the entity. Either way the result is broken — use a migration to alter column definitions.
+**Example:**
+```ts
+// ✗ don't change column length directly in the entity and expect it to apply
+@Column({ name: 'creditor_address', type: 'varchar', length: 100 })
+creditor_address: string;
+// Changing length to 500 in the entity file alone will NOT apply in prod
+
+// ✓ write a migration instead
+await queryRunner.query(`ALTER TABLE creditor MODIFY COLUMN creditor_address VARCHAR(500)`);
+```
+**Location:** src/products/creditor.entity.ts
+**Source:** PR#205 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/205
+**Added:** 2026-07-20

--- a/.ai/ledger.json
+++ b/.ai/ledger.json
@@ -1,6 +1,6 @@
 {
   "repo": "wangpharma-org/Backend-Ecommerce",
-  "last_run": "2026-05-19",
+  "last_run": "2026-07-20",
   "approvers": [
     "62theories"
   ],
@@ -10,25 +10,30 @@
       "kind": "rule",
       "file": ".ai/rules.md",
       "status": "proposed",
+      "origin": "human",
       "source_prs": [
         121,
-        137
+        137,
+        178
       ],
       "reviewers": [
-        "MossOcelot"
+        "MossOcelot",
+        "Sasit-Nine"
       ],
       "confidence": "high",
       "first_seen": "2026-05-19",
-      "last_seen": "2026-05-19",
+      "last_seen": "2026-07-20",
       "approved_by": null,
       "approved_at": null,
-      "promoted_from": "preference"
+      "promoted_from": "preference",
+      "notes": "PR#178 Sasit-Nine added 3 more 'เอา console.log ออก' inline comments, further corroborating this rule"
     },
     {
       "id": "D-001",
       "kind": "domain",
       "file": ".ai/domain.md",
       "status": "proposed",
+      "origin": "human",
       "source_prs": [
         143
       ],
@@ -46,6 +51,7 @@
       "kind": "convention",
       "file": ".ai/conventions.md",
       "status": "proposed",
+      "origin": "human",
       "source_prs": [
         148
       ],
@@ -63,6 +69,7 @@
       "kind": "gotcha",
       "file": ".ai/gotchas.md",
       "status": "proposed",
+      "origin": "human",
       "source_prs": [
         143
       ],
@@ -80,6 +87,7 @@
       "kind": "preference",
       "file": ".ai/quarantine.md",
       "status": "quarantined",
+      "origin": "human",
       "source_prs": [
         123
       ],
@@ -91,6 +99,141 @@
       "last_seen": "2026-05-19",
       "approved_by": null,
       "approved_at": null
+    },
+    {
+      "id": "R-003",
+      "kind": "rule",
+      "file": ".ai/rules.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        176,
+        154
+      ],
+      "reviewers": [
+        "Sasit-Nine",
+        "MossOcelot"
+      ],
+      "confidence": "high",
+      "first_seen": "2026-07-20",
+      "last_seen": "2026-07-20",
+      "approved_by": null,
+      "approved_at": null,
+      "notes": "PR#176 Sasit-Nine: missing @UseGuards on endpoint entirely. PR#154 MossOcelot: inline role check in controller → move to Guard/Decorator"
+    },
+    {
+      "id": "C-002",
+      "kind": "convention",
+      "file": ".ai/conventions.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "medium",
+      "first_seen": "2026-07-20",
+      "last_seen": "2026-07-20",
+      "approved_by": null,
+      "approved_at": null,
+      "notes": "PR#176: migration file not included in PR alongside schema-changing entity/table additions"
+    },
+    {
+      "id": "G-002",
+      "kind": "gotcha",
+      "file": ".ai/gotchas.md",
+      "status": "proposed",
+      "origin": "human",
+      "source_prs": [
+        205
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "high",
+      "first_seen": "2026-07-20",
+      "last_seen": "2026-07-20",
+      "approved_by": null,
+      "approved_at": null,
+      "notes": "PR#205: 'ห้ามแก้ Entity เนื่องจาก Column จะโดน Drop ทิ้ง และสร้างใหม่' — factual TypeORM DROP+recreate behavior"
+    },
+    {
+      "id": "Q-002",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-07-20",
+      "last_seen": "2026-07-20",
+      "approved_by": null,
+      "approved_at": null,
+      "notes": "Object-style TypeORM select. Single reviewer — needs corroboration to promote"
+    },
+    {
+      "id": "Q-003",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "human",
+      "source_prs": [
+        176
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-07-20",
+      "last_seen": "2026-07-20",
+      "approved_by": null,
+      "approved_at": null,
+      "notes": "Domain endpoints in domain controller, not AppController. Single reviewer — needs corroboration"
+    },
+    {
+      "id": "Q-004",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "human",
+      "source_prs": [
+        226
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-07-20",
+      "last_seen": "2026-07-20",
+      "approved_by": null,
+      "approved_at": null,
+      "notes": "Config constants in env vars, not hardcoded. Single reviewer — needs corroboration"
+    },
+    {
+      "id": "Q-005",
+      "kind": "preference",
+      "file": ".ai/quarantine.md",
+      "status": "quarantined",
+      "origin": "human",
+      "source_prs": [
+        205
+      ],
+      "reviewers": [
+        "Sasit-Nine"
+      ],
+      "confidence": "low",
+      "first_seen": "2026-07-20",
+      "last_seen": "2026-07-20",
+      "approved_by": null,
+      "approved_at": null,
+      "notes": "Check for duplicate Kafka listeners before adding new ones. Single reviewer — needs corroboration"
     }
   ]
 }

--- a/.ai/quarantine.md
+++ b/.ai/quarantine.md
@@ -11,3 +11,34 @@ Format per entry: `### Q-NNN <statement>` then **Why:** / **Example:** / **Sourc
 **Promote to convention when:** seen again in ≥1 more PR by another reviewer.
 **Source:** PR#123 @MossOcelot — github.com/wangpharma-org/Backend-Ecommerce/pull/123
 **Added:** 2026-05-19  **Status:** quarantined (not team-agreed)
+
+### Q-002  Prefer object-style `select` in TypeORM queries
+**Why:** PR#176 — `findSmallestUnit` used `select: ['pro_unit1', 'pro_unit2', ...]` (array style). Reviewer flagged it should be `select: { pro_unit1: true, pro_unit2: true, ... }` (object style), which is the TypeORM v0.3+ recommended form and gives better type inference.
+**Example:**
+```ts
+// ✗ array style
+select: ['pro_unit1', 'pro_unit2', 'pro_unit3']
+// ✓ object style
+select: { pro_unit1: true, pro_unit2: true, pro_unit3: true }
+```
+**Promote to convention when:** flagged in ≥1 more PR by another reviewer.
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-07-20  **Status:** quarantined (single reviewer)
+
+### Q-003  Domain-specific endpoints belong in their feature module's controller, not AppController
+**Why:** PR#176 — `check-happy-hour-reward` was added to `AppController`, giving it an unrelated dependency on `HappyHourService`. Reviewer suggested moving it to `HappyHourController` or `ShoppingOrderController`.
+**Promote to convention when:** seen in ≥1 more PR by another reviewer.
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176
+**Added:** 2026-07-20  **Status:** quarantined (single reviewer)
+
+### Q-004  Store configuration constants (checksums, salts, hashes) in environment variables, not hardcoded in source
+**Why:** PR#226 — `COM_FILE_HASH` was hardcoded in `app.controller.ts`; reviewer commented "เก็บค่า COM_FILE_HASH ใน env". Hardcoded constants make rotation difficult and widen the blast radius of source leaks.
+**Promote to convention when:** seen in ≥1 more PR by another reviewer.
+**Source:** PR#226 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/226
+**Added:** 2026-07-20  **Status:** quarantined (single reviewer)
+
+### Q-005  Before adding a Kafka event listener or handler function, verify no listener for that topic already exists
+**Why:** PR#205 — PR added a new listener and handler for `product_update_from_easyacc`; reviewer pointed out both already existed. Duplicate listeners can cause double-processing or silent conflicts.
+**Promote to convention when:** seen in ≥1 more PR by another reviewer.
+**Source:** PR#205 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/205
+**Added:** 2026-07-20  **Status:** quarantined (single reviewer)

--- a/.ai/rules.md
+++ b/.ai/rules.md
@@ -37,3 +37,25 @@ this.logger.error('failed to fetch products', err)
 ```
 **Source:** ECWC-282 session 2026-05-30
 **Added:** 2026-05-30
+
+### R-003  Use `@UseGuards` on every route handler; encapsulate role/permission checks in Guards or Decorators
+**Why:** PR#176 flagged a `/ecom/check-happy-hour-reward` endpoint with no `@UseGuards` — any unauthenticated caller could trigger reward mutation. PR#154 flagged an inline `if (!hasPermission && !isAdmin)` check inside a controller method; reviewer asked to move it to a Guard/Decorator so the pattern is reusable and consistent.
+**Example:**
+```ts
+// ✗ no — no guard at all
+@Post('/ecom/check-happy-hour-reward')
+async checkHappyHourReward(...) { ... }
+
+// ✗ no — inline role check in controller body
+async someAdminAction(@Req() req) {
+  if (req.user.role !== UserRole.Admin) throw new ForbiddenException();
+}
+
+// ✓ guard on every handler; role via decorator
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.Admin)
+@Post('/ecom/check-happy-hour-reward')
+async checkHappyHourReward(...) { ... }
+```
+**Source:** PR#176 @Sasit-Nine — github.com/wangpharma-org/Backend-Ecommerce/pull/176 ; PR#154 @MossOcelot — /pull/154
+**Added:** 2026-07-20  **Enforce:** code-review checklist; consider ESLint custom rule


### PR DESCRIPTION
## Summary

This PR is **auto-distilled** from merged-PR review feedback since the last run (2026-05-19). It is **propose-only** — no item takes effect until @62theories reviews and approves this PR.

All items have `status: "proposed"` in `ledger.json`. On merge, a human should flip approved items to `status: "agreed"`, set `approved_by`, and set `approved_at`.

---

## New knowledge proposed

### Rules (must-follow)

| ID | Statement | Source PRs | Reviewers | Confidence |
|----|-----------|-----------|-----------|------------|
| R-003 | Use `@UseGuards` on every route handler; role/permission checks must live in Guards or Decorators, not inline controller `if` statements | #176, #154 | Sasit-Nine, MossOcelot | high |

### Conventions (how we do it here)

| ID | Statement | Source PRs | Reviewers | Confidence |
|----|-----------|-----------|-----------|------------|
| C-002 | A PR that adds, removes, or renames schema elements must include the TypeORM migration file in the same PR | #176 | Sasit-Nine | medium |

### Gotchas (looks correct but breaks)

| ID | Statement | Source PRs | Reviewers | Confidence |
|----|-----------|-----------|-----------|------------|
| G-002 | Changing a TypeORM `@Column` definition in an Entity causes DROP + recreate (or silent schema divergence with `synchronize: false`) | #205 | Sasit-Nine | high |

### Quarantine (single reviewer — needs team agreement to promote)

| ID | Statement | Source | Notes |
|----|-----------|--------|-------|
| Q-002 | Prefer object-style `select: { field: true }` over array-style in TypeORM | PR#176 Sasit-Nine | Promote when seen in ≥1 more PR |
| Q-003 | Domain-specific endpoints belong in their feature module's controller, not AppController | PR#176 Sasit-Nine | Promote when seen in ≥1 more PR |
| Q-004 | Config constants (checksums, hashes) belong in env vars, not hardcoded | PR#226 Sasit-Nine | Promote when seen in ≥1 more PR |
| Q-005 | Check for existing Kafka event listeners before adding new ones | PR#205 Sasit-Nine | Promote when seen in ≥1 more PR |

### Corroboration (no new entry — existing item reinforced)

- **R-001** (no console.log): PR#178 (Sasit-Nine) added 3 more inline "เอา console.log ออก" comments — `last_seen` updated to 2026-07-20 in ledger.

---

## Review instructions for @62theories

1. Read each proposed entry in the `.ai/` files (diff below).
2. For entries you **agree with**: note them — on merge update `status: "agreed"`, `approved_by: "62theories"`, `approved_at: "<date>"` in `ledger.json`.
3. For entries you **disagree with or want to modify**: leave an inline comment and this PR will be updated.
4. Quarantine items (Q-002–Q-005) need no action unless you want to promote one to convention.
5. **Do not merge until at least R-003 and G-002 have been reviewed** — both have security/data-safety implications.

---

> 🤖 Auto-generated by the `learn-from-reviews` scheduled routine. PRs scanned: 55 (merged since 2026-05-19). Human-origin feedback only classified as rules/conventions/gotchas; ai-review-only items were discarded or capped at quarantine per SKILL.md policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNLmD5kjJ2oHRpMeoWq4nM)_