### PR TITLE
ECWC-389 / แก้ให้การค้นหาสินค้าใน e-com ไม่สามารถค้นหาและสั่งซื้อด้วยคำต้องห้ามได้

### DIFF
--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -1521,6 +1521,42 @@ export class ProductsService {
   //   }
   // }
 
+  // ES filter เอง cover ไม่ถึง external/enter fallback (search_auto.php, search_enter.php)
+  // ต้องกรองซ้ำหลัง fetch จาก DB กัน fallback หลุด filter เดียวกันเข้ามา
+  private isSearchExcludedProduct(product: {
+    pro_name: string;
+    pro_priceA: number;
+    pro_priceB: number;
+    pro_priceC: number;
+  }): boolean {
+    const name = product.pro_name ?? '';
+    const excludedPrefixes = [
+      'ฟรี',
+      '@',
+      'ส่งเสริม',
+      'รีเบท',
+      '-',
+      '/',
+      'ค่า',
+      '.',
+    ];
+    const excludedContains = ['บัตรโลตัส', 'สนับสนุน', 'ชดเชย'];
+    const excludedPrices = [0, 1, 10000000];
+
+    if (excludedPrefixes.some((prefix) => name.startsWith(prefix))) {
+      return true;
+    }
+    if (name.endsWith('ฟรี')) {
+      return true;
+    }
+    if (excludedContains.some((word) => name.includes(word))) {
+      return true;
+    }
+    return [product.pro_priceA, product.pro_priceB, product.pro_priceC].some(
+      (price) => excludedPrices.includes(Number(price)),
+    );
+  }
+
   async searchProductsElastic(data: {
     keyword: string;
     offset: number;
@@ -1586,6 +1622,22 @@ export class ProductsService {
                   { prefix: { 'pro_name.keyword': '-' } },
                   { prefix: { 'pro_name.keyword': '/' } },
                   { prefix: { 'pro_name.keyword': 'ค่า' } },
+                  { prefix: { 'pro_name.keyword': '.' } },
+                  { wildcard: { 'pro_name.keyword': { value: '*ฟรี' } } },
+                  {
+                    wildcard: {
+                      'pro_name.keyword': { value: '*บัตรโลตัส*' },
+                    },
+                  },
+                  {
+                    wildcard: {
+                      'pro_name.keyword': { value: '*สนับสนุน*' },
+                    },
+                  },
+                  { wildcard: { 'pro_name.keyword': { value: '*ชดเชย*' } } },
+                  { terms: { pro_priceA: [1, 10000000] } },
+                  { terms: { pro_priceB: [1, 10000000] } },
+                  { terms: { pro_priceC: [1, 10000000] } },
                   { exists: { field: 'invisible_id' } },
                   ...(isL16
                     ? []
@@ -1837,7 +1889,14 @@ export class ProductsService {
           'fs.date',
         ]);
 
-      const products = await qb.getMany();
+      const rawProducts = await qb.getMany();
+      const products = rawProducts.filter(
+        (product) => !this.isSearchExcludedProduct(product),
+      );
+      totalCount = Math.max(
+        0,
+        totalCount - (rawProducts.length - products.length),
+      );
 
       const productMap = new Map(products.map((p) => [p.pro_code, p]));
 


### PR DESCRIPTION
## 📋 PR Information

### 🔗 Jira Task
- https://nitipongjin-13063.atlassian.net/browse/ECWC-389

### 📌 ประเภทของ PR
- [ ] ✨ Feature ใหม่
- [x] 🐛 แก้ Bug
- [ ] ♻️ Refactor
- [ ] 🚀 Release version ใหม่
- [ ] 📝 Documentation
- [ ] 🔧 Config / Infra

### 🎯 PR นี้เปิดเพื่ออะไร / แก้ปัญหาอะไร
การค้นหาสินค้าด้วย Elasticsearch ยังหลุดสินค้าที่ควรถูกซ่อนออกมาให้ลูกค้าเจอและสั่งซื้อได้ ได้แก่:
- ชื่อสินค้าขึ้นต้นด้วย `.`, `ส่งเสริม`, `ค่า`
- ชื่อสินค้าลงท้ายด้วย `ฟรี`
- ชื่อสินค้ามีคำว่า `บัตรโลตัส`, `สนับสนุน`, `ชดเชย`
- ราคา A/B/C เป็น `0`, `1`, หรือ `10,000,000`

### 🛠️ แก้ปัญหานั้นอย่างไร
1. เพิ่มเงื่อนไข `must_not` ใน Elasticsearch query ที่ `searchProductsElastic` (`src/products/products.service.ts`) ให้ครอบคลุมเงื่อนไขข้างต้นทั้งหมด
2. พบว่าเมื่อ Elasticsearch หา match ไม่เจอเลย (`totalCount === 0`) ระบบจะ fallback ไปเรียก API เว็บเก่า (`search_auto.php`, `search_enter.php`) ซึ่งไม่มีการกรองเลย ทำให้สินค้าต้องห้ามหลุดกลับมาได้อีกทาง จึงเพิ่ม private method `isSearchExcludedProduct()` กรองซ้ำที่ผลลัพธ์สุดท้ายหลัง fetch จาก DB เพื่อครอบคลุมทุก source (Elasticsearch, external, enter) ในจุดเดียว
3. ปรับ `totalCount` ให้ลดตามจำนวนที่ถูกกรองออกในแต่ละหน้า เพื่อไม่ให้ตัวเลขรวมเพี้ยนจากผลที่แสดงจริง

### 🧪 วิธี Test
- ค้นหาคำที่มีเฉพาะสินค้าต้องห้ามเป็นผลลัพธ์ (เช่น "บัตรโลตัส") → ต้องไม่เจอสินค้าเลย
- ค้นหาสินค้าที่มีราคา A/B/C เท่ากับ 1 หรือ 10,000,000 → ต้องไม่ขึ้นในผลการค้นหา
- ค้นหาสินค้าปกติที่มีทั้งกลุ่มปกติและกลุ่มต้องห้ามปนกัน → ต้องเห็นเฉพาะสินค้าปกติ และ totalCount ตรงกับจำนวนที่แสดงจริง

### 🔑 Environment Variables ใหม่
- ไม่มี